### PR TITLE
Tighten realtime WebSocket keep-alive to 15s with env var override

### DIFF
--- a/docs/V2_ROLLOUT_PLAYBOOK.md
+++ b/docs/V2_ROLLOUT_PLAYBOOK.md
@@ -6,7 +6,7 @@
 
 | Env Var | 引入 PR | 預設值 | 當前狀態 | 說明 |
 |---|---|---|---|---|
-| _尚未引入_ | - | - | - | - |
+| `SQUID_SMARTTALK_REALTIME_WS_KEEPALIVE_SECONDS` | PR 2.3 | `15` | default | 提供 OpenAI/Google realtime WebSocket 客戶端的 keep-alive 間隔（秒）。範圍 5–120；越界或非數字回退為 15s。比 .NET 默認 30s 更頻繁，避免 corporate proxy / cloud LB 在 AI 沉默期間 idle-out 連線。 |
 
 ## 灰度狀態定義
 

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Wss/Google/GoogleRealtimeAiWssClient.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Wss/Google/GoogleRealtimeAiWssClient.cs
@@ -26,6 +26,7 @@ public class GoogleRealtimeAiWssClient : IRealtimeAiWssClient
     {
         _googleSettings = googleSettings;
         _webSocket = new ClientWebSocket();
+        _webSocket.Options.KeepAliveInterval = RealtimeAiWebSocketSettings.ResolveKeepAliveInterval();
     }
 
     public async Task ConnectAsync(Uri endpointUri, Dictionary<string, string> customHeaders, CancellationToken cancellationToken)

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Wss/OpenAi/OpenAiRealtimeAiWssClient.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Wss/OpenAi/OpenAiRealtimeAiWssClient.cs
@@ -23,6 +23,7 @@ public class OpenAiRealtimeAiWssClient : IRealtimeAiWssClient
     public OpenAiRealtimeAiWssClient()
     {
         _webSocket = new ClientWebSocket();
+        _webSocket.Options.KeepAliveInterval = RealtimeAiWebSocketSettings.ResolveKeepAliveInterval();
     }
 
     public async Task ConnectAsync(Uri endpointUri, Dictionary<string, string> customHeaders, CancellationToken cancellationToken)

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Wss/RealtimeAiWebSocketSettings.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Wss/RealtimeAiWebSocketSettings.cs
@@ -1,0 +1,47 @@
+namespace SmartTalk.Core.Services.RealtimeAiV2.Wss;
+
+/// <summary>
+/// Shared settings for the realtime provider WebSocket clients (OpenAI, Google).
+///
+/// <para>The keep-alive interval is tighter than .NET's 30-second default
+/// because the realtime APIs send no traffic during AI-silent windows
+/// (e.g. while the caller is reading the menu). Corporate proxies and
+/// cloud LBs that idle-out long-lived TLS at ~30s have been observed
+/// to drop the connection mid-call.</para>
+///
+/// <para>Operators can override via env var. Renaming
+/// <see cref="KeepAliveSecondsEnvVar"/> breaks every air-gapped operator
+/// who pinned a custom value, so the literal is hard-pinned in
+/// <c>RealtimeAiWebSocketSettingsTests</c>.</para>
+/// </summary>
+public static class RealtimeAiWebSocketSettings
+{
+    /// <summary>
+    /// Env var operators set to override the keep-alive interval (in seconds).
+    /// Valid range: 5–120. Out-of-range or unparseable values fall back to the default.
+    /// </summary>
+    public const string KeepAliveSecondsEnvVar = "SQUID_SMARTTALK_REALTIME_WS_KEEPALIVE_SECONDS";
+
+    private static readonly TimeSpan DefaultKeepAlive = TimeSpan.FromSeconds(15);
+    private const int MinSeconds = 5;
+    private const int MaxSeconds = 120;
+
+    /// <summary>
+    /// Returns the keep-alive interval, reading from <see cref="KeepAliveSecondsEnvVar"/>
+    /// at call time. Each new wss client gets the current env value (no caching, since
+    /// changes during process lifetime are rare and the call cost is trivial).
+    /// </summary>
+    public static TimeSpan ResolveKeepAliveInterval() =>
+        Parse(Environment.GetEnvironmentVariable(KeepAliveSecondsEnvVar));
+
+    /// <summary>
+    /// Pure parser — exposed for unit tests so we don't have to mutate process env vars.
+    /// </summary>
+    public static TimeSpan Parse(string raw)
+    {
+        if (int.TryParse(raw, out var seconds) && seconds is >= MinSeconds and <= MaxSeconds)
+            return TimeSpan.FromSeconds(seconds);
+
+        return DefaultKeepAlive;
+    }
+}

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/RealtimeAiWebSocketSettingsTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/RealtimeAiWebSocketSettingsTests.cs
@@ -1,0 +1,61 @@
+using Shouldly;
+using SmartTalk.Core.Services.RealtimeAiV2.Wss;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Services.RealtimeAiV2;
+
+/// <summary>
+/// Pins the `KeepAliveSecondsEnvVar` literal and verifies the parse contract for the
+/// shared keep-alive setting used by both OpenAI and Google realtime wss clients.
+///
+/// <para>
+/// The default (15s) is tighter than .NET's 30s baseline because OpenAI Realtime sends
+/// no traffic during AI-silent windows; corporate proxies and cloud LBs that idle-out
+/// long-lived TLS at ~30s have been observed to drop the connection mid-call. Caller
+/// hears silence until the next utterance triggers a reconnect attempt.
+/// </para>
+///
+/// <para>
+/// Air-gapped / fork operators can override via env var (Rule 8). The test pinning the
+/// env var literal makes a future rename a compile-time-visible decision rather than a
+/// silent breakage of pinned production overrides.
+/// </para>
+/// </summary>
+public class RealtimeAiWebSocketSettingsTests
+{
+    [Fact]
+    public void KeepAliveSecondsEnvVar_ConstantNamePinned()
+    {
+        // Renaming this constant breaks every operator who pinned a custom keep-alive
+        // via env var. Hard-pin in test.
+        RealtimeAiWebSocketSettings.KeepAliveSecondsEnvVar
+            .ShouldBe("SQUID_SMARTTALK_REALTIME_WS_KEEPALIVE_SECONDS");
+    }
+
+    [Theory]
+    [InlineData(null)]                                  // unset env
+    [InlineData("")]                                    // empty
+    [InlineData("   ")]                                 // whitespace
+    [InlineData("abc")]                                 // non-numeric
+    [InlineData("15.5")]                                // decimal (we require int)
+    [InlineData("-10")]                                 // negative
+    [InlineData("0")]                                   // below min
+    [InlineData("4")]                                   // below min
+    [InlineData("121")]                                 // above max
+    [InlineData("9999")]                                // way above max
+    public void Parse_InvalidOrOutOfRangeValue_ReturnsDefaultFifteenSeconds(string raw)
+    {
+        RealtimeAiWebSocketSettings.Parse(raw).ShouldBe(TimeSpan.FromSeconds(15));
+    }
+
+    [Theory]
+    [InlineData("5", 5)]                                // min boundary
+    [InlineData("15", 15)]                              // default value via env
+    [InlineData("30", 30)]                              // .NET default
+    [InlineData("60", 60)]
+    [InlineData("120", 120)]                            // max boundary
+    public void Parse_ValidValueInRange_ReturnsThatValue(string raw, int expectedSeconds)
+    {
+        RealtimeAiWebSocketSettings.Parse(raw).ShouldBe(TimeSpan.FromSeconds(expectedSeconds));
+    }
+}


### PR DESCRIPTION
## Summary

- OpenAI Realtime sends no traffic during AI-silent windows (caller reading the menu), so the .NET default 30s `ClientWebSocket.KeepAliveInterval` is too loose for environments where corporate proxies / cloud LBs idle-out long-lived TLS at ~30s — the connection drops mid-call and the caller hears silence until the next utterance triggers a reconnect
- Extract shared `RealtimeAiWebSocketSettings` used by both OpenAI and Google wss client constructors. Default 15s; operators can override via `SQUID_SMARTTALK_REALTIME_WS_KEEPALIVE_SECONDS` (range 5–120; invalid values fall back to default)
- Pin the env var literal in test (Rule 8) so a future rename surfaces as a CI failure rather than silent breakage of pinned operator overrides

## Test plan

- [x] Unit: 11 theory cases on `Parse` covering null/empty/whitespace, non-numeric, decimal, negative, below-min, above-max, and 5 valid in-range values
- [x] Pinning: env var literal `SQUID_SMARTTALK_REALTIME_WS_KEEPALIVE_SECONDS`
- [x] Regression: full unit suite 224/224 (was 208)
- [ ] Staging: monitor OpenAI WS reconnect rate before / after; confirm reduction in mid-call drops during AI-silent windows

Refs: [`ClientWebSocketOptions.KeepAliveInterval`](https://learn.microsoft.com/en-us/dotnet/api/system.net.websockets.clientwebsocketoptions.keepaliveinterval) default is 30s.

## Feature flag

- Env var: `SQUID_SMARTTALK_REALTIME_WS_KEEPALIVE_SECONDS`
- Default: `15`
- Rollback: set to `30` to restore .NET default behavior