### PR TITLE
Wire OnClientStopAsync and OnSessionEndedAsync for V2 observability

### DIFF
--- a/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectService.Build.Session.cs
+++ b/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectService.Build.Session.cs
@@ -44,6 +44,8 @@ public partial class AiSpeechAssistantConnectService
             IdleFollowUp = BuildIdleFollowUp(),
             OnSessionReadyAsync = HandleSessionReadyAsync,
             OnClientStartAsync = HandleClientStartAsync,
+            OnClientStopAsync = HandleClientStopAsync,
+            OnSessionEndedAsync = HandleSessionEndedAsync,
             OnTranscriptionsCompletedAsync = HandleTranscriptionsCompletedAsync,
             OnRecordingCompleteAsync = HandleRecordingCompleteAsync,
             OnFunctionCallAsync = (data, actions) => OnFunctionCallAsync(data, actions, CancellationToken.None)

--- a/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectService.Events.cs
+++ b/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectService.Events.cs
@@ -27,7 +27,21 @@ public partial class AiSpeechAssistantConnectService
         TriggerTwilioRecordingPhoneCall();
 
         if (!_ctx.IsInAiServiceHours && _ctx.IsEnableManualService) TransferHumanService(_ctx.TransferCallNumber);
-        
+
+        return Task.CompletedTask;
+    }
+
+    private Task HandleClientStopAsync(string sessionId)
+    {
+        Log.Information("[AiAssistant] Twilio stop event received, SessionId: {SessionId}, CallSid: {CallSid}, StreamSid: {StreamSid}", sessionId, _ctx.CallSid, _ctx.StreamSid);
+
+        return Task.CompletedTask;
+    }
+
+    private Task HandleSessionEndedAsync(string sessionId)
+    {
+        Log.Information("[AiAssistant] Session ended, SessionId: {SessionId}, CallSid: {CallSid}", sessionId, _ctx.CallSid);
+
         return Task.CompletedTask;
     }
 


### PR DESCRIPTION
## Summary

- V2's `BuildSessionOptions` left `OnClientStopAsync` and `OnSessionEndedAsync` null, so Twilio's stop event and the session-ended signal were silently swallowed
- Add log-only handlers to record (a) timestamp of the Twilio stop frame — useful when diagnosing carriers that send stop well before or instead of the WS close, and (b) a single audited line per call confirming cleanup ran
- Behavior is unchanged. A subsequent PR can extend `HandleClientStopAsync` to actively close the Twilio WS for non-conformant carriers once observation data justifies it

## Test plan

- [x] Build clean (no behavior change)
- [x] Regression: full unit suite 208/208 pass
- [ ] Staging: confirm `Twilio stop event received` log fires once per call before the orchestrator's WS-close cleanup

No new unit tests added: the callbacks are bare `Log.Information` statements, and the RealtimeAiService side already has session-lifecycle tests (`RealtimeAiServiceSessionLifecycleTests.cs:508+`) that exercise the invocation paths against the shared RealtimeAiService contract.