### PR TITLE
Close the Twilio WebSocket on every ConnectAsync exit path

### DIFF
--- a/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectService.cs
+++ b/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectService.cs
@@ -1,3 +1,4 @@
+using System.Net.WebSockets;
 using Serilog;
 using AutoMapper;
 using Newtonsoft.Json;
@@ -113,8 +114,40 @@ public partial class AiSpeechAssistantConnectService : IAiSpeechAssistantConnect
         {
             Log.Information("[AiAssistant] {Reason}, From: {From}, To: {To}", ex.Message, command.From, command.To);
         }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "[AiAssistant] Unhandled error during connect, From: {From}, To: {To}", command.From, command.To);
+        }
+        finally
+        {
+            await TryCloseTwilioWebSocketAsync(command.TwilioWebSocket).ConfigureAwait(false);
+        }
 
         return new AiSpeechAssistantConnectCloseEvent();
+    }
+
+    /// <summary>
+    /// Best-effort close of the Twilio WebSocket. Used by ConnectAsync's finally block
+    /// to guarantee the socket is released even when an unknown exception escapes — without
+    /// this, the socket dangles until the platform's idle timeout (~30s) and the caller
+    /// hears silence. No-op when the socket is already closed/aborted/null. Swallows all
+    /// errors during close because we cannot do better than best-effort here.
+    /// Public static for unit testability; not intended for external use.
+    /// </summary>
+    public static async Task TryCloseTwilioWebSocketAsync(WebSocket twilioWebSocket)
+    {
+        if (twilioWebSocket is null) return;
+        if (twilioWebSocket.State is WebSocketState.Closed or WebSocketState.Aborted or WebSocketState.None) return;
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+
+        try
+        {
+            await twilioWebSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Session ended", cts.Token).ConfigureAwait(false);
+        }
+        catch (WebSocketException) { }
+        catch (ObjectDisposedException) { }
+        catch (OperationCanceledException) { }
     }
 
     private async Task<Agent> ResolveActiveAgentAsync(CancellationToken cancellationToken)

--- a/src/SmartTalk.UnitTests/Services/AiSpeechAssistantConnect/TryCloseTwilioWebSocketAsyncTests.cs
+++ b/src/SmartTalk.UnitTests/Services/AiSpeechAssistantConnect/TryCloseTwilioWebSocketAsyncTests.cs
@@ -1,0 +1,108 @@
+using System.Net.WebSockets;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Shouldly;
+using SmartTalk.Core.Services.AiSpeechAssistantConnect;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Services.AiSpeechAssistantConnect;
+
+/// <summary>
+/// Best-effort WebSocket cleanup helper. Used by ConnectAsync's finally block
+/// to ensure the Twilio WebSocket is closed even when an unknown exception
+/// escapes the orchestrator and would otherwise leave the socket dangling
+/// for the platform's idle timeout (~30s of silence for the caller).
+///
+/// <para>Contract:</para>
+/// <list type="bullet">
+///   <item>null WebSocket → no-op</item>
+///   <item>Already-closed states (Closed, Aborted, None) → no-op</item>
+///   <item>Live or half-closed states (Open, CloseReceived, CloseSent, Connecting) → CloseAsync</item>
+///   <item>Any exception during CloseAsync → swallowed (we cannot do better than best-effort here)</item>
+///   <item>2-second timeout on CloseAsync to prevent deadlock if the peer never acknowledges</item>
+/// </list>
+/// </summary>
+public class TryCloseTwilioWebSocketAsyncTests
+{
+    [Fact]
+    public async Task TryCloseTwilioWebSocketAsync_NullWebSocket_DoesNotThrow()
+    {
+        var ex = await Record.ExceptionAsync(
+            () => AiSpeechAssistantConnectService.TryCloseTwilioWebSocketAsync(null));
+
+        ex.ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData(WebSocketState.Closed)]
+    [InlineData(WebSocketState.Aborted)]
+    [InlineData(WebSocketState.None)]
+    public async Task TryCloseTwilioWebSocketAsync_AlreadyClosedState_DoesNotCallCloseAsync(WebSocketState state)
+    {
+        var ws = Substitute.For<WebSocket>();
+        ws.State.Returns(state);
+
+        await AiSpeechAssistantConnectService.TryCloseTwilioWebSocketAsync(ws);
+
+        await ws.DidNotReceive().CloseAsync(
+            Arg.Any<WebSocketCloseStatus>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData(WebSocketState.Open)]
+    [InlineData(WebSocketState.CloseReceived)]
+    [InlineData(WebSocketState.CloseSent)]
+    [InlineData(WebSocketState.Connecting)]
+    public async Task TryCloseTwilioWebSocketAsync_LiveOrHalfClosedState_CallsCloseAsyncWithNormalClosure(WebSocketState state)
+    {
+        var ws = Substitute.For<WebSocket>();
+        ws.State.Returns(state);
+
+        await AiSpeechAssistantConnectService.TryCloseTwilioWebSocketAsync(ws);
+
+        await ws.Received(1).CloseAsync(
+            WebSocketCloseStatus.NormalClosure, Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task TryCloseTwilioWebSocketAsync_WebSocketExceptionDuringClose_Swallowed()
+    {
+        var ws = Substitute.For<WebSocket>();
+        ws.State.Returns(WebSocketState.Open);
+        ws.CloseAsync(Arg.Any<WebSocketCloseStatus>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Throws(new WebSocketException("peer already closed"));
+
+        var ex = await Record.ExceptionAsync(
+            () => AiSpeechAssistantConnectService.TryCloseTwilioWebSocketAsync(ws));
+
+        ex.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task TryCloseTwilioWebSocketAsync_ObjectDisposedExceptionDuringClose_Swallowed()
+    {
+        var ws = Substitute.For<WebSocket>();
+        ws.State.Returns(WebSocketState.Open);
+        ws.CloseAsync(Arg.Any<WebSocketCloseStatus>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Throws(new ObjectDisposedException(nameof(WebSocket)));
+
+        var ex = await Record.ExceptionAsync(
+            () => AiSpeechAssistantConnectService.TryCloseTwilioWebSocketAsync(ws));
+
+        ex.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task TryCloseTwilioWebSocketAsync_OperationCanceledDuringClose_Swallowed()
+    {
+        var ws = Substitute.For<WebSocket>();
+        ws.State.Returns(WebSocketState.Open);
+        ws.CloseAsync(Arg.Any<WebSocketCloseStatus>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Throws(new OperationCanceledException("timeout"));
+
+        var ex = await Record.ExceptionAsync(
+            () => AiSpeechAssistantConnectService.TryCloseTwilioWebSocketAsync(ws));
+
+        ex.ShouldBeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- An unknown exception (NRE, DB timeout, OpenAI WS error) escaping ConnectAsync's two-exception try/catch leaves the Twilio WebSocket dangling until the platform's idle timeout — caller hears ~30s of silence
- The forward path also leaves the socket in `CloseReceived` state because `WebSocketReader.RunAsync` exits without sending the close acknowledgement
- Add `catch (Exception)` (Error-level log so unknown failures stay visible) + `finally` that calls a new `public static TryCloseTwilioWebSocketAsync(WebSocket)` helper. Helper is a no-op when the socket is already closed, so the happy path is unchanged

Helper contract: null / Closed / Aborted / None → no-op; live or half-closed → `CloseAsync` with 2s timeout; swallows `WebSocketException`, `ObjectDisposedException`, `OperationCanceledException` (best-effort cleanup).

## Test plan

- [x] Unit: 11 cases covering null input, every `WebSocketState`, and each swallowed exception type
- [x] Regression: full unit suite 219/219 (was 208)
- [ ] Staging: confirm forward-path Twilio WS is acknowledged immediately rather than at request-end

Refs: [`WebSocket.CloseAsync` semantics](https://learn.microsoft.com/en-us/dotnet/api/system.net.websockets.websocket.closeasync).