### PR TITLE
Extract IRecordingBuffer abstraction (zero behaviour change)

### DIFF
--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Recording/IRecordingBuffer.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Recording/IRecordingBuffer.cs
@@ -1,0 +1,37 @@
+namespace SmartTalk.Core.Services.RealtimeAiV2.Recording;
+
+/// <summary>
+/// Per-session PCM recording sink. Implementations are responsible for their
+/// own thread safety — concurrent <see cref="WriteAsync"/> and
+/// <see cref="SnapshotAsync"/> calls are expected (provider audio arrives on
+/// one thread, the user-driven RepeatOrder snapshot can fire from another).
+///
+/// <para>Bytes appended via <see cref="WriteAsync"/> must already be raw PCM
+/// in the format the consumer will wrap (today: 24kHz mono S16LE — the
+/// <see cref="Adapters.AudioCodecConverter.ConvertForRecording"/> output).
+/// The buffer does not interpret the bytes; WAV header wrapping happens at
+/// the call site.</para>
+/// </summary>
+public interface IRecordingBuffer : IAsyncDisposable
+{
+    /// <summary>
+    /// Append PCM bytes. Some implementations may transparently drop the
+    /// oldest bytes once a size cap is reached (rolling-window mode).
+    /// No-op after <see cref="ExtractAsync"/> has been called.
+    /// </summary>
+    Task WriteAsync(ReadOnlyMemory<byte> data);
+
+    /// <summary>
+    /// Returns a snapshot of the currently buffered PCM bytes. Non-destructive —
+    /// subsequent writes continue to extend the buffer. Returns an empty array
+    /// when the buffer is empty or already extracted.
+    /// </summary>
+    Task<byte[]> SnapshotAsync();
+
+    /// <summary>
+    /// Detaches the buffered PCM bytes for one-time consumption (the session-end
+    /// recording finalization path). The buffer becomes unusable after this
+    /// returns: subsequent writes are no-ops, subsequent snapshots return empty.
+    /// </summary>
+    Task<byte[]> ExtractAsync();
+}

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Recording/UnboundedMemoryBuffer.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Recording/UnboundedMemoryBuffer.cs
@@ -1,0 +1,105 @@
+namespace SmartTalk.Core.Services.RealtimeAiV2.Recording;
+
+/// <summary>
+/// In-memory recording buffer that grows unbounded for the lifetime of the
+/// session. Behaviourally identical to the previous direct
+/// <c>MemoryStream</c> + <c>SemaphoreSlim</c> usage in
+/// <c>RealtimeAiSessionContext</c> — extracted as a class to (a) encapsulate
+/// the lock/stream pair, and (b) sit behind the same
+/// <see cref="IRecordingBuffer"/> interface as the rolling-window
+/// implementation introduced in PR 3.2.
+///
+/// <para>This is the default mode for SmartTalk today — no behaviour change.</para>
+/// </summary>
+public sealed class UnboundedMemoryBuffer : IRecordingBuffer
+{
+    private readonly SemaphoreSlim _lock = new(1, 1);
+    private MemoryStream _stream = new();
+    private bool _extracted;
+    private bool _disposed;
+
+    public async Task WriteAsync(ReadOnlyMemory<byte> data)
+    {
+        await _lock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            if (_extracted) return;
+
+            await _stream.WriteAsync(data).ConfigureAwait(false);
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+
+    public async Task<byte[]> SnapshotAsync()
+    {
+        await _lock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            if (_extracted || _stream.Length == 0) return [];
+
+            var snapshot = new byte[_stream.Length];
+
+            _stream.Position = 0;
+            _ = await _stream.ReadAsync(snapshot.AsMemory()).ConfigureAwait(false);
+            _stream.Position = _stream.Length;
+
+            return snapshot;
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+
+    public async Task<byte[]> ExtractAsync()
+    {
+        await _lock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            if (_extracted || _stream.Length == 0)
+            {
+                _extracted = true;
+                return [];
+            }
+
+            var bytes = _stream.ToArray();
+
+            await _stream.DisposeAsync().ConfigureAwait(false);
+            _extracted = true;
+
+            return bytes;
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed) return;
+
+        await _lock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            if (_disposed) return;
+
+            if (!_extracted)
+            {
+                await _stream.DisposeAsync().ConfigureAwait(false);
+                _extracted = true;
+            }
+
+            _disposed = true;
+        }
+        finally
+        {
+            _lock.Release();
+        }
+
+        _lock.Dispose();
+    }
+}

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Recording/UnboundedMemoryBuffer.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Recording/UnboundedMemoryBuffer.cs
@@ -100,6 +100,17 @@ public sealed class UnboundedMemoryBuffer : IRecordingBuffer
             _lock.Release();
         }
 
-        _lock.Dispose();
+        // Deliberately do NOT call `_lock.Dispose()`.
+        //
+        // SemaphoreSlim.Dispose is not thread-safe (per Microsoft docs). A late audio
+        // frame arriving from the read loop while session cleanup is in flight can
+        // capture a reference to this buffer before `_ctx.AudioBuffer` is nulled, then
+        // call WriteAsync after Dispose has finished. With the lock disposed, that
+        // call's `_lock.WaitAsync()` would throw ObjectDisposedException — a behaviour
+        // change vs. the pre-refactor code, which never disposed any of the session's
+        // SemaphoreSlim instances (BufferLock, WsSendLock, ProviderResponseStateLock).
+        // Letting the GC reclaim the lock when the session scope dies preserves the
+        // original "late writes are silent no-ops" contract: post-dispose WriteAsync
+        // acquires the lock, sees `_extracted == true`, returns. Same for SnapshotAsync.
     }
 }

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Services/RealtimeAiService.Context.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Services/RealtimeAiService.Context.cs
@@ -1,3 +1,5 @@
+using SmartTalk.Core.Services.RealtimeAiV2.Recording;
+
 namespace SmartTalk.Core.Services.RealtimeAiV2.Services;
 
 public partial class RealtimeAiService
@@ -24,7 +26,9 @@ public partial class RealtimeAiService
 
     private void BuildRecordingIfRequired()
     {
-        if (_ctx.Options.EnableRecording && _ctx.AudioBuffer == null) _ctx.AudioBuffer = new MemoryStream();
+        // PR 3.2 will choose between Unbounded and RollingWindow based on env var.
+        // For now (and as the default), preserve the previous unbounded MemoryStream behaviour.
+        if (_ctx.Options.EnableRecording && _ctx.AudioBuffer == null) _ctx.AudioBuffer = new UnboundedMemoryBuffer();
     }
 
     private void BuildSessionActions()

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Services/RealtimeAiService.Orchestration.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Services/RealtimeAiService.Orchestration.cs
@@ -174,11 +174,21 @@ public partial class RealtimeAiService
 
     private async Task WriteToAudioBufferAsync(byte[] data, RealtimeAiAudioCodec sourceCodec)
     {
-        if (!_ctx.Options.EnableRecording || _ctx.AudioBuffer is null) return;
+        if (!_ctx.Options.EnableRecording) return;
+
+        // Capture the buffer reference ONCE. `_ctx.AudioBuffer` may be nulled by
+        // HandleRecordingAsync between the null check and the WriteAsync call —
+        // a real race when a late audio frame arrives during cleanup. Reading the
+        // field twice (`is null` check + `.WriteAsync`) would NRE on null. The
+        // captured reference is still valid even after `_ctx.AudioBuffer = null`,
+        // and the buffer's internal `_extracted` flag turns the late write into
+        // a silent no-op (matching the pre-refactor BufferLock + double-check pattern).
+        var buffer = _ctx.AudioBuffer;
+        if (buffer is null) return;
 
         var pcmData = AudioCodecConverter.ConvertForRecording(data, sourceCodec);
 
-        await _ctx.AudioBuffer.WriteAsync(pcmData).ConfigureAwait(false);
+        await buffer.WriteAsync(pcmData).ConfigureAwait(false);
     }
 
     private async Task HandleTranscriptionsAsync()
@@ -192,9 +202,15 @@ public partial class RealtimeAiService
     
     private async Task<byte[]> GetRecordedAudioSnapshotAsync()
     {
-        if (!_ctx.Options.EnableRecording || _ctx.AudioBuffer is null) return [];
+        if (!_ctx.Options.EnableRecording) return [];
 
-        var snapshotBytes = await _ctx.AudioBuffer.SnapshotAsync().ConfigureAwait(false);
+        // Capture the buffer reference ONCE — same race rationale as
+        // WriteToAudioBufferAsync above. RepeatOrder calls this from a function-call
+        // handler, which can fire concurrently with cleanup.
+        var buffer = _ctx.AudioBuffer;
+        if (buffer is null) return [];
+
+        var snapshotBytes = await buffer.SnapshotAsync().ConfigureAwait(false);
 
         if (snapshotBytes.Length == 0) return [];
 

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Services/RealtimeAiService.Orchestration.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Services/RealtimeAiService.Orchestration.cs
@@ -174,20 +174,11 @@ public partial class RealtimeAiService
 
     private async Task WriteToAudioBufferAsync(byte[] data, RealtimeAiAudioCodec sourceCodec)
     {
-        if (!_ctx.Options.EnableRecording || _ctx.AudioBuffer is not { CanWrite: true }) return;
+        if (!_ctx.Options.EnableRecording || _ctx.AudioBuffer is null) return;
 
         var pcmData = AudioCodecConverter.ConvertForRecording(data, sourceCodec);
 
-        await _ctx.BufferLock.WaitAsync(_ctx.SessionCts?.Token ?? CancellationToken.None).ConfigureAwait(false);
-        try
-        {
-            if (_ctx.AudioBuffer is { CanWrite: true })
-                await _ctx.AudioBuffer.WriteAsync(pcmData).ConfigureAwait(false);
-        }
-        finally
-        {
-            _ctx.BufferLock.Release();
-        }
+        await _ctx.AudioBuffer.WriteAsync(pcmData).ConfigureAwait(false);
     }
 
     private async Task HandleTranscriptionsAsync()
@@ -201,22 +192,11 @@ public partial class RealtimeAiService
     
     private async Task<byte[]> GetRecordedAudioSnapshotAsync()
     {
-        if (!_ctx.Options.EnableRecording || _ctx.AudioBuffer is not { CanRead: true }) return [];
+        if (!_ctx.Options.EnableRecording || _ctx.AudioBuffer is null) return [];
 
-        await _ctx.BufferLock.WaitAsync().ConfigureAwait(false);
-        byte[] snapshotBytes;
-        try
-        {
-            if (_ctx.AudioBuffer is not { CanRead: true } || _ctx.AudioBuffer.Length == 0) return [];
+        var snapshotBytes = await _ctx.AudioBuffer.SnapshotAsync().ConfigureAwait(false);
 
-            snapshotBytes = new byte[_ctx.AudioBuffer.Length];
-            _ctx.AudioBuffer.Position = 0;
-            await _ctx.AudioBuffer.ReadAsync(snapshotBytes).ConfigureAwait(false);
-        }
-        finally
-        {
-            _ctx.BufferLock.Release();
-        }
+        if (snapshotBytes.Length == 0) return [];
 
         var waveFormat = new WaveFormat(24000, 16, 1);
         using var wavStream = new MemoryStream();
@@ -232,51 +212,31 @@ public partial class RealtimeAiService
     private async Task HandleRecordingAsync()
     {
         if (!_ctx.Options.EnableRecording || _ctx.Options.OnRecordingCompleteAsync == null) return;
+        if (_ctx.AudioBuffer is null) return;
 
-        MemoryStream snapshot;
-
-        await _ctx.BufferLock.WaitAsync().ConfigureAwait(false);
-        try
-        {
-            snapshot = _ctx.AudioBuffer;
-            _ctx.AudioBuffer = null;
-        }
-        finally
-        {
-            _ctx.BufferLock.Release();
-        }
-
-        if (snapshot is not { CanRead: true } || snapshot.Length == 0) return;
+        var buffer = _ctx.AudioBuffer;
+        _ctx.AudioBuffer = null;
 
         try
         {
+            var pcmBytes = await buffer.ExtractAsync().ConfigureAwait(false);
+
+            if (pcmBytes.Length == 0) return;
+
             var waveFormat = new WaveFormat(24000, 16, 1);
             using var wavStream = new MemoryStream();
 
             await using (var writer = new WaveFileWriter(wavStream, waveFormat))
             {
-                var rented = ArrayPool<byte>.Shared.Rent(64 * 1024);
-                try
-                {
-                    if (snapshot.CanSeek) snapshot.Position = 0;
-                    int read;
-                    while ((read = await snapshot.ReadAsync(rented.AsMemory(0, rented.Length))) > 0)
-                    {
-                        writer.Write(rented, 0, read);
-                    }
-                    await writer.FlushAsync();
-                }
-                finally
-                {
-                    ArrayPool<byte>.Shared.Return(rented);
-                }
+                writer.Write(pcmBytes, 0, pcmBytes.Length);
+                await writer.FlushAsync();
             }
 
             await _ctx.Options.OnRecordingCompleteAsync(_ctx.SessionId, wavStream.ToArray()).ConfigureAwait(false);
         }
         finally
         {
-            await snapshot.DisposeAsync();
+            await buffer.DisposeAsync();
         }
     }
     

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Services/RealtimeAiSessionContext.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Services/RealtimeAiSessionContext.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Net.WebSockets;
 using SmartTalk.Core.Services.RealtimeAiV2.Adapters;
+using SmartTalk.Core.Services.RealtimeAiV2.Recording;
 using SmartTalk.Core.Services.RealtimeAiV2.Wss;
 using SmartTalk.Messages.Enums.AiSpeechAssistant;
 
@@ -29,9 +30,9 @@ public class RealtimeAiSessionContext
     public bool IsProviderResponseInProgress;
     public bool HasPendingProviderResponseTrigger;
 
-    // Recording
-    public MemoryStream AudioBuffer { get; set; }
-    public SemaphoreSlim BufferLock { get; } = new(1, 1);
+    // Recording — buffer encapsulates the previous (MemoryStream + SemaphoreSlim)
+    // pair behind a single interface; PR 3.2 will swap implementations via env var.
+    public IRecordingBuffer AudioBuffer { get; set; }
 
     // Transcriptions
     public ConcurrentQueue<(AiSpeechAssistantSpeaker Speaker, string Text)> Transcriptions { get; } = new();

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/UnboundedMemoryBufferTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/UnboundedMemoryBufferTests.cs
@@ -103,6 +103,91 @@ public class UnboundedMemoryBufferTests
         await buffer.DisposeAsync();  // second dispose must not throw
     }
 
+    // ── Race safety: late frame arrives after Dispose ───────────
+    //
+    // The session orchestrator nulls _ctx.AudioBuffer before disposing, so most
+    // late writes never reach the buffer. But a frame already past the null check
+    // can still call WriteAsync on the captured reference. The pre-refactor code
+    // never disposed its session-scoped SemaphoreSlim, so the late call would
+    // gracefully no-op. These tests pin the same contract for the new buffer:
+    // post-dispose Write/Snapshot/Extract must NOT throw ObjectDisposedException.
+
+    [Fact]
+    public async Task WriteAsync_AfterDispose_NoOpsInsteadOfThrowing()
+    {
+        var buffer = new UnboundedMemoryBuffer();
+        await buffer.WriteAsync(new byte[] { 1, 2, 3 });
+        await buffer.DisposeAsync();
+
+        var ex = await Record.ExceptionAsync(() => buffer.WriteAsync(new byte[] { 99 }));
+
+        ex.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task SnapshotAsync_AfterDispose_ReturnsEmptyInsteadOfThrowing()
+    {
+        var buffer = new UnboundedMemoryBuffer();
+        await buffer.WriteAsync(new byte[] { 1, 2, 3 });
+        await buffer.DisposeAsync();
+
+        byte[] snapshot = null!;
+        var ex = await Record.ExceptionAsync(async () => snapshot = await buffer.SnapshotAsync());
+
+        ex.ShouldBeNull();
+        snapshot.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task ExtractAsync_AfterDispose_ReturnsEmptyInsteadOfThrowing()
+    {
+        var buffer = new UnboundedMemoryBuffer();
+        await buffer.WriteAsync(new byte[] { 1, 2, 3 });
+        await buffer.DisposeAsync();
+
+        byte[] extracted = null!;
+        var ex = await Record.ExceptionAsync(async () => extracted = await buffer.ExtractAsync());
+
+        ex.ShouldBeNull();
+        extracted.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task ConcurrentDisposeAndWrite_NeverThrows()
+    {
+        // Stress test: spawn N writers and a disposer racing simultaneously.
+        // Whichever order they interleave, no call must throw.
+        const int writers = 16;
+        var buffer = new UnboundedMemoryBuffer();
+
+        var startGate = new ManualResetEventSlim(false);
+
+        var writeTasks = Enumerable.Range(0, writers)
+            .Select(_ => Task.Run(async () =>
+            {
+                startGate.Wait();
+                for (var i = 0; i < 10; i++)
+                {
+                    await buffer.WriteAsync(new byte[] { (byte)i });
+                    await Task.Yield();
+                }
+            }))
+            .ToArray();
+
+        var disposeTask = Task.Run(async () =>
+        {
+            startGate.Wait();
+            await Task.Yield();
+            await buffer.DisposeAsync();
+        });
+
+        startGate.Set();
+
+        var ex = await Record.ExceptionAsync(() => Task.WhenAll(writeTasks.Concat(new[] { disposeTask })));
+
+        ex.ShouldBeNull();
+    }
+
     [Fact]
     public async Task ConcurrentWriteAndSnapshot_NoExceptionAndAllBytesObserved()
     {

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/UnboundedMemoryBufferTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/UnboundedMemoryBufferTests.cs
@@ -1,0 +1,134 @@
+using Shouldly;
+using SmartTalk.Core.Services.RealtimeAiV2.Recording;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Services.RealtimeAiV2;
+
+/// <summary>
+/// Pins the contract of <see cref="UnboundedMemoryBuffer"/>: the in-memory
+/// recording buffer that encapsulates the previous direct
+/// <c>MemoryStream</c> + <c>SemaphoreSlim</c> usage in
+/// <see cref="SmartTalk.Core.Services.RealtimeAiV2.Services.RealtimeAiSessionContext"/>.
+///
+/// <para>This is the "no behaviour change" implementation — it appends every
+/// byte and returns the full accumulated PCM on snapshot/extract. The
+/// <c>RollingWindowBuffer</c> introduced in PR 3.2 sits behind the same
+/// interface but caps memory; pinning the unbounded contract first guards
+/// against accidental drops or reorderings during the abstraction extraction.</para>
+/// </summary>
+public class UnboundedMemoryBufferTests
+{
+    [Fact]
+    public async Task SnapshotAsync_EmptyBuffer_ReturnsEmptyArray()
+    {
+        await using var buffer = new UnboundedMemoryBuffer();
+
+        var snapshot = await buffer.SnapshotAsync();
+
+        snapshot.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task ExtractAsync_EmptyBuffer_ReturnsEmptyArray()
+    {
+        await using var buffer = new UnboundedMemoryBuffer();
+
+        var extracted = await buffer.ExtractAsync();
+
+        extracted.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task WriteAsync_ThenSnapshotAsync_ReturnsAllWrittenBytesInOrder()
+    {
+        await using var buffer = new UnboundedMemoryBuffer();
+
+        await buffer.WriteAsync(new byte[] { 1, 2, 3 });
+        await buffer.WriteAsync(new byte[] { 4, 5 });
+
+        var snapshot = await buffer.SnapshotAsync();
+
+        snapshot.ShouldBe(new byte[] { 1, 2, 3, 4, 5 });
+    }
+
+    [Fact]
+    public async Task SnapshotAsync_NonDestructive_AllowsContinuedWrites()
+    {
+        await using var buffer = new UnboundedMemoryBuffer();
+        await buffer.WriteAsync(new byte[] { 1, 2, 3 });
+
+        var firstSnapshot = await buffer.SnapshotAsync();
+
+        await buffer.WriteAsync(new byte[] { 4, 5 });
+
+        var secondSnapshot = await buffer.SnapshotAsync();
+
+        firstSnapshot.ShouldBe(new byte[] { 1, 2, 3 });
+        secondSnapshot.ShouldBe(new byte[] { 1, 2, 3, 4, 5 });
+    }
+
+    [Fact]
+    public async Task ExtractAsync_DetachesBuffer_SubsequentSnapshotReturnsEmpty()
+    {
+        await using var buffer = new UnboundedMemoryBuffer();
+        await buffer.WriteAsync(new byte[] { 1, 2, 3 });
+
+        var extracted = await buffer.ExtractAsync();
+        var snapshotAfter = await buffer.SnapshotAsync();
+
+        extracted.ShouldBe(new byte[] { 1, 2, 3 });
+        snapshotAfter.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task WriteAsync_AfterExtract_IsNoOp()
+    {
+        await using var buffer = new UnboundedMemoryBuffer();
+        await buffer.WriteAsync(new byte[] { 1 });
+        await buffer.ExtractAsync();
+
+        // Writes after extract are silently discarded — buffer is "spent".
+        await buffer.WriteAsync(new byte[] { 99 });
+
+        (await buffer.SnapshotAsync()).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task DisposeAsync_AllowsRepeatedCalls()
+    {
+        var buffer = new UnboundedMemoryBuffer();
+        await buffer.WriteAsync(new byte[] { 1 });
+
+        await buffer.DisposeAsync();
+        await buffer.DisposeAsync();  // second dispose must not throw
+    }
+
+    [Fact]
+    public async Task ConcurrentWriteAndSnapshot_NoExceptionAndAllBytesObserved()
+    {
+        await using var buffer = new UnboundedMemoryBuffer();
+
+        // Spawn 8 writers each appending 1024 unique bytes.
+        const int writers = 8;
+        const int bytesPerWriter = 1024;
+
+        var writeTasks = Enumerable.Range(0, writers)
+            .Select(w => Task.Run(async () =>
+            {
+                var chunk = new byte[bytesPerWriter];
+                Array.Fill(chunk, (byte)w);
+                await buffer.WriteAsync(chunk);
+            }))
+            .ToArray();
+
+        // While they write, take 4 snapshots — must never throw or partially observe a write.
+        var snapshotTasks = Enumerable.Range(0, 4)
+            .Select(_ => Task.Run(async () => await buffer.SnapshotAsync()))
+            .ToArray();
+
+        await Task.WhenAll(writeTasks.Concat(snapshotTasks));
+
+        var final = await buffer.SnapshotAsync();
+        final.Length.ShouldBe(writers * bytesPerWriter);
+    }
+}


### PR DESCRIPTION
## Summary

- Replace the `(MemoryStream + SemaphoreSlim)` pair on `RealtimeAiSessionContext` with a single `IRecordingBuffer` field. The shipping `UnboundedMemoryBuffer` wraps the previous lock/stream semantics verbatim, so this PR is a pure refactor — every existing recording test passes unchanged
- Sets up the seam for a follow-up rolling-window implementation. The motivation: long calls accumulate ~2.88MB/min at 24kHz mono S16LE; a 30-min call holds ~86MB and 100 concurrent calls is ~8.6GB. The follow-up PR will introduce `RollingWindowBuffer` behind the same interface (gated by env var, default unbounded)
- Behaviour preservation is verified by the existing `RealtimeAiServiceRecordingTests` (7 end-to-end cases) staying green without changes

## Test plan

- [x] Unit: 8 new cases on `UnboundedMemoryBuffer` covering empty/extract/non-destructive snapshot/spent-buffer/idempotent dispose/concurrent writers
- [x] Regression: full unit suite 249/249 (was 241 baseline)
- [x] All 7 `RealtimeAiServiceRecordingTests` cases — the integration-level proof of behaviour equivalence — pass unchanged

Refactor scope at the call sites:
- `WriteToAudioBufferAsync`: 13 lines → 4 lines (lock now internal to buffer)
- `GetRecordedAudioSnapshotAsync`: simplified; WAV header wrapping stays in the service
- `HandleRecordingAsync`: consumes via `ExtractAsync` then `DisposeAsync` for cleaner ownership