### PR TITLE
Fix ResolveDeliveryInfoAsync inverted condition and missing token replace

### DIFF
--- a/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectService.Build.Knowledge.cs
+++ b/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectService.Build.Knowledge.cs
@@ -294,9 +294,37 @@ public partial class AiSpeechAssistantConnectService
 
     private async Task ResolveDeliveryInfoAsync(CancellationToken cancellationToken)
     {
-        if (!_ctx.Prompt.Contains("#{delivery_info}", StringComparison.OrdinalIgnoreCase) || !_ctx.Prompt.Contains("#{CRM_路线_送货日数据}", StringComparison.OrdinalIgnoreCase)) return;
+        if (!HasDeliveryInfoToken(_ctx.Prompt)) return;
 
         var cache = await _salesDataProvider.GetDeliveryInfoCacheByPhoneNumberAsync(_ctx.From, cancellationToken).ConfigureAwait(false);
-        _ctx.Prompt = _ctx.Prompt.Replace("#{delivery_info}", cache?.CacheValue?.Trim() ?? " ");
+
+        _ctx.Prompt = ApplyDeliveryInfoTokens(_ctx.Prompt, cache?.CacheValue?.Trim());
+    }
+
+    /// <summary>
+    /// Returns true if the prompt contains either delivery info token literal.
+    /// Tokens are pinned: <c>#{delivery_info}</c> (English) or <c>#{CRM_路线_送货日数据}</c> (Chinese).
+    /// Public static for unit testability; not intended for external use.
+    /// </summary>
+    public static bool HasDeliveryInfoToken(string prompt) =>
+        !string.IsNullOrEmpty(prompt) &&
+        (prompt.Contains("#{delivery_info}", StringComparison.OrdinalIgnoreCase) ||
+         prompt.Contains("#{CRM_路线_送货日数据}", StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>
+    /// Replaces both delivery info tokens with the given value.
+    /// Null/empty <paramref name="deliveryValue"/> becomes a single space placeholder
+    /// (preserves V2's existing <c>?? " "</c> semantic so the model never sees a literal token).
+    /// Public static for unit testability; not intended for external use.
+    /// </summary>
+    public static string ApplyDeliveryInfoTokens(string prompt, string deliveryValue)
+    {
+        if (string.IsNullOrEmpty(prompt)) return prompt;
+
+        var value = string.IsNullOrEmpty(deliveryValue) ? " " : deliveryValue;
+
+        return prompt
+            .Replace("#{delivery_info}", value)
+            .Replace("#{CRM_路线_送货日数据}", value);
     }
 }

--- a/src/SmartTalk.UnitTests/Services/AiSpeechAssistantConnect/DeliveryInfoTokenTests.cs
+++ b/src/SmartTalk.UnitTests/Services/AiSpeechAssistantConnect/DeliveryInfoTokenTests.cs
@@ -1,0 +1,127 @@
+using Shouldly;
+using SmartTalk.Core.Services.AiSpeechAssistantConnect;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Services.AiSpeechAssistantConnect;
+
+/// <summary>
+/// Covers the two pure helpers extracted from
+/// <see cref="AiSpeechAssistantConnectService.ResolveDeliveryInfoAsync"/>:
+/// <list type="bullet">
+///   <item><c>HasDeliveryInfoToken</c> — predicate that decides whether to fetch from DB</item>
+///   <item><c>ApplyDeliveryInfoTokens</c> — pure prompt token replacement</item>
+/// </list>
+/// Together they restore the V2 design intent that was bricked by an inverted
+/// condition (<c>||</c> instead of <c>&amp;&amp;</c>) and a missing second Replace.
+/// </summary>
+public class DeliveryInfoTokenTests
+{
+    // ── HasDeliveryInfoToken ─────────────────────────────────────
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void HasDeliveryInfoToken_NullOrEmptyPrompt_ReturnsFalse(string prompt)
+    {
+        AiSpeechAssistantConnectService.HasDeliveryInfoToken(prompt).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void HasDeliveryInfoToken_PromptWithoutTokens_ReturnsFalse()
+    {
+        AiSpeechAssistantConnectService.HasDeliveryInfoToken("Hello, no tokens here.").ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData("Hi #{delivery_info} bye")]
+    [InlineData("Hi #{DELIVERY_INFO} bye")]                          // case-insensitive
+    [InlineData("Hi #{Delivery_Info} bye")]
+    [InlineData("Hi #{CRM_路线_送货日数据} bye")]                       // alternate Chinese token
+    [InlineData("#{delivery_info} and #{CRM_路线_送货日数据}")]         // both tokens
+    public void HasDeliveryInfoToken_PromptWithEitherToken_ReturnsTrue(string prompt)
+    {
+        AiSpeechAssistantConnectService.HasDeliveryInfoToken(prompt).ShouldBeTrue();
+    }
+
+    // ── ApplyDeliveryInfoTokens ─────────────────────────────────
+
+    [Theory]
+    [InlineData(null, "abc", null)]
+    [InlineData("", "abc", "")]
+    public void ApplyDeliveryInfoTokens_NullOrEmptyPrompt_ReturnsAsIs(string prompt, string value, string expected)
+    {
+        AiSpeechAssistantConnectService.ApplyDeliveryInfoTokens(prompt, value).ShouldBe(expected);
+    }
+
+    [Fact]
+    public void ApplyDeliveryInfoTokens_NoTokens_ReturnsPromptUnchanged()
+    {
+        const string prompt = "Hello world, no tokens.";
+
+        AiSpeechAssistantConnectService.ApplyDeliveryInfoTokens(prompt, "abc").ShouldBe(prompt);
+    }
+
+    [Fact]
+    public void ApplyDeliveryInfoTokens_DeliveryInfoTokenOnly_Replaced()
+    {
+        var result = AiSpeechAssistantConnectService.ApplyDeliveryInfoTokens(
+            "Schedule: #{delivery_info}, that's it.", "Mon-Fri 9am");
+
+        result.ShouldBe("Schedule: Mon-Fri 9am, that's it.");
+    }
+
+    [Fact]
+    public void ApplyDeliveryInfoTokens_CrmDeliveryTokenOnly_Replaced()
+    {
+        var result = AiSpeechAssistantConnectService.ApplyDeliveryInfoTokens(
+            "送货：#{CRM_路线_送货日数据}。", "周一至周五");
+
+        result.ShouldBe("送货：周一至周五。");
+    }
+
+    [Fact]
+    public void ApplyDeliveryInfoTokens_BothTokens_BothReplacedWithSameValue()
+    {
+        var result = AiSpeechAssistantConnectService.ApplyDeliveryInfoTokens(
+            "EN: #{delivery_info}\nCN: #{CRM_路线_送货日数据}", "Wed");
+
+        result.ShouldBe("EN: Wed\nCN: Wed");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void ApplyDeliveryInfoTokens_NullOrEmptyValue_ReplacesWithPlaceholderSpace(string value)
+    {
+        // Preserves V2's existing `?? " "` semantic for the legacy single-token path:
+        // null/empty cache → placeholder " " (single space) so the prompt does not
+        // contain a literal `#{...}` token visible to the model.
+        var result = AiSpeechAssistantConnectService.ApplyDeliveryInfoTokens(
+            "Schedule: #{delivery_info}", value);
+
+        result.ShouldBe("Schedule:  ");  // trailing single space replaces the token
+    }
+
+    [Fact]
+    public void ApplyDeliveryInfoTokens_WhitespaceOnlyValue_PreservedVerbatim()
+    {
+        // Whitespace-only is NOT treated as empty — caller (ResolveDeliveryInfoAsync)
+        // already calls .Trim() on the cache value before passing in, so a
+        // whitespace input here would only happen if the trimmed value is " "
+        // (i.e. caller explicitly wants placeholder). This guards the contract that
+        // the helper does not second-guess the caller's intent.
+        var result = AiSpeechAssistantConnectService.ApplyDeliveryInfoTokens(
+            "Schedule: #{delivery_info}", "   ");
+
+        result.ShouldBe("Schedule:    ");  // 3 spaces (the value) replaces the token
+    }
+
+    [Fact]
+    public void ApplyDeliveryInfoTokens_RepeatedTokenInPrompt_AllOccurrencesReplaced()
+    {
+        var result = AiSpeechAssistantConnectService.ApplyDeliveryInfoTokens(
+            "#{delivery_info} and again #{delivery_info}", "X");
+
+        result.ShouldBe("X and again X");
+    }
+}


### PR DESCRIPTION
## Summary

- `ResolveDeliveryInfoAsync` returned early on every call: condition was `if (!a || !b) return;` (requires BOTH tokens), but real prompts only ever contain one. Delivery info has never been injected into any V2 prompt
- Even when the predicate did pass, only `#{delivery_info}` was replaced — the alternate Chinese token `#{CRM_路线_送货日数据}` was left as a literal in the prompt
- Fix: extract `HasDeliveryInfoToken` + `ApplyDeliveryInfoTokens` as `public static` (matches `CheckIfInServiceHours` precedent on the same partial class), wire `ResolveDeliveryInfoAsync` to call them. Mirrors the working pattern in `ResolveCustomerInfoAsync`

## Test plan

- [x] Unit: 18 theory cases — token presence (null/empty/case-insensitive/either/both), value semantics (null/empty/whitespace placeholder), repeated tokens
- [x] Regression: full unit suite 172/172
- [ ] Integration test for full `BuildKnowledgeAsync` is deferred to the upcoming knowledge fetch+apply split

The `#{CRM_路线_送货日数据}` literal is preserved verbatim — it appears nowhere else in the codebase, and any DB-stored prompt using this exact form will start working as designed for the first time.