### PR TITLE
Migrate OpenAI Realtime API from Beta to GA contract

### DIFF
--- a/src/SmartTalk.Core/Services/AiSpeechAssistant/AiSpeechAssistantService.cs
+++ b/src/SmartTalk.Core/Services/AiSpeechAssistant/AiSpeechAssistantService.cs
@@ -549,14 +549,16 @@ public partial class AiSpeechAssistantService : IAiSpeechAssistantService
 
     private void ConfigWebSocketRequestHeader(ClientWebSocket clientWebSocket, Domain.AISpeechAssistant.AiSpeechAssistant assistant)
     {
+        // OpenAI removed the `OpenAI-Beta: realtime=v1` header from the Realtime API on
+        // 2026-05-07 when the API moved Beta → GA. Sending it now returns `invalid_beta`
+        // and kills the WebSocket before the first session.update. ZhiPuAi mirrors the
+        // OpenAI Realtime contract, so it follows the same migration.
         switch (assistant.ModelProvider)
         {
             case RealtimeAiProvider.OpenAi:
-                clientWebSocket.Options.SetRequestHeader("OpenAI-Beta", "realtime=v1");
                 clientWebSocket.Options.SetRequestHeader("Authorization", $"Bearer {_openAiSettings.ApiKey}");
                 break;
             case RealtimeAiProvider.ZhiPuAi:
-                clientWebSocket.Options.SetRequestHeader("OpenAI-Beta", "realtime=v1");
                 clientWebSocket.Options.SetRequestHeader("Authorization", $"Bearer {_zhiPuAiSettings.ApiKey}");
                 break;
             case RealtimeAiProvider.Azure:
@@ -690,16 +692,22 @@ public partial class AiSpeechAssistantService : IAiSpeechAssistantService
 
                     Log.Information($"Received event: {jsonDocument?.RootElement.GetProperty("type").GetString()}");
                     
-                    if (jsonDocument?.RootElement.GetProperty("type").GetString() == "error" && jsonDocument.RootElement.TryGetProperty("error", out var error))
+                    // Read event type once. GA renamed several audio events on 2026-05-07; we accept
+                    // BOTH the old beta name and the new GA name so we survive any transition-window
+                    // mismatch and any leftover preview snapshots.
+                    var openAiEventType = jsonDocument?.RootElement.GetProperty("type").GetString();
+
+                    if (openAiEventType == "error" && jsonDocument.RootElement.TryGetProperty("error", out var error))
                     {
                         Log.Information("Receive openai websocket error" + error.GetProperty("message").GetString());
-                        
+
                     }
-                    
-                    if (jsonDocument?.RootElement.GetProperty("type").GetString() == "session.updated")
+
+                    if (openAiEventType == "session.updated")
                         Log.Information("Session updated successfully");
 
-                    if (jsonDocument?.RootElement.GetProperty("type").GetString() == "response.audio.delta" && jsonDocument.RootElement.TryGetProperty("delta", out var delta))
+                    if ((openAiEventType == "response.audio.delta" || openAiEventType == "response.output_audio.delta")
+                        && jsonDocument.RootElement.TryGetProperty("delta", out var delta))
                     {
                         var audioDelta = new
                         {
@@ -727,7 +735,7 @@ public partial class AiSpeechAssistantService : IAiSpeechAssistantService
                         await SendMark(twilioWebSocket, _aiSpeechAssistantStreamContext, cancellationToken);
                     }
                     
-                    if (jsonDocument?.RootElement.GetProperty("type").GetString() == "input_audio_buffer.speech_started")
+                    if (openAiEventType == "input_audio_buffer.speech_started")
                     {
                         Log.Information("Speech started detected.");
                         var clearEvent = new
@@ -749,19 +757,19 @@ public partial class AiSpeechAssistantService : IAiSpeechAssistantService
                         StopInactivityTimer();
                     }
 
-                    if (jsonDocument?.RootElement.GetProperty("type").GetString() == "conversation.item.input_audio_transcription.completed")
+                    if (openAiEventType == "conversation.item.input_audio_transcription.completed")
                     {
                         var response = jsonDocument.RootElement.GetProperty("transcript").ToString();
                         _aiSpeechAssistantStreamContext.ConversationTranscription.Add(new ValueTuple<AiSpeechAssistantSpeaker, string>(AiSpeechAssistantSpeaker.User, response));
                     }
-                    
-                    if (jsonDocument?.RootElement.GetProperty("type").GetString() == "response.audio_transcript.done")
+
+                    if (openAiEventType == "response.audio_transcript.done" || openAiEventType == "response.output_audio_transcript.done")
                     {
                         var response = jsonDocument.RootElement.GetProperty("transcript").ToString();
                         _aiSpeechAssistantStreamContext.ConversationTranscription.Add(new ValueTuple<AiSpeechAssistantSpeaker, string>(AiSpeechAssistantSpeaker.Ai, response));
                     }
-                    
-                    if (jsonDocument?.RootElement.GetProperty("type").GetString() == "response.done")
+
+                    if (openAiEventType == "response.done")
                     {
                         var response = jsonDocument.RootElement.GetProperty("response");
 
@@ -1201,32 +1209,55 @@ public partial class AiSpeechAssistantService : IAiSpeechAssistantService
     {
         var assistant = _mapper.Map<Domain.AISpeechAssistant.AiSpeechAssistant>(_aiSpeechAssistantStreamContext.Assistant);
         var configs = await InitialSessionConfigAsync(assistant, cancellationToken).ConfigureAwait(false);
-        
+
+        // GA session.update payload (post 2026-05-07): see OpenAiRealtimeAiAdapter for full notes.
+        // - `session.type = "realtime"` is required at the inner-object level
+        // - audio nested under `audio.{input,output}` with format as an object (no `rate` for G.711)
+        // - `modalities` → `output_modalities`; `temperature` removed
+        // Twilio Media Streams is fixed at g711_ulaw 8 kHz, so we emit `{type: "audio/pcmu"}`.
         return assistant.ModelProvider switch
         {
             RealtimeAiProvider.OpenAi => new
             {
-                turn_detection = InitialSessionParameters(configs, AiSpeechAssistantSessionConfigType.TurnDirection),
-                input_audio_format = "g711_ulaw",
-                output_audio_format = "g711_ulaw",
-                voice = string.IsNullOrEmpty(assistant.ModelVoice) ? "alloy" : assistant.ModelVoice,
+                type = "realtime",
                 instructions = _aiSpeechAssistantStreamContext.LastPrompt,
-                modalities = new[] { "text", "audio" },
-                temperature = 0.8,
-                input_audio_transcription = new { model = "whisper-1" },
-                input_audio_noise_reduction = InitialSessionParameters(configs, AiSpeechAssistantSessionConfigType.InputAudioNoiseReduction),
+                output_modalities = new[] { "audio" },
+                audio = new
+                {
+                    input = new
+                    {
+                        format = new { type = "audio/pcmu" },
+                        transcription = new { model = "whisper-1" },
+                        turn_detection = InitialSessionParameters(configs, AiSpeechAssistantSessionConfigType.TurnDirection),
+                        noise_reduction = InitialSessionParameters(configs, AiSpeechAssistantSessionConfigType.InputAudioNoiseReduction)
+                    },
+                    output = new
+                    {
+                        format = new { type = "audio/pcmu" },
+                        voice = string.IsNullOrEmpty(assistant.ModelVoice) ? "alloy" : assistant.ModelVoice
+                    }
+                },
                 tools = configs.Where(x => x.Type == AiSpeechAssistantSessionConfigType.Tool).Select(x => x.Config)
             },
             RealtimeAiProvider.Azure => new
             {
-                turn_detection = InitialSessionParameters(configs, AiSpeechAssistantSessionConfigType.TurnDirection),
-                input_audio_format = "g711_ulaw",
-                output_audio_format = "g711_ulaw",
-                voice = string.IsNullOrEmpty(assistant.ModelVoice) ? "alloy" : assistant.ModelVoice,
+                type = "realtime",
                 instructions = _aiSpeechAssistantStreamContext.LastPrompt,
-                modalities = new[] { "text", "audio" },
-                temperature = 0.8,
-                input_audio_transcription = new { model = "whisper-1" },
+                output_modalities = new[] { "audio" },
+                audio = new
+                {
+                    input = new
+                    {
+                        format = new { type = "audio/pcmu" },
+                        transcription = new { model = "whisper-1" },
+                        turn_detection = InitialSessionParameters(configs, AiSpeechAssistantSessionConfigType.TurnDirection)
+                    },
+                    output = new
+                    {
+                        format = new { type = "audio/pcmu" },
+                        voice = string.IsNullOrEmpty(assistant.ModelVoice) ? "alloy" : assistant.ModelVoice
+                    }
+                },
                 tools = configs.Where(x => x.Type == AiSpeechAssistantSessionConfigType.Tool).Select(x => x.Config)
             },
             _ => throw new NotSupportedException(nameof(assistant.ModelProvider))

--- a/src/SmartTalk.Core/Services/RealtimeAi/Wss/OpenAi/OpenAiRealtimeAiAdapter.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAi/Wss/OpenAi/OpenAiRealtimeAiAdapter.cs
@@ -29,10 +29,12 @@ public class OpenAiRealtimeAiAdapter : IRealtimeAiProviderAdapter
     public Dictionary<string, string> GetHeaders(RealtimeAiServerRegion region)
     {
         var apiKey = region == RealtimeAiServerRegion.US ? _openAiSettings.ApiKey : _openAiSettings.HkApiKey;
-        
+
+        // OpenAI removed the `OpenAI-Beta: realtime=v1` header from the Realtime API on 2026-05-07
+        // when the API moved Beta → GA. Sending it now returns `invalid_beta` and the WS is closed
+        // before the first session.update. Authorization is the only required custom header.
         return new Dictionary<string, string>
         {
-            { "OpenAI-Beta", "realtime=v1" },
             { "Authorization", $"Bearer {apiKey}" }
         };
     }
@@ -46,20 +48,36 @@ public class OpenAiRealtimeAiAdapter : IRealtimeAiProviderAdapter
         var knowledge = await _aiSpeechAssistantDataProvider.GetAiSpeechAssistantKnowledgeAsync(int.Parse(profile.ProfileId), isActive: true, cancellationToken: cancellationToken).ConfigureAwait(false);
         var prompt = await ReplaceKnowledgeVariablesAsync(knowledge?.Prompt, cancellationToken).ConfigureAwait(false);
 
+        // GA session.update payload (post 2026-05-07):
+        // - new required `session.type` field ("realtime" | "transcription")
+        // - audio config nested under `session.audio.{input,output}` rather than flat fields
+        // - audio format becomes an object {type[, rate]} rather than a bare codec string
+        // - `modalities` → `output_modalities`; `temperature` field dropped
+        // Reference: https://platform.openai.com/docs/guides/realtime
+        // Canonical sample: https://github.com/twilio-samples/speech-assistant-openai-realtime-api-python
         var sessionPayload = new
         {
             type = "session.update",
             session = new
             {
-                turn_detection = InitialSessionParameters(configs, AiSpeechAssistantSessionConfigType.TurnDirection),
-                input_audio_format = options.InputFormat.GetDescription(),
-                output_audio_format = options.OutputFormat.GetDescription(),
-                voice = string.IsNullOrEmpty(modelConfig.Voice) ? "alloy" : modelConfig.Voice,
+                type = "realtime",
                 instructions = prompt ?? options.InitialPrompt,
-                modalities = new[] { "text", "audio" },
-                temperature = 0.8,
-                input_audio_transcription = new { model = "whisper-1" },
-                input_audio_noise_reduction = InitialSessionParameters(configs, AiSpeechAssistantSessionConfigType.InputAudioNoiseReduction),
+                output_modalities = new[] { "audio" },
+                audio = new
+                {
+                    input = new
+                    {
+                        format = ConvertCodecToGaFormat(options.InputFormat),
+                        transcription = new { model = "whisper-1" },
+                        turn_detection = InitialSessionParameters(configs, AiSpeechAssistantSessionConfigType.TurnDirection),
+                        noise_reduction = InitialSessionParameters(configs, AiSpeechAssistantSessionConfigType.InputAudioNoiseReduction)
+                    },
+                    output = new
+                    {
+                        format = ConvertCodecToGaFormat(options.OutputFormat),
+                        voice = string.IsNullOrEmpty(modelConfig.Voice) ? "alloy" : modelConfig.Voice
+                    }
+                },
                 tools = configs.Where(x => x.Type == AiSpeechAssistantSessionConfigType.Tool).Select(x => x.Config)
             }
         };
@@ -68,6 +86,20 @@ public class OpenAiRealtimeAiAdapter : IRealtimeAiProviderAdapter
 
         return sessionPayload;
     }
+
+    /// <summary>
+    /// Converts our internal codec enum to the GA session.update audio.format object.
+    /// G.711 (pcmu/pcma) is fixed at 8 kHz in the GA contract; sending `rate` is
+    /// rejected as an unknown field. PCM16 carries an explicit rate. Canonical reference:
+    /// https://github.com/twilio-samples/speech-assistant-openai-realtime-api-python
+    /// </summary>
+    private static object ConvertCodecToGaFormat(RealtimeAiAudioCodec codec) => codec switch
+    {
+        RealtimeAiAudioCodec.MULAW => new { type = "audio/pcmu" },
+        RealtimeAiAudioCodec.ALAW => new { type = "audio/pcma" },
+        RealtimeAiAudioCodec.PCM16 => new { type = "audio/pcm", rate = 24000 },
+        _ => new { type = "audio/pcmu" }
+    };
 
     private async Task<string> ReplaceKnowledgeVariablesAsync(string prompt, CancellationToken cancellationToken)
     {
@@ -175,30 +207,37 @@ public class OpenAiRealtimeAiAdapter : IRealtimeAiProviderAdapter
             {
                 case "session.updated":
                     return new ParsedRealtimeAiProviderEvent { Type = RealtimeAiWssEventType.SessionInitialized, Data = rawMessage, RawJson = rawMessage, ItemId = itemId };
-                
+
+                // GA renamed several audio events (post 2026-05-07). Accept BOTH the old beta name
+                // and the new GA name so we survive any transition-window mismatch between models.
+                // https://platform.openai.com/docs/guides/realtime
                 case "response.audio.delta":
+                case "response.output_audio.delta":
                     var audioPayload = root.TryGetProperty("delta", out var deltaProp) ? deltaProp.GetString() : null;
                     return new ParsedRealtimeAiProviderEvent { Type = RealtimeAiWssEventType.ResponseAudioDelta, Data = new RealtimeAiWssAudioData { Base64Payload = audioPayload, ItemId = itemId }, RawJson = rawMessage, ItemId = itemId };
-                
+
                 case "response.audio.done":
+                case "response.output_audio.done":
                      return new ParsedRealtimeAiProviderEvent { Type = RealtimeAiWssEventType.ResponseAudioDone, RawJson = rawMessage, ItemId = itemId };
 
                 case "input_audio_buffer.speech_started":
                     return new ParsedRealtimeAiProviderEvent { Type = RealtimeAiWssEventType.SpeechDetected, RawJson = rawMessage, ItemId = itemId };
-                
+
                 case "conversation.item.input_audio_transcription.delta":
                     var userTranscriptDelta = root.TryGetProperty("delta", out var delta) ? delta.GetString() : null;
                     return new ParsedRealtimeAiProviderEvent { Type = RealtimeAiWssEventType.InputAudioTranscriptionPartial, Data = new RealtimeAiWssTranscriptionData { Transcript = userTranscriptDelta, Speaker = AiSpeechAssistantSpeaker.User }, RawJson = rawMessage };
-                
+
                 case "conversation.item.input_audio_transcription.completed":
                     var userTranscript = root.TryGetProperty("transcript", out var transcript) ? transcript.GetString() : null;
                     return new ParsedRealtimeAiProviderEvent { Type = RealtimeAiWssEventType.InputAudioTranscriptionCompleted, Data = new RealtimeAiWssTranscriptionData { Transcript = userTranscript, Speaker = AiSpeechAssistantSpeaker.User }, RawJson = rawMessage };
-                
+
                 case "response.audio_transcript.delta":
+                case "response.output_audio_transcript.delta":
                     var aiTranscriptDelta = root.TryGetProperty("delta", out var aiDelta) ? aiDelta.GetString() : null;
                     return new ParsedRealtimeAiProviderEvent { Type = RealtimeAiWssEventType.OutputAudioTranscriptionPartial, Data = new RealtimeAiWssTranscriptionData { Transcript = aiTranscriptDelta, Speaker = AiSpeechAssistantSpeaker.Ai }, RawJson = rawMessage };
-                
+
                 case "response.audio_transcript.done":
+                case "response.output_audio_transcript.done":
                     var aiTranscription = root.TryGetProperty("transcript", out var aiTranscript) ? aiTranscript.GetString() : null;
                     return new ParsedRealtimeAiProviderEvent { Type = RealtimeAiWssEventType.OutputAudioTranscriptionCompleted, Data = new RealtimeAiWssTranscriptionData { Transcript = aiTranscription, Speaker = AiSpeechAssistantSpeaker.Ai }, RawJson = rawMessage };
 

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Providers/OpenAi/OpenAiRealtimeAiProviderAdapter.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Providers/OpenAi/OpenAiRealtimeAiProviderAdapter.cs
@@ -22,10 +22,12 @@ public class OpenAiRealtimeAiProviderAdapter : IRealtimeAiProviderAdapter
     public Dictionary<string, string> GetHeaders(RealtimeAiServerRegion region)
     {
         var apiKey = region == RealtimeAiServerRegion.US ? _openAiSettings.ApiKey : _openAiSettings.HkApiKey;
-        
+
+        // OpenAI removed the `OpenAI-Beta: realtime=v1` header from the Realtime API on 2026-05-07
+        // when the API moved Beta → GA. Sending it now returns `invalid_beta` and the WS is closed
+        // before the first session.update. Authorization is the only required custom header.
         return new Dictionary<string, string>
         {
-            { "OpenAI-Beta", "realtime=v1" },
             { "Authorization", $"Bearer {apiKey}" }
         };
     }
@@ -34,26 +36,54 @@ public class OpenAiRealtimeAiProviderAdapter : IRealtimeAiProviderAdapter
     {
         var modelConfig = options.ModelConfig;
 
-        var sessionPayload = new
+        // GA session.update payload (post 2026-05-07):
+        // - new required `session.type` field ("realtime" | "transcription")
+        // - audio config nested under `session.audio.{input,output}` rather than flat fields
+        // - audio format becomes an object {type, rate} rather than a bare string
+        // - `modalities` → `output_modalities`; `temperature` field dropped
+        // Reference: https://platform.openai.com/docs/guides/realtime
+        // Canonical sample: https://github.com/twilio-samples/speech-assistant-openai-realtime-api-python
+        return new
         {
             type = "session.update",
             session = new
             {
-                turn_detection = modelConfig.TurnDetection ?? new { type = "server_vad" },
-                input_audio_format = clientCodec.GetDescription(),
-                output_audio_format = clientCodec.GetDescription(),
-                voice = string.IsNullOrEmpty(modelConfig.Voice) ? "alloy" : modelConfig.Voice,
+                type = "realtime",
                 instructions = modelConfig.Prompt,
-                modalities = new[] { "text", "audio" },
-                temperature = 0.8,
-                input_audio_transcription = new { model = "whisper-1" },
-                input_audio_noise_reduction = modelConfig.InputAudioNoiseReduction,
+                output_modalities = new[] { "audio" },
+                audio = new
+                {
+                    input = new
+                    {
+                        format = ConvertCodecToGaFormat(clientCodec),
+                        transcription = new { model = "whisper-1" },
+                        turn_detection = modelConfig.TurnDetection ?? new { type = "server_vad" },
+                        noise_reduction = modelConfig.InputAudioNoiseReduction
+                    },
+                    output = new
+                    {
+                        format = ConvertCodecToGaFormat(clientCodec),
+                        voice = string.IsNullOrEmpty(modelConfig.Voice) ? "alloy" : modelConfig.Voice
+                    }
+                },
                 tools = modelConfig.Tools.Any() ? modelConfig.Tools : null
             }
         };
-
-        return sessionPayload;
     }
+
+    /// <summary>
+    /// Converts our internal codec enum to the GA session.update audio.format object.
+    /// G.711 (pcmu/pcma) is fixed at 8 kHz in the GA contract; sending `rate` is
+    /// rejected as an unknown field. PCM16 carries an explicit rate. Canonical reference:
+    /// https://github.com/twilio-samples/speech-assistant-openai-realtime-api-python
+    /// </summary>
+    private static object ConvertCodecToGaFormat(RealtimeAiAudioCodec codec) => codec switch
+    {
+        RealtimeAiAudioCodec.MULAW => new { type = "audio/pcmu" },
+        RealtimeAiAudioCodec.ALAW => new { type = "audio/pcma" },
+        RealtimeAiAudioCodec.PCM16 => new { type = "audio/pcm", rate = 24000 },
+        _ => new { type = "audio/pcmu" }
+    };
 
     public string BuildAudioAppendMessage(RealtimeAiWssAudioData audioData)
     {
@@ -169,13 +199,18 @@ public class OpenAiRealtimeAiProviderAdapter : IRealtimeAiProviderAdapter
                 case "session.updated":
                     return Result(RealtimeAiWssEventType.SessionInitialized, rawMessage);
 
+                // GA renamed several audio events; accept BOTH the old beta name and the new GA
+                // name so the deploy is robust to any leftover preview snapshots and to the GA
+                // models. https://learn.microsoft.com/en-us/azure/foundry/openai/how-to/realtime-audio-preview-api-migration-guide
                 case "response.audio.delta":
+                case "response.output_audio.delta":
                     var audioPayload = root.TryGetProperty("delta", out var deltaProp) ? deltaProp.GetString() : null;
                     return Result(RealtimeAiWssEventType.ResponseAudioDelta, new RealtimeAiWssAudioData { Base64Payload = audioPayload, ItemId = itemId });
 
                 case "response.audio.done":
+                case "response.output_audio.done":
                     return Result(RealtimeAiWssEventType.ResponseAudioDone);
-                
+
                 case "response.created":
                     return Result(RealtimeAiWssEventType.ResponseStarted);
 
@@ -189,9 +224,11 @@ public class OpenAiRealtimeAiProviderAdapter : IRealtimeAiProviderAdapter
                     return Result(RealtimeAiWssEventType.InputAudioTranscriptionCompleted, Transcription("transcript", AiSpeechAssistantSpeaker.User));
 
                 case "response.audio_transcript.delta":
+                case "response.output_audio_transcript.delta":
                     return Result(RealtimeAiWssEventType.OutputAudioTranscriptionPartial, Transcription("delta", AiSpeechAssistantSpeaker.Ai));
 
                 case "response.audio_transcript.done":
+                case "response.output_audio_transcript.done":
                     return Result(RealtimeAiWssEventType.OutputAudioTranscriptionCompleted, Transcription("transcript", AiSpeechAssistantSpeaker.Ai));
 
                 case "response.done":

--- a/src/SmartTalk.UnitTests/Services/RealtimeAi/OpenAiRealtimeAiAdapterGaPayloadTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAi/OpenAiRealtimeAiAdapterGaPayloadTests.cs
@@ -1,0 +1,250 @@
+using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NSubstitute;
+using Shouldly;
+using SmartTalk.Core.Domain.AISpeechAssistant;
+using SmartTalk.Core.Services.AiSpeechAssistant;
+using SmartTalk.Core.Services.RealtimeAi.Services;
+using SmartTalk.Core.Services.RealtimeAi.wss.OpenAi;
+using SmartTalk.Core.Settings.OpenAi;
+using SmartTalk.Messages.Enums.RealtimeAi;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Services.RealtimeAi;
+
+/// <summary>
+/// Pins the V1 OpenAI Realtime adapter to the GA contract (post 2026-05-07).
+/// The V1 path is not exercised in production today (V2 carries all traffic), but
+/// keeping V1 on the same contract prevents `invalid_beta` regressions if it is
+/// ever reactivated and keeps the two adapters in lockstep.
+/// </summary>
+public class OpenAiRealtimeAiAdapterGaPayloadTests
+{
+    private static OpenAiRealtimeAiAdapter NewAdapter(IAiSpeechAssistantDataProvider dataProvider = null)
+    {
+        var settings = new OpenAiSettings(Substitute.For<IConfiguration>());
+        var provider = dataProvider ?? Substitute.For<IAiSpeechAssistantDataProvider>();
+
+        // Default: no knowledge entry, no function calls, no caches.
+        provider.GetAiSpeechAssistantKnowledgeAsync(Arg.Any<int?>(), Arg.Any<int?>(), Arg.Any<bool?>(), Arg.Any<CancellationToken>())
+            .Returns((AiSpeechAssistantKnowledge)null);
+        provider.GetAiSpeechAssistantFunctionCallByAssistantIdsAsync(Arg.Any<List<int>>(), Arg.Any<RealtimeAiProvider>(), Arg.Any<bool?>(), Arg.Any<CancellationToken>())
+            .Returns(new List<AiSpeechAssistantFunctionCall>());
+
+        return new OpenAiRealtimeAiAdapter(settings, provider);
+    }
+
+    private static RealtimeSessionOptions OptionsWithCodec(RealtimeAiAudioCodec codec, string voice = "alloy", string prompt = "you are helpful") =>
+        new()
+        {
+            InputFormat = codec,
+            OutputFormat = codec,
+            InitialPrompt = prompt,
+            ConnectionProfile = new RealtimeAiConnectionProfile { ProfileId = "1" },
+            ModelConfig = new RealtimeAiModelConfig
+            {
+                Provider = RealtimeAiProvider.OpenAi,
+                Voice = voice
+            }
+        };
+
+    private static async Task<JObject> SerializeSessionAsync(OpenAiRealtimeAiAdapter adapter, RealtimeSessionOptions options) =>
+        JObject.Parse(JsonConvert.SerializeObject(await adapter.GetInitialSessionPayloadAsync(options, "sess-1", CancellationToken.None)));
+
+    // ── Headers ────────────────────────────────────────────────────
+
+    [Fact]
+    public void GetHeaders_DoesNotIncludeBetaHeader_AfterGaCutover()
+    {
+        var adapter = NewAdapter();
+
+        var headers = adapter.GetHeaders(RealtimeAiServerRegion.US);
+
+        headers.ShouldNotContainKey("OpenAI-Beta");
+        headers.ShouldContainKey("Authorization");
+    }
+
+    // ── Session payload top-level shape ────────────────────────────
+
+    [Fact]
+    public async Task GetInitialSessionPayload_TopLevel_HasSessionTypeRealtime()
+    {
+        var adapter = NewAdapter();
+
+        var json = await SerializeSessionAsync(adapter, OptionsWithCodec(RealtimeAiAudioCodec.MULAW));
+
+        json["type"]!.Value<string>().ShouldBe("session.update");
+        json["session"]!["type"]!.Value<string>().ShouldBe("realtime");
+    }
+
+    [Fact]
+    public async Task GetInitialSessionPayload_UsesOutputModalities_NotLegacyModalities()
+    {
+        var adapter = NewAdapter();
+
+        var json = await SerializeSessionAsync(adapter, OptionsWithCodec(RealtimeAiAudioCodec.MULAW));
+
+        json["session"]!["modalities"].ShouldBeNull();
+        json["session"]!["output_modalities"]!.Values<string>().ShouldBe(new[] { "audio" });
+    }
+
+    [Fact]
+    public async Task GetInitialSessionPayload_DoesNotEmitTemperature_AfterGaCutover()
+    {
+        var adapter = NewAdapter();
+
+        var json = await SerializeSessionAsync(adapter, OptionsWithCodec(RealtimeAiAudioCodec.MULAW));
+
+        json["session"]!["temperature"].ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task GetInitialSessionPayload_DoesNotEmitFlatAudioFields_AfterGaCutover()
+    {
+        var adapter = NewAdapter();
+
+        var json = await SerializeSessionAsync(adapter, OptionsWithCodec(RealtimeAiAudioCodec.MULAW));
+
+        var session = json["session"]!;
+        session["input_audio_format"].ShouldBeNull();
+        session["output_audio_format"].ShouldBeNull();
+        session["input_audio_transcription"].ShouldBeNull();
+        session["voice"].ShouldBeNull();
+        session["turn_detection"].ShouldBeNull();
+    }
+
+    // ── Audio format object (codec mapping) ────────────────────────
+
+    [Theory]
+    [InlineData(RealtimeAiAudioCodec.MULAW, "audio/pcmu")]
+    [InlineData(RealtimeAiAudioCodec.ALAW, "audio/pcma")]
+    public async Task GetInitialSessionPayload_G711Codec_FormatHasTypeOnly_NoRateField(RealtimeAiAudioCodec codec, string expectedType)
+    {
+        var adapter = NewAdapter();
+
+        var json = await SerializeSessionAsync(adapter, OptionsWithCodec(codec));
+
+        var inputFormat = json["session"]!["audio"]!["input"]!["format"]!;
+        inputFormat["type"]!.Value<string>().ShouldBe(expectedType);
+        inputFormat["rate"].ShouldBeNull();
+
+        var outputFormat = json["session"]!["audio"]!["output"]!["format"]!;
+        outputFormat["type"]!.Value<string>().ShouldBe(expectedType);
+        outputFormat["rate"].ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task GetInitialSessionPayload_Pcm16Codec_FormatCarriesExplicitRate()
+    {
+        var adapter = NewAdapter();
+
+        var json = await SerializeSessionAsync(adapter, OptionsWithCodec(RealtimeAiAudioCodec.PCM16));
+
+        var inputFormat = json["session"]!["audio"]!["input"]!["format"]!;
+        inputFormat["type"]!.Value<string>().ShouldBe("audio/pcm");
+        inputFormat["rate"]!.Value<int>().ShouldBe(24000);
+
+        var outputFormat = json["session"]!["audio"]!["output"]!["format"]!;
+        outputFormat["type"]!.Value<string>().ShouldBe("audio/pcm");
+        outputFormat["rate"]!.Value<int>().ShouldBe(24000);
+    }
+
+    // ── Nested audio config is preserved ────────────────────────────
+
+    [Fact]
+    public async Task GetInitialSessionPayload_AudioInput_CarriesTranscriptionAndTurnDetection()
+    {
+        var adapter = NewAdapter();
+
+        var json = await SerializeSessionAsync(adapter, OptionsWithCodec(RealtimeAiAudioCodec.MULAW));
+
+        var input = json["session"]!["audio"]!["input"]!;
+        input["transcription"]!["model"]!.Value<string>().ShouldBe("whisper-1");
+        input["turn_detection"]!["type"]!.Value<string>().ShouldBe("server_vad");
+    }
+
+    [Fact]
+    public async Task GetInitialSessionPayload_AudioOutput_CarriesVoice()
+    {
+        var adapter = NewAdapter();
+
+        var json = await SerializeSessionAsync(adapter, OptionsWithCodec(RealtimeAiAudioCodec.MULAW, voice: "shimmer"));
+
+        json["session"]!["audio"]!["output"]!["voice"]!.Value<string>().ShouldBe("shimmer");
+    }
+
+    [Fact]
+    public async Task GetInitialSessionPayload_VoiceFallsBackToAlloy_WhenUnset()
+    {
+        var adapter = NewAdapter();
+
+        var json = await SerializeSessionAsync(adapter, OptionsWithCodec(RealtimeAiAudioCodec.MULAW, voice: ""));
+
+        json["session"]!["audio"]!["output"]!["voice"]!.Value<string>().ShouldBe("alloy");
+    }
+
+    [Fact]
+    public async Task GetInitialSessionPayload_PreservesInstructionsAtSessionLevel()
+    {
+        var adapter = NewAdapter();
+
+        var json = await SerializeSessionAsync(adapter, OptionsWithCodec(RealtimeAiAudioCodec.MULAW, prompt: "你是收銀員"));
+
+        json["session"]!["instructions"]!.Value<string>().ShouldBe("你是收銀員");
+    }
+
+    // ── Event-name parsing accepts both old and new names ──────────
+
+    [Theory]
+    [InlineData("response.audio.delta")]
+    [InlineData("response.output_audio.delta")]
+    public void ParseMessage_BothAudioDeltaNames_MapToResponseAudioDelta(string eventType)
+    {
+        var adapter = NewAdapter();
+        var raw = JsonConvert.SerializeObject(new { type = eventType, delta = "AQID", item_id = "itm-1" });
+
+        var parsed = adapter.ParseMessage(raw);
+
+        parsed.Type.ShouldBe(RealtimeAiWssEventType.ResponseAudioDelta);
+    }
+
+    [Theory]
+    [InlineData("response.audio.done")]
+    [InlineData("response.output_audio.done")]
+    public void ParseMessage_BothAudioDoneNames_MapToResponseAudioDone(string eventType)
+    {
+        var adapter = NewAdapter();
+        var raw = JsonConvert.SerializeObject(new { type = eventType, item_id = "itm-1" });
+
+        var parsed = adapter.ParseMessage(raw);
+
+        parsed.Type.ShouldBe(RealtimeAiWssEventType.ResponseAudioDone);
+    }
+
+    [Theory]
+    [InlineData("response.audio_transcript.delta")]
+    [InlineData("response.output_audio_transcript.delta")]
+    public void ParseMessage_BothAudioTranscriptDeltaNames_MapToOutputAudioTranscriptionPartial(string eventType)
+    {
+        var adapter = NewAdapter();
+        var raw = JsonConvert.SerializeObject(new { type = eventType, delta = "partial" });
+
+        var parsed = adapter.ParseMessage(raw);
+
+        parsed.Type.ShouldBe(RealtimeAiWssEventType.OutputAudioTranscriptionPartial);
+    }
+
+    [Theory]
+    [InlineData("response.audio_transcript.done")]
+    [InlineData("response.output_audio_transcript.done")]
+    public void ParseMessage_BothAudioTranscriptDoneNames_MapToOutputAudioTranscriptionCompleted(string eventType)
+    {
+        var adapter = NewAdapter();
+        var raw = JsonConvert.SerializeObject(new { type = eventType, transcript = "hi" });
+
+        var parsed = adapter.ParseMessage(raw);
+
+        parsed.Type.ShouldBe(RealtimeAiWssEventType.OutputAudioTranscriptionCompleted);
+    }
+}

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterGaPayloadTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterGaPayloadTests.cs
@@ -1,0 +1,192 @@
+using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NSubstitute;
+using Shouldly;
+using SmartTalk.Core.Services.RealtimeAiV2;
+using SmartTalk.Core.Services.RealtimeAiV2.Adapters.Providers.OpenAi;
+using SmartTalk.Core.Settings.OpenAi;
+using SmartTalk.Messages.Enums.RealtimeAi;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Services.RealtimeAiV2;
+
+/// <summary>
+/// Pins the OpenAI Realtime API GA contract (post 2026-05-07).
+/// Beta-era fields that would now be rejected by the server MUST stay out of the payload.
+/// </summary>
+public class OpenAiRealtimeAiProviderAdapterGaPayloadTests
+{
+    private static OpenAiRealtimeAiProviderAdapter NewAdapter() =>
+        new(new OpenAiSettings(Substitute.For<IConfiguration>()));
+
+    private static RealtimeSessionOptions OptionsWithPromptAndVoice(string prompt = "you are helpful", string voice = "alloy") =>
+        new()
+        {
+            ModelConfig = new RealtimeAiModelConfig
+            {
+                Prompt = prompt,
+                Voice = voice,
+                Tools = new List<object>()
+            }
+        };
+
+    private static JObject SerializeSession(object payload) =>
+        JObject.Parse(JsonConvert.SerializeObject(payload));
+
+    // ── Headers ────────────────────────────────────────────────────
+
+    [Fact]
+    public void GetHeaders_DoesNotIncludeBetaHeader_AfterGaCutover()
+    {
+        // The `OpenAI-Beta: realtime=v1` header was removed at GA cutover. Sending it now
+        // produces `invalid_beta` and the WS is closed before our first session.update.
+        var adapter = NewAdapter();
+
+        var headers = adapter.GetHeaders(RealtimeAiServerRegion.US);
+
+        headers.ShouldNotContainKey("OpenAI-Beta");
+        headers.ShouldContainKey("Authorization");
+    }
+
+    // ── Session payload top-level shape ────────────────────────────
+
+    [Fact]
+    public void BuildSessionConfig_TopLevel_HasSessionTypeRealtime()
+    {
+        var adapter = NewAdapter();
+
+        var json = SerializeSession(adapter.BuildSessionConfig(OptionsWithPromptAndVoice(), RealtimeAiAudioCodec.MULAW));
+
+        json["type"]!.Value<string>().ShouldBe("session.update");
+        json["session"]!["type"]!.Value<string>().ShouldBe("realtime");
+    }
+
+    [Fact]
+    public void BuildSessionConfig_UsesOutputModalities_NotLegacyModalities()
+    {
+        // GA renamed `modalities` → `output_modalities` and dropped the input direction
+        // (it is always inferred from session.type).
+        var adapter = NewAdapter();
+
+        var json = SerializeSession(adapter.BuildSessionConfig(OptionsWithPromptAndVoice(), RealtimeAiAudioCodec.MULAW));
+
+        json["session"]!["modalities"].ShouldBeNull();
+        json["session"]!["output_modalities"]!.Values<string>().ShouldBe(new[] { "audio" });
+    }
+
+    [Fact]
+    public void BuildSessionConfig_DoesNotEmitTemperature_AfterGaCutover()
+    {
+        // `temperature` was removed from the GA session payload schema.
+        var adapter = NewAdapter();
+
+        var json = SerializeSession(adapter.BuildSessionConfig(OptionsWithPromptAndVoice(), RealtimeAiAudioCodec.MULAW));
+
+        json["session"]!["temperature"].ShouldBeNull();
+    }
+
+    [Fact]
+    public void BuildSessionConfig_DoesNotEmitFlatAudioFields_AfterGaCutover()
+    {
+        // GA moved audio config under `session.audio.{input,output}` and removed the flat
+        // `input_audio_format` / `output_audio_format` / `voice` / `input_audio_transcription`
+        // siblings on `session`.
+        var adapter = NewAdapter();
+
+        var json = SerializeSession(adapter.BuildSessionConfig(OptionsWithPromptAndVoice(), RealtimeAiAudioCodec.MULAW));
+
+        var session = json["session"]!;
+        session["input_audio_format"].ShouldBeNull();
+        session["output_audio_format"].ShouldBeNull();
+        session["input_audio_transcription"].ShouldBeNull();
+        session["voice"].ShouldBeNull();
+        session["turn_detection"].ShouldBeNull();
+    }
+
+    // ── Audio format object (codec mapping) ────────────────────────
+
+    [Theory]
+    [InlineData(RealtimeAiAudioCodec.MULAW, "audio/pcmu")]
+    [InlineData(RealtimeAiAudioCodec.ALAW, "audio/pcma")]
+    public void BuildSessionConfig_G711Codec_FormatHasTypeOnly_NoRateField(RealtimeAiAudioCodec codec, string expectedType)
+    {
+        // G.711 is fixed at 8 kHz; sending a `rate` field is rejected by the GA server as
+        // an unknown property. Canonical Twilio sample emits {"type": "audio/pcmu"} only.
+        var adapter = NewAdapter();
+
+        var json = SerializeSession(adapter.BuildSessionConfig(OptionsWithPromptAndVoice(), codec));
+
+        var inputFormat = json["session"]!["audio"]!["input"]!["format"]!;
+        inputFormat["type"]!.Value<string>().ShouldBe(expectedType);
+        inputFormat["rate"].ShouldBeNull();
+
+        var outputFormat = json["session"]!["audio"]!["output"]!["format"]!;
+        outputFormat["type"]!.Value<string>().ShouldBe(expectedType);
+        outputFormat["rate"].ShouldBeNull();
+    }
+
+    [Fact]
+    public void BuildSessionConfig_Pcm16Codec_FormatCarriesExplicitRate()
+    {
+        // PCM16 rate is not fixed; the GA contract requires us to declare it explicitly.
+        var adapter = NewAdapter();
+
+        var json = SerializeSession(adapter.BuildSessionConfig(OptionsWithPromptAndVoice(), RealtimeAiAudioCodec.PCM16));
+
+        var inputFormat = json["session"]!["audio"]!["input"]!["format"]!;
+        inputFormat["type"]!.Value<string>().ShouldBe("audio/pcm");
+        inputFormat["rate"]!.Value<int>().ShouldBe(24000);
+
+        var outputFormat = json["session"]!["audio"]!["output"]!["format"]!;
+        outputFormat["type"]!.Value<string>().ShouldBe("audio/pcm");
+        outputFormat["rate"]!.Value<int>().ShouldBe(24000);
+    }
+
+    // ── Nested audio config is preserved ────────────────────────────
+
+    [Fact]
+    public void BuildSessionConfig_AudioInput_CarriesTranscriptionAndTurnDetection()
+    {
+        var adapter = NewAdapter();
+        var options = OptionsWithPromptAndVoice();
+        options.ModelConfig.TurnDetection = new { type = "server_vad" };
+
+        var json = SerializeSession(adapter.BuildSessionConfig(options, RealtimeAiAudioCodec.MULAW));
+
+        var input = json["session"]!["audio"]!["input"]!;
+        input["transcription"]!["model"]!.Value<string>().ShouldBe("whisper-1");
+        input["turn_detection"]!["type"]!.Value<string>().ShouldBe("server_vad");
+    }
+
+    [Fact]
+    public void BuildSessionConfig_AudioOutput_CarriesVoice()
+    {
+        var adapter = NewAdapter();
+
+        var json = SerializeSession(adapter.BuildSessionConfig(OptionsWithPromptAndVoice(voice: "shimmer"), RealtimeAiAudioCodec.MULAW));
+
+        json["session"]!["audio"]!["output"]!["voice"]!.Value<string>().ShouldBe("shimmer");
+    }
+
+    [Fact]
+    public void BuildSessionConfig_VoiceFallsBackToAlloy_WhenUnset()
+    {
+        // Preserves prior behavior: empty/null voice → alloy default.
+        var adapter = NewAdapter();
+
+        var json = SerializeSession(adapter.BuildSessionConfig(OptionsWithPromptAndVoice(voice: ""), RealtimeAiAudioCodec.MULAW));
+
+        json["session"]!["audio"]!["output"]!["voice"]!.Value<string>().ShouldBe("alloy");
+    }
+
+    [Fact]
+    public void BuildSessionConfig_PreservesInstructionsAtSessionLevel()
+    {
+        var adapter = NewAdapter();
+
+        var json = SerializeSession(adapter.BuildSessionConfig(OptionsWithPromptAndVoice(prompt: "你是收銀員"), RealtimeAiAudioCodec.MULAW));
+
+        json["session"]!["instructions"]!.Value<string>().ShouldBe("你是收銀員");
+    }
+}


### PR DESCRIPTION
## Summary

PRODUCTION-DOWN HOTFIX. OpenAI's Realtime API moved Beta → GA on 2026-05-07. Every WebSocket connection still sending `OpenAI-Beta: realtime=v1` is rejected with `invalid_beta` ("Unknown beta requested: 'realtime'"), so all voice assistant calls have been failing.

This commit migrates **every** place we touch the OpenAI Realtime API — V2 adapter (production path), V1 adapter, and the V1 inline session in `AiSpeechAssistantService` — so the two paths stay in lockstep and V1 cannot silently regress into `invalid_beta` if anyone re-enables it later.

Three changes are applied uniformly:

1. **Drop the `OpenAI-Beta: realtime=v1` request header** from `GetHeaders` (V2 adapter, V1 adapter, and `ConfigWebSocketRequestHeader` for OpenAi + ZhiPuAi branches).
2. **Restructure `session.update` to the GA shape**: required `session.type = "realtime"`, nested `audio.{input,output}.*`, audio `format` becomes an object (`{type: "audio/pcmu"}` for G.711 with **no `rate`** field per the GA contract, `{type: "audio/pcm", rate: 24000}` for PCM16), `modalities` → `output_modalities = ["audio"]`, `temperature` removed. Applied in V2 adapter, V1 adapter, and the V1 inline `InitialSessionAsync` for both OpenAi and Azure provider branches.
3. **Accept both old beta and new GA event names** in `ParseMessage` / inline event handlers so we survive any transition-window mismatch: `response.audio.delta` ↔ `response.output_audio.delta`, `response.audio.done` ↔ `response.output_audio.done`, `response.audio_transcript.delta` ↔ `response.output_audio_transcript.delta`, `response.audio_transcript.done` ↔ `response.output_audio_transcript.done`.

Behavioural settings (voice fallback to `alloy`, server VAD default, whisper-1 transcription, prompt injection, tools passthrough, noise reduction) are preserved exactly — only the JSON shape changed.

## Test plan

- [x] Build clean (0 errors)
- [x] New V2 pinning suite `OpenAiRealtimeAiProviderAdapterGaPayloadTests`: 12/12 pass
- [x] New V1 pinning suite `OpenAiRealtimeAiAdapterGaPayloadTests`: 20/20 pass (includes dual-event-name `ParseMessage` cases)
- [x] Full unit suite: 186/186 pass (was 154 before, +32 new pinning cases)
- [ ] Staging deploy: WS connect no longer rejected with `invalid_beta`
- [ ] Real Twilio call: `session.update` accepted, audio flows end-to-end, mixed Cantonese/Mandarin/English still works
- [ ] Monitor `invalid_beta` rate drops to zero in production logs after deploy

## Refs

- [OpenAI Realtime API platform docs (GA)](https://platform.openai.com/docs/guides/realtime)
- [OpenAI deprecations page (Realtime Beta sunset 2026-05-07)](https://developers.openai.com/api/docs/deprecations)
- [Canonical Twilio + OpenAI Realtime sample (post-GA shape)](https://github.com/twilio-samples/speech-assistant-openai-realtime-api-python)