### PR TITLE
Set gpt-realtime-2 as the default Realtime API model URL

### DIFF
--- a/src/SmartTalk.Messages/Constants/AiSpeechAssistantStore.cs
+++ b/src/SmartTalk.Messages/Constants/AiSpeechAssistantStore.cs
@@ -5,6 +5,6 @@ namespace SmartTalk.Messages.Constants;
 
 public static class AiSpeechAssistantStore
 {
-    public static string DefaultUrl = "wss://api.openai.com/v1/realtime?model=gpt-realtime-1.5";
+    public static string DefaultUrl = "wss://api.openai.com/v1/realtime?model=gpt-realtime-2";
     public static string AiKidDefaultUrl = "wss://api.openai.com/v1/realtime?model=gpt-4o-mini-realtime-preview-2024-12-17";
 }

--- a/src/SmartTalk.UnitTests/Messages/Constants/AiSpeechAssistantStoreTests.cs
+++ b/src/SmartTalk.UnitTests/Messages/Constants/AiSpeechAssistantStoreTests.cs
@@ -1,0 +1,52 @@
+using Shouldly;
+using SmartTalk.Messages.Constants;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Messages.Constants;
+
+/// <summary>
+/// Pins the literal Realtime API URL strings advertised by <see cref="AiSpeechAssistantStore"/>.
+///
+/// <para>
+/// These URLs flow into the OpenAI Realtime WebSocket connection any time an
+/// <c>AiSpeechAssistant</c> row has no <c>ModelUrl</c> override (the typical case).
+/// A silent change here re-points every assistant in production at a different
+/// OpenAI model; pinning the literal makes such a change a CI-visible decision.
+/// </para>
+/// </summary>
+public class AiSpeechAssistantStoreTests
+{
+    private const string OpenAiRealtimeWssPrefix = "wss://api.openai.com/v1/realtime?model=";
+
+    [Fact]
+    public void DefaultUrl_PointsAtGptRealtime2()
+    {
+        // gpt-realtime-2 is the GA realtime model (released 2026-05-07), superseding
+        // gpt-realtime-1.5. Same pricing, GPT-5-class reasoning, 128K context.
+        AiSpeechAssistantStore.DefaultUrl
+            .ShouldBe("wss://api.openai.com/v1/realtime?model=gpt-realtime-2");
+    }
+
+    [Fact]
+    public void AiKidDefaultUrl_PointsAtGpt4oMiniRealtimePreview()
+    {
+        AiSpeechAssistantStore.AiKidDefaultUrl
+            .ShouldBe("wss://api.openai.com/v1/realtime?model=gpt-4o-mini-realtime-preview-2024-12-17");
+    }
+
+    [Theory]
+    [InlineData(nameof(AiSpeechAssistantStore.DefaultUrl))]
+    [InlineData(nameof(AiSpeechAssistantStore.AiKidDefaultUrl))]
+    public void AllAdvertisedUrls_StartWithOpenAiRealtimeWssPrefix(string fieldName)
+    {
+        var value = typeof(AiSpeechAssistantStore)
+            .GetField(fieldName)!
+            .GetValue(null)!
+            .ToString()!;
+
+        value.ShouldStartWith(OpenAiRealtimeWssPrefix,
+            customMessage: $"{fieldName} must point at OpenAI Realtime WebSocket endpoint");
+        value.Length.ShouldBeGreaterThan(OpenAiRealtimeWssPrefix.Length,
+            customMessage: $"{fieldName} must include a model id after the prefix");
+    }
+}


### PR DESCRIPTION
## Summary

- Move the global default from `gpt-realtime-1.5` to `gpt-realtime-2` (GA on 2026-05-07). Same pricing, GPT-5-class reasoning, 128K context window (vs 32K on 1.5), configurable `reasoning_effort` parameter
- API contract is unchanged — same WebSocket endpoint, same `session.update` schema. The change is purely a query-string model id swap
- Pin the new default literal so a future rename is a CI-visible decision

## Why now

- gpt-realtime-1.5 has documented regressions in production: Spanish-language naturalness vs the preview snapshot, and a [progressive latency increase in long sessions](https://community.openai.com/t/progressive-latency-increase-in-long-gpt-realtime-1-5-gpt-realtime-voice-sessions-including-non-tool-turns-not-fully-reset-by-conversation-item-deletion/1376004) that does not reset on conversation truncation. Restaurant calls of 5–15 minutes routinely fall into the latency-degraded window
- gpt-realtime-2 benchmarks +15.2 pts on Big Bench Audio, +13.8 pts on Audio MultiChallenge, +16.8 pts on ComplexFuncBench vs 1.5 ([OpenAI announcement](https://openai.com/index/advancing-voice-intelligence-with-new-models-in-the-api/)); the 128K context directly addresses the long-session latency root cause

## Test plan

- [x] Unit: pin `DefaultUrl` literal to the new value; pin `AiKidDefaultUrl` (unchanged); 1 [Theory] verifying both URLs match the canonical OpenAI Realtime WSS prefix
- [x] Regression: full unit suite 302/302 pass (was 298)
- [ ] Staging: deploy and observe first-audio latency / function-call success / mid-call disconnect rate for 24h before propagating to prod
- [ ] Prod canary: optional — apply to a subset of assistants via `ModelUrl` override before global default takes effect

## Rollback

- **Code rollback**: `git revert` this PR. Single-line constant change is trivial to revert.
- **Per-assistant rollback** (faster than code revert): `UPDATE AiSpeechAssistant SET ModelUrl = 'wss://api.openai.com/v1/realtime?model=gpt-realtime-1.5' WHERE Id = <affected_id>;`
- **Global emergency rollback** (faster still): change the literal back to `gpt-realtime-1.5` and push a hotfix; no DB / migration involved