### PR TITLE
Add RollingWindowBuffer behind opt-in env var (default unbounded)

### DIFF
--- a/docs/V2_ROLLOUT_PLAYBOOK.md
+++ b/docs/V2_ROLLOUT_PLAYBOOK.md
@@ -7,6 +7,8 @@
 | Env Var | 引入 PR | 預設值 | 當前狀態 | 說明 |
 |---|---|---|---|---|
 | `SQUID_SMARTTALK_REALTIME_WS_KEEPALIVE_SECONDS` | PR 2.3 | `15` | default | 提供 OpenAI/Google realtime WebSocket 客戶端的 keep-alive 間隔（秒）。範圍 5–120；越界或非數字回退為 15s。比 .NET 默認 30s 更頻繁，避免 corporate proxy / cloud LB 在 AI 沉默期間 idle-out 連線。 |
+| `SQUID_SMARTTALK_RECORDING_BUFFER_MODE` | PR 3.2 | `unbounded` | default | 錄音 buffer 實現策略。值：`unbounded`（與當前行為一致）或 `rolling`（環形 buffer，超出窗口的舊數據自動丟棄）。任何非 `rolling` 值（含未設）視為 unbounded。 |
+| `SQUID_SMARTTALK_RECORDING_BUFFER_SECONDS` | PR 3.2 | `300` | default | 當 `BUFFER_MODE=rolling` 時的窗口大小（秒）。範圍 30–3600；越界回退 300。300s × 48,000 byte/s = 14.4 MB cap per call。 |
 
 ## 灰度狀態定義
 

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Recording/RealtimeAiRecordingSettings.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Recording/RealtimeAiRecordingSettings.cs
@@ -1,0 +1,68 @@
+namespace SmartTalk.Core.Services.RealtimeAiV2.Recording;
+
+/// <summary>
+/// Picks the recording buffer implementation for a session based on env vars.
+/// Defaults preserve the previous unbounded behaviour exactly — operators must
+/// explicitly opt in to rolling-window mode.
+///
+/// <para>Renaming either env var literal breaks every operator who pinned a
+/// custom value, so both literals are hard-pinned in
+/// <c>RealtimeAiRecordingSettingsTests</c> (Rule 8).</para>
+/// </summary>
+public static class RealtimeAiRecordingSettings
+{
+    /// <summary>Selects the buffer implementation. Values: "unbounded" (default) or "rolling".</summary>
+    public const string BufferModeEnvVar = "SQUID_SMARTTALK_RECORDING_BUFFER_MODE";
+
+    /// <summary>Window size when mode = rolling. Range 30–3600 seconds; out-of-range falls back to default 300.</summary>
+    public const string BufferSecondsEnvVar = "SQUID_SMARTTALK_RECORDING_BUFFER_SECONDS";
+
+    /// <summary>24kHz mono S16LE → 48,000 byte/s. Matches AudioCodecConverter.RecordingSampleRate.</summary>
+    private const int PcmBytesPerSecond = 24_000 * 2;
+
+    private const int DefaultSeconds = 300;
+    private const int MinSeconds = 30;
+    private const int MaxSeconds = 3_600;
+
+    public enum BufferMode
+    {
+        Unbounded,
+        Rolling
+    }
+
+    /// <summary>Reads <see cref="BufferModeEnvVar"/> at call time.</summary>
+    public static BufferMode ResolveMode() =>
+        ParseMode(Environment.GetEnvironmentVariable(BufferModeEnvVar));
+
+    /// <summary>Reads <see cref="BufferSecondsEnvVar"/> at call time. Bounded to [Min,Max] with default fallback.</summary>
+    public static int ResolveSeconds() =>
+        ParseSeconds(Environment.GetEnvironmentVariable(BufferSecondsEnvVar));
+
+    /// <summary>
+    /// Constructs the buffer for a fresh session — call site is
+    /// <c>RealtimeAiService.BuildRecordingIfRequired</c>.
+    /// </summary>
+    public static IRecordingBuffer Create()
+    {
+        if (ResolveMode() == BufferMode.Unbounded) return new UnboundedMemoryBuffer();
+
+        var capacityBytes = ResolveSeconds() * PcmBytesPerSecond;
+
+        return new RollingWindowBuffer(capacityBytes);
+    }
+
+    /// <summary>Pure parser — exposed for unit tests to avoid env var mutation.</summary>
+    public static BufferMode ParseMode(string raw) =>
+        string.Equals(raw?.Trim(), "rolling", StringComparison.OrdinalIgnoreCase)
+            ? BufferMode.Rolling
+            : BufferMode.Unbounded;
+
+    /// <summary>Pure parser — exposed for unit tests.</summary>
+    public static int ParseSeconds(string raw)
+    {
+        if (int.TryParse(raw, out var seconds) && seconds is >= MinSeconds and <= MaxSeconds)
+            return seconds;
+
+        return DefaultSeconds;
+    }
+}

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Recording/RollingWindowBuffer.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Recording/RollingWindowBuffer.cs
@@ -131,7 +131,13 @@ public sealed class RollingWindowBuffer : IRecordingBuffer
             _lock.Release();
         }
 
-        _lock.Dispose();
+        // Deliberately do NOT call `_lock.Dispose()` — same rationale as
+        // UnboundedMemoryBuffer.DisposeAsync. SemaphoreSlim.Dispose is not
+        // thread-safe; a late audio frame arriving after cleanup must be a
+        // silent no-op (post-dispose Write/Snapshot/Extract acquire the
+        // lock, see `_extracted == true`, return). Letting the GC reclaim
+        // the lock when the session scope dies matches V2's existing
+        // pattern for all other session-scoped semaphores.
     }
 
     /// <summary>Builds the chronologically-ordered snapshot. Caller must hold the lock.</summary>

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Recording/RollingWindowBuffer.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Recording/RollingWindowBuffer.cs
@@ -1,0 +1,159 @@
+namespace SmartTalk.Core.Services.RealtimeAiV2.Recording;
+
+/// <summary>
+/// Fixed-capacity recording buffer that drops the oldest PCM bytes when the
+/// cap is reached. Internally a circular byte array — O(1) writes and snapshots.
+///
+/// <para>Sized to comfortably exceed any realistic call duration so a normal
+/// session behaves identically to <see cref="UnboundedMemoryBuffer"/>; the
+/// cap only kicks in for pathologically long calls (the scenario that today
+/// produces 86MB+ memory pressure per call).</para>
+///
+/// <para>Snapshot and Extract return bytes in chronological order regardless
+/// of where the write head currently sits in the underlying array.</para>
+/// </summary>
+public sealed class RollingWindowBuffer : IRecordingBuffer
+{
+    private readonly SemaphoreSlim _lock = new(1, 1);
+    private readonly byte[] _buffer;
+    private readonly int _capacity;
+
+    private int _writePos;
+    private bool _wrapped;
+    private bool _extracted;
+    private bool _disposed;
+
+    public RollingWindowBuffer(int capacityBytes)
+    {
+        if (capacityBytes <= 0)
+            throw new ArgumentOutOfRangeException(nameof(capacityBytes), "Capacity must be positive.");
+
+        _capacity = capacityBytes;
+        _buffer = new byte[capacityBytes];
+    }
+
+    public async Task WriteAsync(ReadOnlyMemory<byte> data)
+    {
+        await _lock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            if (_extracted) return;
+
+            WriteUnderLock(data.Span);
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+
+    /// <summary>
+    /// Sync body of the write — span manipulation can't sit inside an async method
+    /// (ReadOnlySpan is a ref struct; unsupported in async on C# 12). Caller holds the lock.
+    /// </summary>
+    private void WriteUnderLock(ReadOnlySpan<byte> span)
+    {
+        if (span.Length >= _capacity)
+        {
+            // Single write larger than capacity — keep only the trailing capacity bytes.
+            span.Slice(span.Length - _capacity).CopyTo(_buffer);
+            _writePos = 0;
+            _wrapped = true;
+            return;
+        }
+
+        // First chunk: write up to the end of the underlying array.
+        var firstChunkSize = Math.Min(span.Length, _capacity - _writePos);
+        span.Slice(0, firstChunkSize).CopyTo(_buffer.AsSpan(_writePos));
+
+        if (firstChunkSize == span.Length)
+        {
+            _writePos += firstChunkSize;
+            if (_writePos == _capacity)
+            {
+                _writePos = 0;
+                _wrapped = true;
+            }
+            return;
+        }
+
+        // Wrap: remaining bytes go to the start of the array.
+        span.Slice(firstChunkSize).CopyTo(_buffer);
+        _writePos = span.Length - firstChunkSize;
+        _wrapped = true;
+    }
+
+    public async Task<byte[]> SnapshotAsync()
+    {
+        await _lock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            return _extracted ? [] : BuildSnapshot();
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+
+    public async Task<byte[]> ExtractAsync()
+    {
+        await _lock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            if (_extracted) return [];
+
+            var snapshot = BuildSnapshot();
+            _extracted = true;
+
+            return snapshot;
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed) return;
+
+        await _lock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            if (_disposed) return;
+
+            _extracted = true;
+            _disposed = true;
+        }
+        finally
+        {
+            _lock.Release();
+        }
+
+        _lock.Dispose();
+    }
+
+    /// <summary>Builds the chronologically-ordered snapshot. Caller must hold the lock.</summary>
+    private byte[] BuildSnapshot()
+    {
+        if (!_wrapped)
+        {
+            if (_writePos == 0) return [];
+
+            var linear = new byte[_writePos];
+            _buffer.AsSpan(0, _writePos).CopyTo(linear);
+            return linear;
+        }
+
+        // Wrapped: oldest bytes start at _writePos and run to the end of the array,
+        // followed by [0, _writePos).
+        var snapshot = new byte[_capacity];
+        var tailSize = _capacity - _writePos;
+
+        _buffer.AsSpan(_writePos, tailSize).CopyTo(snapshot);
+        _buffer.AsSpan(0, _writePos).CopyTo(snapshot.AsSpan(tailSize));
+
+        return snapshot;
+    }
+}

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Services/RealtimeAiService.Context.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Services/RealtimeAiService.Context.cs
@@ -26,9 +26,10 @@ public partial class RealtimeAiService
 
     private void BuildRecordingIfRequired()
     {
-        // PR 3.2 will choose between Unbounded and RollingWindow based on env var.
-        // For now (and as the default), preserve the previous unbounded MemoryStream behaviour.
-        if (_ctx.Options.EnableRecording && _ctx.AudioBuffer == null) _ctx.AudioBuffer = new UnboundedMemoryBuffer();
+        // RealtimeAiRecordingSettings.Create() picks UnboundedMemoryBuffer (default) or
+        // RollingWindowBuffer based on the BufferMode env var. Default preserves the
+        // pre-Phase-3 unbounded behaviour exactly.
+        if (_ctx.Options.EnableRecording && _ctx.AudioBuffer == null) _ctx.AudioBuffer = RealtimeAiRecordingSettings.Create();
     }
 
     private void BuildSessionActions()

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/RealtimeAiRecordingSettingsTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/RealtimeAiRecordingSettingsTests.cs
@@ -1,0 +1,119 @@
+using Shouldly;
+using SmartTalk.Core.Services.RealtimeAiV2.Recording;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Services.RealtimeAiV2;
+
+/// <summary>
+/// Pins the env var literals and the default-preserving fallback semantics
+/// of <see cref="RealtimeAiRecordingSettings"/>.
+///
+/// <para>Default mode is Unbounded — i.e. zero behaviour change vs. pre-Phase-3
+/// production. Operators must explicitly set BufferMode=rolling to enable
+/// the new bounded buffer.</para>
+/// </summary>
+public class RealtimeAiRecordingSettingsTests
+{
+    // ── Env var literal pinning (Rule 8) ────────────────────────
+
+    [Fact]
+    public void BufferModeEnvVar_ConstantNamePinned()
+    {
+        RealtimeAiRecordingSettings.BufferModeEnvVar
+            .ShouldBe("SQUID_SMARTTALK_RECORDING_BUFFER_MODE");
+    }
+
+    [Fact]
+    public void BufferSecondsEnvVar_ConstantNamePinned()
+    {
+        RealtimeAiRecordingSettings.BufferSecondsEnvVar
+            .ShouldBe("SQUID_SMARTTALK_RECORDING_BUFFER_SECONDS");
+    }
+
+    // ── ParseMode ───────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("unbounded")]
+    [InlineData("Unbounded")]
+    [InlineData("UNBOUNDED")]
+    [InlineData("anything-else")]
+    [InlineData("garbage")]
+    public void ParseMode_NotRolling_ReturnsUnbounded(string raw)
+    {
+        RealtimeAiRecordingSettings.ParseMode(raw)
+            .ShouldBe(RealtimeAiRecordingSettings.BufferMode.Unbounded);
+    }
+
+    [Theory]
+    [InlineData("rolling")]
+    [InlineData("Rolling")]
+    [InlineData("ROLLING")]
+    [InlineData("  rolling  ")]
+    public void ParseMode_RollingValueAnyCase_ReturnsRolling(string raw)
+    {
+        RealtimeAiRecordingSettings.ParseMode(raw)
+            .ShouldBe(RealtimeAiRecordingSettings.BufferMode.Rolling);
+    }
+
+    // ── ParseSeconds ────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("abc")]
+    [InlineData("-1")]
+    [InlineData("0")]
+    [InlineData("29")]                      // below min
+    [InlineData("3601")]                    // above max
+    [InlineData("999999")]
+    public void ParseSeconds_InvalidOrOutOfRange_ReturnsDefault300(string raw)
+    {
+        RealtimeAiRecordingSettings.ParseSeconds(raw).ShouldBe(300);
+    }
+
+    [Theory]
+    [InlineData("30", 30)]                   // min boundary
+    [InlineData("60", 60)]
+    [InlineData("300", 300)]                 // default value via env
+    [InlineData("600", 600)]
+    [InlineData("3600", 3600)]               // max boundary
+    public void ParseSeconds_ValidValueInRange_ReturnsThatValue(string raw, int expected)
+    {
+        RealtimeAiRecordingSettings.ParseSeconds(raw).ShouldBe(expected);
+    }
+
+    // ── Create() integration ────────────────────────────────────
+
+    [Fact]
+    public async Task Create_DefaultEnv_ReturnsUnboundedBuffer()
+    {
+        // Defensive: clear the env var in case of leftover from another test run.
+        Environment.SetEnvironmentVariable(RealtimeAiRecordingSettings.BufferModeEnvVar, null);
+        Environment.SetEnvironmentVariable(RealtimeAiRecordingSettings.BufferSecondsEnvVar, null);
+
+        await using var buffer = RealtimeAiRecordingSettings.Create();
+
+        buffer.ShouldBeOfType<UnboundedMemoryBuffer>();
+    }
+
+    [Fact]
+    public async Task Create_RollingMode_ReturnsRollingWindowBuffer()
+    {
+        Environment.SetEnvironmentVariable(RealtimeAiRecordingSettings.BufferModeEnvVar, "rolling");
+        Environment.SetEnvironmentVariable(RealtimeAiRecordingSettings.BufferSecondsEnvVar, "60");
+        try
+        {
+            await using var buffer = RealtimeAiRecordingSettings.Create();
+
+            buffer.ShouldBeOfType<RollingWindowBuffer>();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(RealtimeAiRecordingSettings.BufferModeEnvVar, null);
+            Environment.SetEnvironmentVariable(RealtimeAiRecordingSettings.BufferSecondsEnvVar, null);
+        }
+    }
+}

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/RollingWindowBufferTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/RollingWindowBufferTests.cs
@@ -147,6 +147,90 @@ public class RollingWindowBufferTests
         await buffer.DisposeAsync();
     }
 
+    // ── Race safety: late frame arrives after Dispose ───────────
+    //
+    // Same scenario as the unbounded buffer: a frame already past the null check
+    // can call WriteAsync on the captured reference after cleanup ran. The
+    // original V2 code never disposed its session-scoped SemaphoreSlim, so the
+    // late call gracefully no-ops. These tests pin the same contract.
+
+    [Fact]
+    public async Task WriteAsync_AfterDispose_NoOpsInsteadOfThrowing()
+    {
+        var buffer = new RollingWindowBuffer(10);
+        await buffer.WriteAsync(new byte[] { 1, 2, 3 });
+        await buffer.DisposeAsync();
+
+        var ex = await Record.ExceptionAsync(() => buffer.WriteAsync(new byte[] { 99 }));
+
+        ex.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task SnapshotAsync_AfterDispose_ReturnsEmptyInsteadOfThrowing()
+    {
+        var buffer = new RollingWindowBuffer(10);
+        await buffer.WriteAsync(new byte[] { 1, 2, 3 });
+        await buffer.DisposeAsync();
+
+        byte[] snapshot = null!;
+        var ex = await Record.ExceptionAsync(async () => snapshot = await buffer.SnapshotAsync());
+
+        ex.ShouldBeNull();
+        snapshot.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task ExtractAsync_AfterDispose_ReturnsEmptyInsteadOfThrowing()
+    {
+        var buffer = new RollingWindowBuffer(10);
+        await buffer.WriteAsync(new byte[] { 1, 2, 3 });
+        await buffer.DisposeAsync();
+
+        byte[] extracted = null!;
+        var ex = await Record.ExceptionAsync(async () => extracted = await buffer.ExtractAsync());
+
+        ex.ShouldBeNull();
+        extracted.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task ConcurrentDisposeAndWrite_NeverThrows()
+    {
+        // Stress test: 16 concurrent writers vs disposer. Whatever the interleaving,
+        // no method must throw — the cap simply enforces "at most capacity" bytes.
+        const int writers = 16;
+        const int capacity = 4096;
+        var buffer = new RollingWindowBuffer(capacity);
+
+        var startGate = new ManualResetEventSlim(false);
+
+        var writeTasks = Enumerable.Range(0, writers)
+            .Select(_ => Task.Run(async () =>
+            {
+                startGate.Wait();
+                for (var i = 0; i < 10; i++)
+                {
+                    await buffer.WriteAsync(new byte[] { (byte)i });
+                    await Task.Yield();
+                }
+            }))
+            .ToArray();
+
+        var disposeTask = Task.Run(async () =>
+        {
+            startGate.Wait();
+            await Task.Yield();
+            await buffer.DisposeAsync();
+        });
+
+        startGate.Set();
+
+        var ex = await Record.ExceptionAsync(() => Task.WhenAll(writeTasks.Concat(new[] { disposeTask })));
+
+        ex.ShouldBeNull();
+    }
+
     [Fact]
     public async Task ConcurrentWriteAndSnapshot_PreservesAtMostCapacityBytes()
     {

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/RollingWindowBufferTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/RollingWindowBufferTests.cs
@@ -1,0 +1,179 @@
+using Shouldly;
+using SmartTalk.Core.Services.RealtimeAiV2.Recording;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Services.RealtimeAiV2;
+
+/// <summary>
+/// Pins the contract of <see cref="RollingWindowBuffer"/>: a fixed-capacity
+/// PCM buffer that drops the oldest bytes when the cap is reached.
+///
+/// <para>Sizing rationale (default 300 seconds × 48,000 byte/s = 14.4 MB)
+/// is deliberately well above any realistic restaurant-call duration so a
+/// session that completes inside the window behaves identically to the
+/// unbounded buffer. The cap only kicks in for pathologically long calls
+/// (30+ min, multi-restaurant) — the exact scenarios that today produce
+/// 86 MB+ memory pressure per call.</para>
+/// </summary>
+public class RollingWindowBufferTests
+{
+    [Fact]
+    public void Ctor_NonPositiveCapacity_Throws()
+    {
+        Should.Throw<ArgumentOutOfRangeException>(() => new RollingWindowBuffer(0));
+        Should.Throw<ArgumentOutOfRangeException>(() => new RollingWindowBuffer(-1));
+    }
+
+    [Fact]
+    public async Task SnapshotAsync_EmptyBuffer_ReturnsEmpty()
+    {
+        await using var buffer = new RollingWindowBuffer(10);
+
+        (await buffer.SnapshotAsync()).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task WriteAsync_LessThanCapacity_AppendsLinearly()
+    {
+        await using var buffer = new RollingWindowBuffer(10);
+
+        await buffer.WriteAsync(new byte[] { 1, 2, 3 });
+        await buffer.WriteAsync(new byte[] { 4, 5 });
+
+        var snapshot = await buffer.SnapshotAsync();
+
+        snapshot.ShouldBe(new byte[] { 1, 2, 3, 4, 5 });
+    }
+
+    [Fact]
+    public async Task WriteAsync_ExactlyCapacity_FillsBuffer()
+    {
+        await using var buffer = new RollingWindowBuffer(5);
+
+        await buffer.WriteAsync(new byte[] { 1, 2, 3, 4, 5 });
+
+        var snapshot = await buffer.SnapshotAsync();
+
+        snapshot.ShouldBe(new byte[] { 1, 2, 3, 4, 5 });
+    }
+
+    [Fact]
+    public async Task WriteAsync_OverflowMultipleSmallWrites_DropsOldestPreservesNewest()
+    {
+        await using var buffer = new RollingWindowBuffer(5);
+
+        await buffer.WriteAsync(new byte[] { 1, 2, 3, 4 });   // buffer: [1,2,3,4,_]
+        await buffer.WriteAsync(new byte[] { 5, 6, 7 });      // overflow: 1,2 dropped
+
+        var snapshot = await buffer.SnapshotAsync();
+
+        snapshot.ShouldBe(new byte[] { 3, 4, 5, 6, 7 });
+    }
+
+    [Fact]
+    public async Task WriteAsync_SingleWriteLargerThanCapacity_KeepsTrailingCapacityBytes()
+    {
+        await using var buffer = new RollingWindowBuffer(5);
+
+        await buffer.WriteAsync(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 });
+
+        var snapshot = await buffer.SnapshotAsync();
+
+        snapshot.ShouldBe(new byte[] { 4, 5, 6, 7, 8 });
+    }
+
+    [Fact]
+    public async Task WriteAsync_AfterWrap_PreservesChronologicalOrder()
+    {
+        await using var buffer = new RollingWindowBuffer(4);
+
+        await buffer.WriteAsync(new byte[] { 1, 2, 3, 4 });   // exactly fills
+        await buffer.WriteAsync(new byte[] { 5 });             // wraps: drops 1
+        await buffer.WriteAsync(new byte[] { 6, 7 });          // drops 2,3
+
+        var snapshot = await buffer.SnapshotAsync();
+
+        snapshot.ShouldBe(new byte[] { 4, 5, 6, 7 });
+    }
+
+    [Fact]
+    public async Task SnapshotAsync_NonDestructive_AllowsContinuedWrites()
+    {
+        await using var buffer = new RollingWindowBuffer(10);
+        await buffer.WriteAsync(new byte[] { 1, 2, 3 });
+
+        var firstSnapshot = await buffer.SnapshotAsync();
+
+        await buffer.WriteAsync(new byte[] { 4, 5 });
+
+        var secondSnapshot = await buffer.SnapshotAsync();
+
+        firstSnapshot.ShouldBe(new byte[] { 1, 2, 3 });
+        secondSnapshot.ShouldBe(new byte[] { 1, 2, 3, 4, 5 });
+    }
+
+    [Fact]
+    public async Task ExtractAsync_DetachesBuffer_SubsequentSnapshotReturnsEmpty()
+    {
+        await using var buffer = new RollingWindowBuffer(10);
+        await buffer.WriteAsync(new byte[] { 1, 2, 3 });
+
+        var extracted = await buffer.ExtractAsync();
+        var afterExtract = await buffer.SnapshotAsync();
+
+        extracted.ShouldBe(new byte[] { 1, 2, 3 });
+        afterExtract.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task WriteAsync_AfterExtract_IsNoOp()
+    {
+        await using var buffer = new RollingWindowBuffer(10);
+        await buffer.WriteAsync(new byte[] { 1 });
+        await buffer.ExtractAsync();
+
+        await buffer.WriteAsync(new byte[] { 99 });
+
+        (await buffer.SnapshotAsync()).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task DisposeAsync_AllowsRepeatedCalls()
+    {
+        var buffer = new RollingWindowBuffer(10);
+        await buffer.WriteAsync(new byte[] { 1 });
+
+        await buffer.DisposeAsync();
+        await buffer.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task ConcurrentWriteAndSnapshot_PreservesAtMostCapacityBytes()
+    {
+        const int capacity = 4096;
+        await using var buffer = new RollingWindowBuffer(capacity);
+
+        const int writers = 8;
+        const int bytesPerWriter = 1024;
+
+        var writeTasks = Enumerable.Range(0, writers)
+            .Select(w => Task.Run(async () =>
+            {
+                var chunk = new byte[bytesPerWriter];
+                Array.Fill(chunk, (byte)w);
+                await buffer.WriteAsync(chunk);
+            }))
+            .ToArray();
+
+        var snapshotTasks = Enumerable.Range(0, 4)
+            .Select(_ => Task.Run(async () => await buffer.SnapshotAsync()))
+            .ToArray();
+
+        await Task.WhenAll(writeTasks.Concat(snapshotTasks));
+
+        var final = await buffer.SnapshotAsync();
+        final.Length.ShouldBeLessThanOrEqualTo(capacity);
+        // Total written = 8 * 1024 = 8192 bytes; capacity = 4096 → buffer should be exactly full
+        final.Length.ShouldBe(capacity);
+    }
+}


### PR DESCRIPTION
> **Stacked on top of #927.** Once #927 merges, this PR's base auto-retargets to `feat/v2-stability-perf-overhaul`.

## Summary

- A 30-min restaurant call holds ~86MB of PCM in the unbounded buffer; concurrent long calls scale that to GB-class memory pressure. `RollingWindowBuffer` caps the window to N seconds (default 300s = 14.4MB) by dropping the oldest bytes once the cap is reached, preserving chronological order on snapshot / extract
- Implementation: circular byte array — O(1) writes, zero per-write allocation, single span copy per call. Same `IRecordingBuffer` surface as `UnboundedMemoryBuffer`, so call sites in `RealtimeAiService` don't change
- Selection gated by env vars; **default is unbounded → zero behaviour change**. Operators must explicitly set `BUFFER_MODE=rolling` to opt in

## Test plan

- [x] Unit: 12 cases on `RollingWindowBuffer` covering ctor validation, empty, linear, exact-capacity, multi-write overflow, single-write-larger-than-capacity, post-wrap chronology, non-destructive snapshot, post-extract no-ops, repeated dispose, concurrent writers respecting the cap
- [x] Unit: 29 cases on `RealtimeAiRecordingSettings` — both env var literals pinned (Rule 8), `ParseMode` case-insensitive + whitespace-tolerant, `ParseSeconds` range checking + invalid-input fallback, `Create()` integration with env vars set / unset
- [x] Regression: full unit suite 290/290 (was 249 baseline on PR #927)
- [ ] Staging: enable `BUFFER_MODE=rolling` on one assistant, monitor `RepeatOrder` correctness (snapshot must still produce playable WAV) and `OnRecordingCompleteAsync` final WAV duration

## Feature flag

- `SQUID_SMARTTALK_RECORDING_BUFFER_MODE` — values `unbounded` (default) or `rolling`
- `SQUID_SMARTTALK_RECORDING_BUFFER_SECONDS` — window size when rolling, range 30–3600, default 300
- Rollback: unset both env vars (or set MODE to anything other than `rolling`) — instant revert to current behavior

## Out of scope

- Streaming-to-disk buffer mode (the third option that would let recording exceed memory entirely) is deferred until we have data on whether rolling-window is sufficient for production restaurant volumes