### PR TITLE
Defend LoadAssistantInfoAsync against null data provider results

### DIFF
--- a/src/SmartTalk.Core/Services/AiSpeechAssistant/AiSpeechAssistantDataProvider.cs
+++ b/src/SmartTalk.Core/Services/AiSpeechAssistant/AiSpeechAssistantDataProvider.cs
@@ -200,7 +200,13 @@ public partial class AiSpeechAssistantDataProvider : IAiSpeechAssistantDataProvi
 
         var result = await assistantInfo.FirstOrDefaultAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
 
-        return (result.assistant, result.knowledge, result.userProfile);
+        // Use null-conditional access so a no-match (FirstOrDefaultAsync returns null on the
+        // anonymous projection) yields a (null, null, null) tuple instead of NRE'ing on
+        // `result.assistant`. Callers that assume non-null tuple elements (V1) keep their
+        // existing crash semantics — they will now NRE on the next deref of the returned
+        // null instead of inside this method, which is functionally equivalent. Callers that
+        // null-check (V2's LoadAssistantInfoAsync) can react cleanly.
+        return (result?.assistant, result?.knowledge, result?.userProfile);
     }
 
     public async Task<Domain.AISpeechAssistant.AiSpeechAssistant> GetAiSpeechAssistantByNumbersAsync(string didNumber, CancellationToken cancellationToken)

--- a/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectService.Build.Knowledge.cs
+++ b/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectService.Build.Knowledge.cs
@@ -1,9 +1,12 @@
 using Serilog;
+using SmartTalk.Core.Services.AiSpeechAssistantConnect.Exceptions;
 using SmartTalk.Messages.Dto.Smarties;
 using SmartTalk.Messages.Dto.AiSpeechAssistant;
 using SmartTalk.Messages.Dto.Pos;
 using SmartTalk.Messages.Enums.AiSpeechAssistant;
 using SmartTalk.Messages.Enums.STT;
+using AiSpeechAssistantEntity = SmartTalk.Core.Domain.AISpeechAssistant.AiSpeechAssistant;
+using AiSpeechAssistantKnowledgeEntity = SmartTalk.Core.Domain.AISpeechAssistant.AiSpeechAssistantKnowledge;
 
 namespace SmartTalk.Core.Services.AiSpeechAssistantConnect;
 
@@ -32,11 +35,30 @@ public partial class AiSpeechAssistantConnectService
 
         Log.Information("[AiAssistant] Assistant matched, AssistantId: {AssistantId}, HasProfile: {HasProfile}, From: {From}, To: {To}", assistant?.Id, userProfile != null, _ctx.From, _ctx.To);
 
+        EnsureAssistantInfoComplete(assistant, knowledge);
+
         _ctx.Assistant = _mapper.Map<AiSpeechAssistantDto>(assistant);
         _ctx.Knowledge = _mapper.Map<AiSpeechAssistantKnowledgeDto>(knowledge);
-        
+
         _ctx.Prompt = _ctx.Knowledge.Prompt;
         _ctx.UserProfileJson = userProfile?.ProfileJson;
+    }
+
+    /// <summary>
+    /// Validates that the data provider returned both an assistant and an active knowledge entry.
+    /// Throws <see cref="AiAssistantNotAvailableException"/> with an actionable message — the
+    /// existing <c>ConnectAsync</c> try/catch catches this exception type cleanly and closes
+    /// the Twilio WebSocket; raw <c>NullReferenceException</c> would otherwise escape and leave
+    /// the call hanging.
+    /// Public static; not intended for external use.
+    /// </summary>
+    public static void EnsureAssistantInfoComplete(AiSpeechAssistantEntity assistant, AiSpeechAssistantKnowledgeEntity knowledge)
+    {
+        if (assistant == null)
+            throw new AiAssistantNotAvailableException("No assistant configured for caller/DID");
+
+        if (knowledge == null)
+            throw new AiAssistantNotAvailableException($"No active knowledge for assistant {assistant.Id}");
     }
 
     private void ResolveStaticPromptVariables()

--- a/src/SmartTalk.IntegrationTests/Services/AiSpeechAssistant/AiSpeechAssistantConnectFixture.DataProvider.cs
+++ b/src/SmartTalk.IntegrationTests/Services/AiSpeechAssistant/AiSpeechAssistantConnectFixture.DataProvider.cs
@@ -10,6 +10,29 @@ namespace SmartTalk.IntegrationTests.Services.AiSpeechAssistant;
 public partial class AiSpeechAssistantConnectFixture
 {
     [Fact]
+    public async Task ShouldGetAssistantInfo_NoMatch_ReturnsTupleOfNulls()
+    {
+        // Pin the post-fix contract: when no assistant matches the (caller, DID) combo,
+        // the data provider must return (null, null, null) — not throw NRE. The previous
+        // implementation crashed inside the provider on `result.assistant` deref, leaking
+        // a raw NullReferenceException up to V2's ConnectAsync (which only handles
+        // AiAssistantNotAvailableException + AiAssistantCallForwardedException) and
+        // leaving the Twilio WebSocket dangling. Regression here means that bug returns.
+
+        await Run<IAiSpeechAssistantDataProvider>(async dataProvider =>
+        {
+            var (assistant, knowledge, userProfile) =
+                await dataProvider.GetAiSpeechAssistantInfoByNumbersAsync(
+                    callerNumber: "+10000000000",        // unmatched caller
+                    didNumber: "+19999999999");          // unmatched DID
+
+            assistant.ShouldBeNull();
+            knowledge.ShouldBeNull();
+            userProfile.ShouldBeNull();
+        });
+    }
+
+    [Fact]
     public async Task ShouldGetAssistantInfo_WithKnowledgeAndUserProfile()
     {
         await RunWithUnitOfWork<IRepository, IUnitOfWork>(async (repository, unitOfWork) =>

--- a/src/SmartTalk.UnitTests/Services/AiSpeechAssistantConnect/EnsureAssistantInfoCompleteTests.cs
+++ b/src/SmartTalk.UnitTests/Services/AiSpeechAssistantConnect/EnsureAssistantInfoCompleteTests.cs
@@ -1,0 +1,71 @@
+using Shouldly;
+using SmartTalk.Core.Domain.AISpeechAssistant;
+using SmartTalk.Core.Services.AiSpeechAssistantConnect;
+using SmartTalk.Core.Services.AiSpeechAssistantConnect.Exceptions;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Services.AiSpeechAssistantConnect;
+
+/// <summary>
+/// Covers the V2 null-defense extracted from
+/// <see cref="AiSpeechAssistantConnectService.LoadAssistantInfoAsync"/>.
+///
+/// <para>
+/// Before this PR, an unmatched (caller, DID, assistantId) tuple let the data
+/// provider's <c>FirstOrDefaultAsync(...)</c> return null, then the
+/// <c>return (result.assistant, ...)</c> dereference threw NullReferenceException
+/// from inside the data provider — an exception type that escaped the V2 ConnectAsync
+/// try/catch (which only handled AiAssistantNotAvailableException and AiAssistantCallForwardedException),
+/// leaking up the call stack and leaving the Twilio WebSocket dangling.
+/// </para>
+///
+/// <para>
+/// The fix: data provider returns a tuple of nulls (via <c>?.</c>); V2 explicitly
+/// checks for null assistant or null knowledge and throws AiAssistantNotAvailableException,
+/// which the existing try/catch handles cleanly.
+/// </para>
+/// </summary>
+public class EnsureAssistantInfoCompleteTests
+{
+    [Fact]
+    public void EnsureAssistantInfoComplete_BothNonNull_ReturnsWithoutThrowing()
+    {
+        var assistant = new AiSpeechAssistant { Id = 42 };
+        var knowledge = new AiSpeechAssistantKnowledge { AssistantId = 42, Prompt = "p" };
+
+        Should.NotThrow(() =>
+            AiSpeechAssistantConnectService.EnsureAssistantInfoComplete(assistant, knowledge));
+    }
+
+    [Fact]
+    public void EnsureAssistantInfoComplete_NullAssistant_ThrowsNotAvailable()
+    {
+        var ex = Should.Throw<AiAssistantNotAvailableException>(() =>
+            AiSpeechAssistantConnectService.EnsureAssistantInfoComplete(null, null));
+
+        ex.Message.ShouldContain("No assistant configured");
+    }
+
+    [Fact]
+    public void EnsureAssistantInfoComplete_NullKnowledge_ThrowsNotAvailable_WithAssistantId()
+    {
+        var assistant = new AiSpeechAssistant { Id = 99 };
+
+        var ex = Should.Throw<AiAssistantNotAvailableException>(() =>
+            AiSpeechAssistantConnectService.EnsureAssistantInfoComplete(assistant, null));
+
+        ex.Message.ShouldContain("No active knowledge");
+        ex.Message.ShouldContain("99");  // includes assistant id for diagnostics
+    }
+
+    [Fact]
+    public void EnsureAssistantInfoComplete_NullAssistantTakesPrecedenceOverNullKnowledge()
+    {
+        // When both are null, the assistant-missing message wins (more actionable).
+        var ex = Should.Throw<AiAssistantNotAvailableException>(() =>
+            AiSpeechAssistantConnectService.EnsureAssistantInfoComplete(null, null));
+
+        ex.Message.ShouldContain("No assistant configured");
+        ex.Message.ShouldNotContain("No active knowledge");
+    }
+}


### PR DESCRIPTION
## Summary

- `GetAiSpeechAssistantInfoByNumbersAsync` previously NRE'd inside the data provider when `FirstOrDefaultAsync` returned null on the anonymous projection. The raw `NullReferenceException` escaped V2's two-exception try/catch and left the Twilio WebSocket dangling for 30s
- Data provider: switch the tuple deref to null-conditional (`?.`) so a no-match yields `(null, null, null)` instead of NRE
- V2 caller: extract `EnsureAssistantInfoComplete(assistant, knowledge)` as `public static`. Throws `AiAssistantNotAvailableException` with an actionable message — caught cleanly by the existing `ConnectAsync` try/catch, which closes the Twilio WS

## Test plan

- [x] Unit: 4 cases — both non-null (no throw), null assistant ("No assistant configured"), null knowledge with assistant id in the message, precedence rule (assistant-missing wins when both null)
- [x] Integration: `ShouldGetAssistantInfo_NoMatch_ReturnsTupleOfNulls` pins the post-fix data provider contract end-to-end against a live DB
- [x] Regression: full unit suite 158/158

V1 (`AiSpeechAssistantService.cs:268`) still NRE's at `knowledge.Prompt.Replace(...)` when no match — that pre-existed this PR and is V1's own concern. No regression in user-visible behaviour because V1's broad `catch (Exception)` already handles the migrated NRE location.

Type aliases used in the partial class to disambiguate the `SmartTalk.Core.Domain.AISpeechAssistant` namespace from the same-named entity class.