### PR TITLE
Centralize PST timezone resolution behind PstTimeZone helper

### DIFF
--- a/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectService.Build.Knowledge.cs
+++ b/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectService.Build.Knowledge.cs
@@ -1,4 +1,5 @@
 using Serilog;
+using SmartTalk.Core.Utils;
 using SmartTalk.Messages.Dto.Smarties;
 using SmartTalk.Messages.Dto.AiSpeechAssistant;
 using SmartTalk.Messages.Dto.Pos;
@@ -41,7 +42,7 @@ public partial class AiSpeechAssistantConnectService
 
     private void ResolveStaticPromptVariables()
     {
-        var pstTime = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time"));
+        var pstTime = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, PstTimeZone.Get());
 
         _ctx.Prompt = _ctx.Prompt
             .Replace("#{user_profile}", string.IsNullOrEmpty(_ctx.UserProfileJson) ? " " : _ctx.UserProfileJson)

--- a/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectService.cs
+++ b/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectService.cs
@@ -2,6 +2,7 @@ using Serilog;
 using AutoMapper;
 using Newtonsoft.Json;
 using SmartTalk.Core.Ioc;
+using SmartTalk.Core.Utils;
 using SmartTalk.Core.Domain.System;
 using SmartTalk.Core.Services.Jobs;
 using SmartTalk.Core.Services.Pos;
@@ -161,8 +162,7 @@ public partial class AiSpeechAssistantConnectService : IAiSpeechAssistantConnect
         if (serviceHoursJson == null)
             return (true, isTransferHuman && !string.IsNullOrEmpty(transferCallNumber));
 
-        var pstZone = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
-        var pstTime = TimeZoneInfo.ConvertTime(utcNow, pstZone);
+        var pstTime = TimeZoneInfo.ConvertTime(utcNow, PstTimeZone.Get());
 
         var workingHours = JsonConvert.DeserializeObject<List<AgentServiceHoursDto>>(serviceHoursJson);
         var specificWorkingHours = workingHours?.FirstOrDefault(x => x.DayOfWeek == pstTime.DayOfWeek);

--- a/src/SmartTalk.Core/Utils/PstTimeZone.cs
+++ b/src/SmartTalk.Core/Utils/PstTimeZone.cs
@@ -1,0 +1,68 @@
+namespace SmartTalk.Core.Utils;
+
+/// <summary>
+/// Resolves the Pacific Standard Time zone once per process and caches the result.
+///
+/// <para>Why this exists:</para>
+/// <list type="bullet">
+///   <item>The zone is needed in multiple V2 code paths
+///         (<c>CheckIfInServiceHours</c>, <c>ResolveStaticPromptVariables</c>).
+///         Centralizing the magic string prevents typos like <c>"PST"</c> or
+///         <c>"Pacific"</c>.</item>
+///   <item>.NET 6+ converts between Windows IDs ("Pacific Standard Time") and
+///         IANA IDs ("America/Los_Angeles") automatically when the requested
+///         form is not present on the host. We additionally try the IANA form
+///         as defense-in-depth in case ICU is misconfigured.</item>
+///   <item>.NET 8 caches <see cref="TimeZoneInfo"/> by ID internally, but
+///         using <see cref="Lazy{T}"/> here also serves as a clear,
+///         eager-fail point with an actionable error message.</item>
+/// </list>
+/// </summary>
+public static class PstTimeZone
+{
+    /// <summary>Windows-style ID, the historical default for this codebase.</summary>
+    public const string WindowsId = "Pacific Standard Time";
+
+    /// <summary>IANA-style ID used as a fallback if the Windows ID cannot be resolved.</summary>
+    public const string IanaId = "America/Los_Angeles";
+
+    private static readonly Lazy<TimeZoneInfo> Lazy = new(ResolveOrThrow);
+
+    /// <summary>
+    /// Returns the cached Pacific Standard Time zone. Thread-safe; the underlying
+    /// resolution runs at most once per process. If resolution fails, the cached
+    /// failure is rethrown on every subsequent access (this is an unrecoverable
+    /// host configuration error).
+    /// </summary>
+    public static TimeZoneInfo Get() => Lazy.Value;
+
+    private static TimeZoneInfo ResolveOrThrow()
+    {
+        if (TryResolve(WindowsId, out var byWindows)) return byWindows;
+        if (TryResolve(IanaId, out var byIana)) return byIana;
+
+        throw new InvalidOperationException(
+            $"Cannot resolve Pacific Standard Time on this host. " +
+            $"Tried '{WindowsId}' and '{IanaId}'. " +
+            $"Ensure tzdata is installed (Linux) or ICU support is available.");
+    }
+
+    private static bool TryResolve(string id, out TimeZoneInfo zone)
+    {
+        try
+        {
+            zone = TimeZoneInfo.FindSystemTimeZoneById(id);
+            return true;
+        }
+        catch (TimeZoneNotFoundException)
+        {
+            zone = null!;
+            return false;
+        }
+        catch (InvalidTimeZoneException)
+        {
+            zone = null!;
+            return false;
+        }
+    }
+}

--- a/src/SmartTalk.UnitTests/Utils/PstTimeZoneTests.cs
+++ b/src/SmartTalk.UnitTests/Utils/PstTimeZoneTests.cs
@@ -1,0 +1,54 @@
+using Shouldly;
+using SmartTalk.Core.Utils;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Utils;
+
+/// <summary>
+/// Verifies <see cref="PstTimeZone"/> returns the Pacific Standard Time zone
+/// regardless of host OS (Windows ID vs IANA ID).
+///
+/// <para>
+/// .NET 6+ already converts between Windows and IANA IDs internally, and .NET 8
+/// caches <see cref="TimeZoneInfo"/> instances by ID. This helper exists to
+/// (a) centralize the magic string, (b) provide explicit cross-platform
+/// fallback as defense-in-depth for environments without ICU/tzdata data, and
+/// (c) eager-fail with a clear actionable message instead of a stack trace.
+/// </para>
+/// </summary>
+public class PstTimeZoneTests
+{
+    [Fact]
+    public void Get_ReturnsNonNullTimeZone()
+    {
+        PstTimeZone.Get().ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void Get_ReturnsTimeZoneWithBaseUtcOffsetMinusEightHours()
+    {
+        // PST baseline (winter) is UTC-8. Daylight savings doesn't change BaseUtcOffset,
+        // only the active offset (which depends on date). This assertion is
+        // platform-independent (Windows ID and IANA ID both resolve to the same zone).
+        PstTimeZone.Get().BaseUtcOffset.ShouldBe(TimeSpan.FromHours(-8));
+    }
+
+    [Fact]
+    public void Get_CalledTwice_ReturnsSameInstance()
+    {
+        var first = PstTimeZone.Get();
+        var second = PstTimeZone.Get();
+
+        ReferenceEquals(first, second).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Get_ReturnsZoneWithRecognizableId()
+    {
+        // Either the Windows-style or IANA-style ID is acceptable depending on the
+        // platform. Just verifies we resolved a real PST/PDT zone.
+        var id = PstTimeZone.Get().Id;
+
+        id.ShouldBeOneOf("Pacific Standard Time", "America/Los_Angeles");
+    }
+}


### PR DESCRIPTION
## Summary

- Two V2 paths (`CheckIfInServiceHours` and `ResolveStaticPromptVariables`) both hardcoded `"Pacific Standard Time"` and called `TimeZoneInfo.FindSystemTimeZoneById` directly. Replace both with `PstTimeZone.Get()`
- Centralizes the magic string + holds Windows ID and IANA fallback as `public const` fields, so future renames are compile-time-visible
- Defense-in-depth: explicit fallback to `America/Los_Angeles` if the Windows ID isn't resolvable, then an actionable error naming the fix (install tzdata / ICU)
- `Lazy<T>` ensures one resolution per process and is thread-safe

[.NET 6+ already converts](https://learn.microsoft.com/en-us/dotnet/api/system.timezoneinfo.findsystemtimezonebyid) Windows ↔ IANA IDs internally and [.NET 8 caches](https://learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-8) `TimeZoneInfo` by ID — so neither cross-platform safety nor caching are the primary value. This is a code-clarity and defense-in-depth refactor.

## Test plan

- [x] Unit: 4 cases — non-null result, `BaseUtcOffset = -8h`, same instance on repeated calls, ID is one of the two recognized forms
- [x] Existing `CheckIfInServiceHoursTests` (15 cases) implicitly serve as integration coverage and still pass
- [x] Regression: full unit suite 158/158

Out of scope: V1 + other legacy callers (`PhoneOrderProcessJobService`, `TwilioWebhookService`, etc.) keep their inline calls.