### PR TITLE
Make ResolveStaticPromptVariables null-safe

### DIFF
--- a/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectService.Build.Knowledge.cs
+++ b/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectService.Build.Knowledge.cs
@@ -43,11 +43,40 @@ public partial class AiSpeechAssistantConnectService
     {
         var pstTime = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time"));
 
-        _ctx.Prompt = _ctx.Prompt
-            .Replace("#{user_profile}", string.IsNullOrEmpty(_ctx.UserProfileJson) ? " " : _ctx.UserProfileJson)
+        _ctx.Prompt = ResolveStaticTokens(_ctx.Prompt, _ctx.UserProfileJson, _ctx.From, pstTime);
+    }
+
+    /// <summary>
+    /// Pure version of static token replacement, isolated for unit testability.
+    /// Returns the prompt unchanged if it is null or empty (no tokens to replace),
+    /// matching the safe-no-op contract callers expect.
+    /// Public static; not intended for external use.
+    /// </summary>
+    public static string ResolveStaticTokens(string prompt, string userProfileJson, string from, DateTimeOffset pstTime)
+    {
+        if (string.IsNullOrEmpty(prompt)) return prompt;
+
+        return prompt
+            .Replace("#{user_profile}", string.IsNullOrEmpty(userProfileJson) ? " " : userProfileJson)
             .Replace("#{current_time}", pstTime.ToString("yyyy-MM-dd HH:mm:ss"))
-            .Replace("#{customer_phone}", _ctx.From.StartsWith("+1") ? _ctx.From[2..] : _ctx.From)
+            .Replace("#{customer_phone}", FormatCustomerPhone(from))
             .Replace("#{pst_date}", $"{pstTime.Date:yyyy-MM-dd} {pstTime.DayOfWeek}");
+    }
+
+    /// <summary>
+    /// Formats the caller phone number for inclusion in the prompt:
+    /// strips the leading <c>+1</c> for North American numbers, returns the rest verbatim,
+    /// and returns empty string for null/empty input (anonymous Twilio caller edge case).
+    /// Public static; not intended for external use.
+    /// </summary>
+    public static string FormatCustomerPhone(string from)
+    {
+        if (string.IsNullOrEmpty(from)) return string.Empty;
+
+        // NOTE: matching the original behaviour exactly — `string.StartsWith(string)` uses
+        // CurrentCulture comparison. For ASCII "+1" the result is identical to Ordinal,
+        // but we preserve the original to avoid any culture-dependent surprise.
+        return from.StartsWith("+1") ? from[2..] : from;
     }
 
     private async Task ResolveGreetingAsync(CancellationToken cancellationToken)

--- a/src/SmartTalk.UnitTests/Services/AiSpeechAssistantConnect/StaticPromptVariablesTests.cs
+++ b/src/SmartTalk.UnitTests/Services/AiSpeechAssistantConnect/StaticPromptVariablesTests.cs
@@ -1,0 +1,129 @@
+using Shouldly;
+using SmartTalk.Core.Services.AiSpeechAssistantConnect;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Services.AiSpeechAssistantConnect;
+
+/// <summary>
+/// Covers the two pure helpers extracted from
+/// <see cref="AiSpeechAssistantConnectService.ResolveStaticPromptVariables"/>:
+/// <list type="bullet">
+///   <item><c>FormatCustomerPhone</c> — strips <c>+1</c> for North American numbers,
+///         null/empty-safe</item>
+///   <item><c>ResolveStaticTokens</c> — replaces <c>#{user_profile}</c>,
+///         <c>#{current_time}</c>, <c>#{customer_phone}</c>, <c>#{pst_date}</c> tokens
+///         in the prompt; null-safe for prompt and inputs</item>
+/// </list>
+///
+/// <para>
+/// Before this PR, a null caller phone (anonymous Twilio call edge case) or a null
+/// stored prompt (assistant configured without knowledge) would throw a
+/// <see cref="NullReferenceException"/> that escaped the try/catch in
+/// <c>ConnectAsync</c> and left the Twilio WebSocket dangling. These helpers
+/// make the path null-safe.
+/// </para>
+/// </summary>
+public class StaticPromptVariablesTests
+{
+    // ── FormatCustomerPhone ──────────────────────────────────────
+
+    [Theory]
+    [InlineData(null, "")]
+    [InlineData("", "")]
+    public void FormatCustomerPhone_NullOrEmpty_ReturnsEmpty(string from, string expected)
+    {
+        AiSpeechAssistantConnectService.FormatCustomerPhone(from).ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("+15551234567", "5551234567")]
+    [InlineData("+12025551212", "2025551212")]
+    public void FormatCustomerPhone_NorthAmericanNumber_StripsPlusOne(string from, string expected)
+    {
+        AiSpeechAssistantConnectService.FormatCustomerPhone(from).ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("5551234567")]                       // no leading +
+    [InlineData("+8613912345678")]                   // China, must NOT strip
+    [InlineData("+447911123456")]                    // UK
+    [InlineData("Anonymous")]                        // Twilio anonymous marker
+    [InlineData("+CALLER_ID_BLOCKED")]               // Twilio blocked-caller marker
+    public void FormatCustomerPhone_NonNorthAmerican_PreservedVerbatim(string from)
+    {
+        AiSpeechAssistantConnectService.FormatCustomerPhone(from).ShouldBe(from);
+    }
+
+    // ── ResolveStaticTokens ──────────────────────────────────────
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void ResolveStaticTokens_NullOrEmptyPrompt_ReturnsAsIs(string prompt)
+    {
+        var result = AiSpeechAssistantConnectService.ResolveStaticTokens(
+            prompt, "{}", "+15551234567", DateTimeOffset.UtcNow);
+
+        result.ShouldBe(prompt);
+    }
+
+    [Fact]
+    public void ResolveStaticTokens_NoTokens_ReturnsPromptUnchanged()
+    {
+        const string prompt = "Plain prompt without placeholders.";
+
+        var result = AiSpeechAssistantConnectService.ResolveStaticTokens(
+            prompt, "{}", "+15551234567", DateTimeOffset.UtcNow);
+
+        result.ShouldBe(prompt);
+    }
+
+    [Fact]
+    public void ResolveStaticTokens_AllTokens_ReplacedWithFormattedValues()
+    {
+        // PST 2026-02-16 (Monday) 12:34:56 +0000 — using a fixed offset so the test
+        // is deterministic regardless of host timezone.
+        var pstTime = new DateTimeOffset(2026, 2, 16, 12, 34, 56, TimeSpan.FromHours(-8));
+        var prompt = "User: #{user_profile}\nTime: #{current_time}\nPhone: #{customer_phone}\nDate: #{pst_date}";
+
+        var result = AiSpeechAssistantConnectService.ResolveStaticTokens(
+            prompt, "{\"name\":\"Alice\"}", "+15551234567", pstTime);
+
+        result.ShouldBe("User: {\"name\":\"Alice\"}\nTime: 2026-02-16 12:34:56\nPhone: 5551234567\nDate: 2026-02-16 Monday");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void ResolveStaticTokens_NullOrEmptyUserProfile_ReplacesWithSpacePlaceholder(string userProfileJson)
+    {
+        var result = AiSpeechAssistantConnectService.ResolveStaticTokens(
+            "Profile: #{user_profile}|", userProfileJson, "+15551234567", DateTimeOffset.UtcNow);
+
+        result.ShouldBe("Profile:  |");  // single space replaces the token
+    }
+
+    [Theory]
+    [InlineData(null, "")]                            // null phone → empty in token
+    [InlineData("", "")]                              // empty phone → empty in token
+    [InlineData("+15551234567", "5551234567")]
+    [InlineData("Anonymous", "Anonymous")]
+    public void ResolveStaticTokens_PhoneToken_HandledByFormatHelper(string from, string expectedPhone)
+    {
+        var result = AiSpeechAssistantConnectService.ResolveStaticTokens(
+            "Phone[#{customer_phone}]", null, from, DateTimeOffset.UtcNow);
+
+        result.ShouldBe($"Phone[{expectedPhone}]");
+    }
+
+    [Fact]
+    public void ResolveStaticTokens_RepeatedTokens_AllOccurrencesReplaced()
+    {
+        var pstTime = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.FromHours(-8));
+
+        var result = AiSpeechAssistantConnectService.ResolveStaticTokens(
+            "#{customer_phone} and again #{customer_phone}", null, "+15550001", pstTime);
+
+        result.ShouldBe("5550001 and again 5550001");
+    }
+}


### PR DESCRIPTION
## Summary

- Three NRE risks in the static prompt token replacement path: null `_ctx.Prompt` (assistant configured without knowledge), null `_ctx.From` (anonymous Twilio caller), and the resulting NRE escapes `ConnectAsync`'s two-exception try/catch — Twilio WebSocket dangles for 30s
- Extract `ResolveStaticTokens(prompt, userProfileJson, from, pstTime)` and `FormatCustomerPhone(from)` as `public static`. Short-circuit on null/empty prompt; return empty string for null/empty caller phone
- For non-null inputs the output is byte-exact with the previous code — `StartsWith("+1")` retained without `StringComparison.Ordinal` to avoid culture-mode change (ASCII identical anyway)

## Test plan

- [x] Unit: 20 theory cases — `FormatCustomerPhone` (null/empty, `+1` strip, international preserve, Twilio anonymous markers) + `ResolveStaticTokens` (null/empty prompt, no tokens, all 4 tokens, null userProfile, phone variations, repeated tokens, deterministic time formatting)
- [x] Regression: full unit suite 174/174
- [ ] End-to-end coverage of the private wrapper deferred to the upcoming knowledge fetch+apply split

`_ctx.Knowledge` null handling (the upstream root cause) is addressed in #921.