### PR TITLE
Drop outbound Twilio frames sent before the start streamSid arrives

### DIFF
--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Clients/Twilio/TwilioRealtimeAiClientAdapter.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Clients/Twilio/TwilioRealtimeAiClientAdapter.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Serilog;
 using SmartTalk.Messages.Dto.RealtimeAi;
 using SmartTalk.Messages.Enums.RealtimeAi;
 
@@ -77,17 +78,40 @@ public class TwilioRealtimeAiClientAdapter : IRealtimeAiClientAdapter
 
     public object BuildAudioDeltaMessage(string base64Payload, string sessionId)
     {
-        return new { @event = "media", streamSid = _streamSid ?? sessionId, media = new { payload = base64Payload } };
+        if (TryWarnMissingStreamSid(sessionId, "media")) return null;
+
+        return new { @event = "media", streamSid = _streamSid, media = new { payload = base64Payload } };
     }
 
     public object BuildSpeechDetectedMessage(string sessionId)
     {
-        return new { @event = "clear", streamSid = _streamSid ?? sessionId };
+        if (TryWarnMissingStreamSid(sessionId, "clear")) return null;
+
+        return new { @event = "clear", streamSid = _streamSid };
     }
 
     public object BuildTurnCompletedMessage(string sessionId)
     {
-        return new { @event = "mark", streamSid = _streamSid ?? sessionId, mark = new { name = "turn_completed" } };
+        if (TryWarnMissingStreamSid(sessionId, "mark")) return null;
+
+        return new { @event = "mark", streamSid = _streamSid, mark = new { name = "turn_completed" } };
+    }
+
+    /// <summary>
+    /// Returns true (and logs once) when the Twilio start frame hasn't arrived yet.
+    /// In that race window the adapter has no valid streamSid; sending a frame with
+    /// any other value would cause Twilio to silently drop it. Dropping is preferable
+    /// to wasting bandwidth on a frame Twilio cannot route.
+    /// </summary>
+    private bool TryWarnMissingStreamSid(string sessionId, string eventName)
+    {
+        if (_streamSid != null) return false;
+
+        Log.Warning(
+            "[Twilio] Dropping outbound {EventName} frame: streamSid not yet set (Twilio start frame still pending). SessionId: {SessionId}",
+            eventName, sessionId);
+
+        return true;
     }
 
     public object BuildTranscriptionMessage(RealtimeAiWssEventType eventType, RealtimeAiWssTranscriptionData transcriptionData, string sessionId)

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Services/RealtimeAiService.Send.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Services/RealtimeAiService.Send.cs
@@ -11,6 +11,10 @@ public partial class RealtimeAiService
 
     private async Task SendToClientAsync(object payload)
     {
+        // null payload signals the client adapter chose to drop the frame
+        // (e.g. Twilio adapter when streamSid is not yet known). Skip the send.
+        if (payload is null) return;
+
         if (_ctx.WebSocket is not { State: WebSocketState.Open }) return;
 
         await _ctx.WsSendLock.WaitAsync(_ctx.SessionCts?.Token ?? CancellationToken.None).ConfigureAwait(false);

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/TwilioStreamSidGuardTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/TwilioStreamSidGuardTests.cs
@@ -1,0 +1,103 @@
+using Shouldly;
+using SmartTalk.Core.Services.RealtimeAiV2.Adapters.Clients.Twilio;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Services.RealtimeAiV2;
+
+/// <summary>
+/// Twilio's media-streams protocol requires every outbound `media` / `clear` / `mark`
+/// frame to carry the exact <c>streamSid</c> Twilio gave us in its <c>start</c> event.
+/// Sending one of these frames before <c>start</c> arrives — or with a fabricated
+/// <c>streamSid</c> — causes Twilio to silently drop the frame.
+///
+/// <para>
+/// Pre-fix the adapter used <c>_streamSid ?? sessionId</c>, so during the race window
+/// (OpenAI <c>session.updated</c> arriving before Twilio's <c>start</c>) the greeting
+/// audio was sent with our internal session GUID as <c>streamSid</c> and Twilio
+/// dropped it. Caller heard silence at the start of the call.
+/// </para>
+///
+/// <para>
+/// Post-fix the adapter returns <c>null</c> when <c>_streamSid</c> isn't yet set;
+/// the orchestrator's <c>SendToClientAsync</c> skips null payloads. The caller still
+/// hears silence during the race window (we can't fabricate a valid streamSid), but
+/// (a) we no longer waste bandwidth on garbage frames, and (b) we get a Serilog
+/// warning naming the race so we can measure how often it happens.
+/// </para>
+/// </summary>
+public class TwilioStreamSidGuardTests
+{
+    private const string SessionIdFallback = "00000000-0000-0000-0000-000000000001";
+
+    private static TwilioRealtimeAiClientAdapter NewAdapter() => new();
+
+    private static void SimulateTwilioStart(TwilioRealtimeAiClientAdapter adapter, string streamSid)
+    {
+        var startMessage = "{\"event\":\"start\",\"start\":{\"streamSid\":\"" + streamSid + "\",\"callSid\":\"CA-test\"}}";
+        adapter.ParseMessage(startMessage);
+    }
+
+    [Fact]
+    public void BuildAudioDeltaMessage_BeforeStart_ReturnsNull()
+    {
+        var adapter = NewAdapter();
+
+        var message = adapter.BuildAudioDeltaMessage("base64", SessionIdFallback);
+
+        message.ShouldBeNull();
+    }
+
+    [Fact]
+    public void BuildAudioDeltaMessage_AfterStart_ReturnsMessageWithRealStreamSid()
+    {
+        var adapter = NewAdapter();
+        SimulateTwilioStart(adapter, "MZ-real-stream-sid");
+
+        var message = adapter.BuildAudioDeltaMessage("base64", SessionIdFallback);
+
+        message.ShouldNotBeNull();
+        // Reflect on the anonymous shape to assert streamSid: { @event = "media", streamSid, media = { payload } }
+        var streamSid = message.GetType().GetProperty("streamSid")!.GetValue(message)!.ToString();
+        streamSid.ShouldBe("MZ-real-stream-sid");
+    }
+
+    [Fact]
+    public void BuildSpeechDetectedMessage_BeforeStart_ReturnsNull()
+    {
+        var adapter = NewAdapter();
+
+        adapter.BuildSpeechDetectedMessage(SessionIdFallback).ShouldBeNull();
+    }
+
+    [Fact]
+    public void BuildSpeechDetectedMessage_AfterStart_ReturnsMessageWithRealStreamSid()
+    {
+        var adapter = NewAdapter();
+        SimulateTwilioStart(adapter, "MZ-stream-2");
+
+        var message = adapter.BuildSpeechDetectedMessage(SessionIdFallback);
+
+        message.ShouldNotBeNull();
+        message.GetType().GetProperty("streamSid")!.GetValue(message)!.ToString().ShouldBe("MZ-stream-2");
+    }
+
+    [Fact]
+    public void BuildTurnCompletedMessage_BeforeStart_ReturnsNull()
+    {
+        var adapter = NewAdapter();
+
+        adapter.BuildTurnCompletedMessage(SessionIdFallback).ShouldBeNull();
+    }
+
+    [Fact]
+    public void BuildTurnCompletedMessage_AfterStart_ReturnsMessageWithRealStreamSid()
+    {
+        var adapter = NewAdapter();
+        SimulateTwilioStart(adapter, "MZ-stream-3");
+
+        var message = adapter.BuildTurnCompletedMessage(SessionIdFallback);
+
+        message.ShouldNotBeNull();
+        message.GetType().GetProperty("streamSid")!.GetValue(message)!.ToString().ShouldBe("MZ-stream-3");
+    }
+}


### PR DESCRIPTION
## Summary

- Twilio's media-streams protocol requires every outbound `media` / `clear` / `mark` frame to carry the exact `streamSid` Twilio gave us in its `start` event. The adapter previously fell back to `_streamSid ?? sessionId` — i.e. our internal Guid — when `_streamSid` wasn't set yet. Twilio silently drops these, so greeting audio chunks issued during the race window (OpenAI `session.updated` arriving ahead of Twilio `start`) were lost
- Return `null` instead of a malformed frame when `_streamSid` is not yet set; the orchestrator's `SendToClientAsync` skips null payloads. Add a Serilog warning naming the dropped event type
- Net effect for the caller is the same (silence during the race window — we cannot fabricate a valid streamSid), but we no longer waste bandwidth on garbage frames and we get measurable signal on how often the race fires

## Test plan

- [x] Unit: 6 cases — 3 for "before start returns null" per frame type (`media`, `clear`, `mark`), 3 for "after start returns message with the captured streamSid"
- [x] Regression: full unit suite 214/214 (was 208 on parent)
- [ ] Staging: monitor `Dropping outbound ... frame: streamSid not yet set` warnings to size the race-window frequency

The buffer-and-flush fix (queue outbound frames until `start` arrives, then flush) is intentionally deferred to a follow-up PR — it requires either widening `IRealtimeAiClientAdapter` with `WaitUntilReadyAsync` or adding an internal queue, both heavier than warranted before we have observation data.