### PR TITLE
Fix g711_alaw codec description typo

### DIFF
--- a/src/SmartTalk.Messages/Enums/RealtimeAi/RealtimeAiAudioCodec.cs
+++ b/src/SmartTalk.Messages/Enums/RealtimeAi/RealtimeAiAudioCodec.cs
@@ -7,7 +7,7 @@ public enum RealtimeAiAudioCodec
     [Description("g711_ulaw")]
     MULAW,
     
-    [Description("g712_alaw")]
+    [Description("g711_alaw")]
     ALAW,
     
     [Description("pcm16")]

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/RealtimeAiAudioCodecDescriptionPinningTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/RealtimeAiAudioCodecDescriptionPinningTests.cs
@@ -1,0 +1,33 @@
+using Shouldly;
+using SmartTalk.Core.Extensions;
+using SmartTalk.Messages.Enums.RealtimeAi;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Services.RealtimeAiV2;
+
+/// <summary>
+/// Pins the literal Description string of every <see cref="RealtimeAiAudioCodec"/>
+/// value to the exact wire format expected by the OpenAI Realtime API
+/// (see https://platform.openai.com/docs/api-reference/realtime-client-events).
+///
+/// These literals are sent verbatim in the <c>session.update</c> payload's
+/// <c>input_audio_format</c> / <c>output_audio_format</c> fields. Any deviation
+/// (case, hyphen, prefix) makes OpenAI reject the session with
+/// <c>invalid_request_error</c> and the call dies before the AI ever speaks.
+///
+/// <para>
+/// A regression here is unrecoverable in production — pin every literal so that
+/// renaming the enum or "fixing" a Description silently breaks live calls.
+/// </para>
+/// </summary>
+public class RealtimeAiAudioCodecDescriptionPinningTests
+{
+    [Theory]
+    [InlineData(RealtimeAiAudioCodec.MULAW, "g711_ulaw")]
+    [InlineData(RealtimeAiAudioCodec.ALAW, "g711_alaw")]
+    [InlineData(RealtimeAiAudioCodec.PCM16, "pcm16")]
+    public void GetDescription_ReturnsOpenAiWireFormatLiteral(RealtimeAiAudioCodec codec, string expected)
+    {
+        codec.GetDescription().ShouldBe(expected);
+    }
+}


### PR DESCRIPTION
## Summary

- `RealtimeAiAudioCodec.ALAW` description was `g712_alaw` — a string that does not exist in any G-series standard. OpenAI Realtime API rejects sessions with this format, so any A-law caller would fail before the AI could speak
- Fix to `g711_alaw` (per [OpenAI Realtime API session.update](https://platform.openai.com/docs/api-reference/realtime-client-events))
- Pin all three codec descriptions in a new test class so renaming or "correcting" these literals fails CI

## Test plan

- [x] Unit: 3 theory cases pinning MULAW=`g711_ulaw`, ALAW=`g711_alaw`, PCM16=`pcm16`
- [x] Regression: full unit suite 157/157

Latent in production today because Twilio US/CA defaults to μ-law (V2 ALAW path is dead code) and V1 hardcodes the literal. This unblocks A-law trunks for European / Asian carriers.