### PR TITLE
Pin CancellationToken.None on Hangfire-deferred hangup

### DIFF
--- a/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectService.FunctionCalls.Hangup.cs
+++ b/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectService.FunctionCalls.Hangup.cs
@@ -1,3 +1,4 @@
+using System.Linq.Expressions;
 using SmartTalk.Core.Services.AiSpeechAssistant;
 using SmartTalk.Messages.Dto.RealtimeAi;
 
@@ -7,12 +8,27 @@ public partial class AiSpeechAssistantConnectService
 {
     private RealtimeAiFunctionCallResult ProcessHangup(CancellationToken cancellationToken)
     {
-        _backgroundJobClient.Schedule<IAiSpeechAssistantService>(
-            x => x.HangupCallAsync(_ctx.CallSid, cancellationToken), TimeSpan.FromSeconds(2));
+        _ = cancellationToken;  // intentionally unused — Hangfire-deferred jobs must not capture scope tokens
+
+        _backgroundJobClient.Schedule(BuildHangupJobExpression(_ctx.CallSid), TimeSpan.FromSeconds(2));
 
         return new RealtimeAiFunctionCallResult
         {
             Output = "Say goodbye to the guests in their **language**"
         };
     }
+
+    /// <summary>
+    /// Builds the Hangfire job expression that defers the hangup by N seconds.
+    /// <para>
+    /// Capturing the request-scope <c>CancellationToken</c> here is unsafe: by the time
+    /// Hangfire fires the job (≥2s later), the originating request scope is already
+    /// disposed and the captured CTS would throw <c>ObjectDisposedException</c>. Always
+    /// pass <see cref="CancellationToken.None"/>; long-running cleanup work in the
+    /// scheduled handler is responsible for its own lifecycle.
+    /// </para>
+    /// <para>Public static for unit testability; not intended for external use.</para>
+    /// </summary>
+    public static Expression<Func<IAiSpeechAssistantService, Task>> BuildHangupJobExpression(string callSid) =>
+        service => service.HangupCallAsync(callSid, CancellationToken.None);
 }

--- a/src/SmartTalk.UnitTests/Services/AiSpeechAssistantConnect/HangupJobExpressionTests.cs
+++ b/src/SmartTalk.UnitTests/Services/AiSpeechAssistantConnect/HangupJobExpressionTests.cs
@@ -1,0 +1,70 @@
+using NSubstitute;
+using Shouldly;
+using SmartTalk.Core.Services.AiSpeechAssistant;
+using SmartTalk.Core.Services.AiSpeechAssistantConnect;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Services.AiSpeechAssistantConnect;
+
+/// <summary>
+/// Pins the shape of the Hangfire-scheduled hangup expression to ensure
+/// <see cref="System.Threading.CancellationToken.None"/> is captured —
+/// not a closure-bound token from the calling scope.
+///
+/// <para>
+/// Hangfire's expression serializer evaluates closure-captured values at
+/// schedule time and stores them as constants in the job record. For
+/// <see cref="System.Threading.CancellationToken"/> the serializer
+/// substitutes <c>default</c> at deserialization regardless, so the runtime
+/// behavior is the same. But:
+/// </para>
+/// <list type="bullet">
+///   <item>If a future refactor changes the parameter type or upgrades
+///         Hangfire, a captured token could leak the live request CTS into
+///         a deferred job that fires after the request scope is disposed —
+///         producing <c>ObjectDisposedException</c>.</item>
+///   <item>The remaining <c>Schedule</c>/<c>Enqueue</c> calls in the same
+///         partial class (<c>ProcessJobs.cs</c>, <c>Build.Session.cs</c>) all
+///         use <c>CancellationToken.None</c>. This test pins the same intent
+///         on the hangup path so the codebase stays uniform.</item>
+/// </list>
+/// </summary>
+public class HangupJobExpressionTests
+{
+    [Fact]
+    public void BuildHangupJobExpression_ProducesCallToHangupCallAsyncWithGivenCallSid()
+    {
+        var expr = AiSpeechAssistantConnectService.BuildHangupJobExpression("CA1234567890");
+
+        var fakeService = Substitute.For<IAiSpeechAssistantService>();
+        _ = expr.Compile()(fakeService);
+
+        fakeService.Received(1).HangupCallAsync("CA1234567890", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public void BuildHangupJobExpression_PassesCancellationTokenNone_NotCapturedToken()
+    {
+        var expr = AiSpeechAssistantConnectService.BuildHangupJobExpression("CA-test");
+
+        var fakeService = Substitute.For<IAiSpeechAssistantService>();
+        _ = expr.Compile()(fakeService);
+
+        // Strict assertion: must be CancellationToken.None — not any other token.
+        fakeService.Received(1).HangupCallAsync(Arg.Any<string>(), CancellationToken.None);
+    }
+
+    [Theory]
+    [InlineData("CA-abcdef")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void BuildHangupJobExpression_PreservesCallSidVerbatim(string callSid)
+    {
+        var expr = AiSpeechAssistantConnectService.BuildHangupJobExpression(callSid);
+
+        var fakeService = Substitute.For<IAiSpeechAssistantService>();
+        _ = expr.Compile()(fakeService);
+
+        fakeService.Received(1).HangupCallAsync(callSid, CancellationToken.None);
+    }
+}


### PR DESCRIPTION
## Summary

- `ProcessHangup` captured the request-scope token in the Hangfire `Schedule` lambda — every other `Schedule`/`Enqueue` in the same partial class passes `CancellationToken.None`, so this was the lone outlier
- Today's Hangfire serializer happens to substitute `default(CancellationToken)` for any closure-captured token, so behaviour is unchanged. But a future Hangfire upgrade or a refactor that accepts non-CT tokens could leak the live request CTS into a job firing after scope disposal — `ObjectDisposedException` mid-call
- Refactor: extract `BuildHangupJobExpression(string callSid)` as `public static`, following the `CheckIfInServiceHours` precedent for unit-testable pure logic. Use `_ = cancellationToken;` to mark the call-site parameter explicitly unused

## Test plan

- [x] Unit: 5 theory cases — expression invokes `HangupCallAsync`, second arg is exactly `CancellationToken.None` (NSubstitute strict assertion), call sid preserved verbatim including null/empty
- [x] Regression: full unit suite 159/159

V1 (`AiSpeechAssistantService.cs:932`) has the same anti-pattern but is intentionally not modified — out of scope for the V2 stability work.