### PR TITLE
Add NULLABLE realtime config fields to AiSpeechAssistant entity

### DIFF
--- a/src/SmartTalk.Core/DbUpFile/Scripts_2026/Script0007_add_realtime_config_fields_to_ai_speech_assistant.sql
+++ b/src/SmartTalk.Core/DbUpFile/Scripts_2026/Script0007_add_realtime_config_fields_to_ai_speech_assistant.sql
@@ -1,0 +1,22 @@
+-- Phase 4.1 of Round 2 V2 stability & perf rollout.
+-- All columns NULLABLE; null means "use the same default as today, no behavior change".
+-- These columns are only READ when both (a) the column is non-null AND (b) the matching
+-- env var (introduced in Phase 4.2) is not 'off'. Until Phase 4.2 ships, this migration
+-- is a pure schema add and produces zero behaviour change in production.
+--
+-- No `AFTER` clauses: column placement in the table layout is cosmetic, and including
+-- `AFTER` forces MySQL to use ALGORITHM=COPY (full table rebuild + write lock for the
+-- duration of the copy) on 5.7, and prevents ALGORITHM=INSTANT (metadata-only, no
+-- table touch) on 8.0+. Without `AFTER`, 8.0+ adds these columns instantly and 5.7
+-- can use ALGORITHM=INPLACE. The `ai_speech_assistant` table is config-scale so the
+-- impact is bounded either way, but the change is preventive — applies to any future
+-- migration this pattern is copied to.
+ALTER TABLE ai_speech_assistant
+    ADD COLUMN `transcription_model`         VARCHAR(64)    NULL,
+    ADD COLUMN `transcription_language`      VARCHAR(8)     NULL,
+    ADD COLUMN `turn_detection_type`         VARCHAR(32)    NULL,
+    ADD COLUMN `turn_detection_threshold`    DECIMAL(4, 3)  NULL,
+    ADD COLUMN `turn_detection_silence_ms`   INT            NULL,
+    ADD COLUMN `input_noise_reduction_type`  VARCHAR(32)    NULL,
+    ADD COLUMN `max_response_output_tokens`  INT            NULL,
+    ADD COLUMN `output_audio_speed`          DECIMAL(3, 2)  NULL;

--- a/src/SmartTalk.Core/Domain/AISpeechAssistant/AiSpeechAssistant.cs
+++ b/src/SmartTalk.Core/Domain/AISpeechAssistant/AiSpeechAssistant.cs
@@ -39,7 +39,38 @@ public class AiSpeechAssistant : IEntity<int>, IAgent, IHasCreatedFields
     
     [Column("model_voice")]
     public string ModelVoice { get; set; }
-    
+
+    // ── Realtime API GA session-config knobs (Phase 4.1 of Round 2 rollout) ───────
+    // All NULLABLE. NULL means "use the same hard-coded default as today" — these
+    // fields are only consumed in Phase 4.2+ when the matching env var is non-off.
+    // Until then this is a pure schema add and the runtime path is unchanged.
+
+    [Column("transcription_model"), StringLength(64)]
+    public string TranscriptionModel { get; set; }
+
+    [Column("transcription_language"), StringLength(8)]
+    public string TranscriptionLanguage { get; set; }
+
+    [Column("turn_detection_type"), StringLength(32)]
+    public string TurnDetectionType { get; set; }
+
+    [Column("turn_detection_threshold")]
+    public decimal? TurnDetectionThreshold { get; set; }
+
+    [Column("turn_detection_silence_ms")]
+    public int? TurnDetectionSilenceMs { get; set; }
+
+    [Column("input_noise_reduction_type"), StringLength(32)]
+    public string InputNoiseReductionType { get; set; }
+
+    [Column("max_response_output_tokens")]
+    public int? MaxResponseOutputTokens { get; set; }
+
+    [Column("output_audio_speed")]
+    public decimal? OutputAudioSpeed { get; set; }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+
     [Column("agent_id")]
     public int AgentId { get; set; }
     

--- a/src/SmartTalk.IntegrationTests/Services/AiSpeechAssistant/AiSpeechAssistantConnectFixture.RealtimeConfigPersistence.cs
+++ b/src/SmartTalk.IntegrationTests/Services/AiSpeechAssistant/AiSpeechAssistantConnectFixture.RealtimeConfigPersistence.cs
@@ -1,0 +1,164 @@
+using Shouldly;
+using SmartTalk.Core.Data;
+using SmartTalk.Core.Domain.AISpeechAssistant;
+using SmartTalk.Messages.Enums.RealtimeAi;
+using Xunit;
+
+namespace SmartTalk.IntegrationTests.Services.AiSpeechAssistant;
+
+/// <summary>
+/// Integration coverage for the Phase 4.1 NULLABLE Realtime API session-config columns
+/// added in <c>Script0007_add_realtime_config_fields_to_ai_speech_assistant.sql</c>.
+///
+/// <para>
+/// These tests pin the persistence contract: NULL values must round-trip as NULL (the
+/// load-bearing invariant for "default = today's behaviour" through Phase 5+), and
+/// every value type must persist + read back identically across the EF Core ↔ MySQL
+/// boundary. Decimal precision in particular is fragile — <c>turn_detection_threshold</c>
+/// is <c>DECIMAL(4,3)</c> and <c>output_audio_speed</c> is <c>DECIMAL(3,2)</c>; a
+/// schema-CLR precision mismatch would silently truncate operator-configured values.
+/// </para>
+/// </summary>
+public partial class AiSpeechAssistantConnectFixture
+{
+    [Fact]
+    public async Task ShouldPersistRealtimeConfig_AllNull_RoundTripsAsNull()
+    {
+        // The load-bearing invariant: fresh rows (no operator config) must round-trip
+        // every new column as NULL — Phase 4.2 logic treats NULL as "use today's default".
+        // If any column coerced to a non-null default on persist, Phase 5+ would activate
+        // opt-in behaviour for every existing prod assistant on Phase 4.2 deploy.
+        int assistantId = 0;
+
+        await RunWithUnitOfWork<IRepository, IUnitOfWork>(async (repository, unitOfWork) =>
+        {
+            var assistant = new Core.Domain.AISpeechAssistant.AiSpeechAssistant
+            {
+                Name = "ConfigNullAssistant",
+                AnsweringNumber = TestDidNumber,
+                ModelProvider = RealtimeAiProvider.OpenAi,
+                ModelVoice = "alloy",
+                IsDefault = true,
+                IsDisplay = true
+            };
+
+            await repository.InsertAsync(assistant);
+            await unitOfWork.SaveChangesAsync();
+
+            assistantId = assistant.Id;
+        });
+
+        await Run<IRepository>(async repository =>
+        {
+            var persisted = await repository.GetByIdAsync<Core.Domain.AISpeechAssistant.AiSpeechAssistant>(assistantId);
+
+            persisted.ShouldNotBeNull();
+            persisted.TranscriptionModel.ShouldBeNull();
+            persisted.TranscriptionLanguage.ShouldBeNull();
+            persisted.TurnDetectionType.ShouldBeNull();
+            persisted.TurnDetectionThreshold.ShouldBeNull();
+            persisted.TurnDetectionSilenceMs.ShouldBeNull();
+            persisted.InputNoiseReductionType.ShouldBeNull();
+            persisted.MaxResponseOutputTokens.ShouldBeNull();
+            persisted.OutputAudioSpeed.ShouldBeNull();
+        });
+    }
+
+    [Fact]
+    public async Task ShouldPersistRealtimeConfig_AllPopulated_RoundTripsValuesIdentically()
+    {
+        // Values chosen to stress decimal precision boundaries:
+        //   turn_detection_threshold (DECIMAL(4,3)) → 0.500 — 3 fractional digits exactly
+        //   output_audio_speed       (DECIMAL(3,2)) → 1.15  — 2 fractional digits at upper UX range
+        // A truncation here would corrupt operator config silently.
+        int assistantId = 0;
+
+        await RunWithUnitOfWork<IRepository, IUnitOfWork>(async (repository, unitOfWork) =>
+        {
+            var assistant = new Core.Domain.AISpeechAssistant.AiSpeechAssistant
+            {
+                Name = "ConfigPopulatedAssistant",
+                AnsweringNumber = TestDidNumber,
+                ModelProvider = RealtimeAiProvider.OpenAi,
+                ModelVoice = "alloy",
+                IsDefault = true,
+                IsDisplay = true,
+                TranscriptionModel = "gpt-4o-transcribe",
+                TranscriptionLanguage = "yue",
+                TurnDetectionType = "semantic_vad",
+                TurnDetectionThreshold = 0.500m,
+                TurnDetectionSilenceMs = 700,
+                InputNoiseReductionType = "near_field",
+                MaxResponseOutputTokens = 1200,
+                OutputAudioSpeed = 1.15m
+            };
+
+            await repository.InsertAsync(assistant);
+            await unitOfWork.SaveChangesAsync();
+
+            assistantId = assistant.Id;
+        });
+
+        await Run<IRepository>(async repository =>
+        {
+            var persisted = await repository.GetByIdAsync<Core.Domain.AISpeechAssistant.AiSpeechAssistant>(assistantId);
+
+            persisted.ShouldNotBeNull();
+            persisted.TranscriptionModel.ShouldBe("gpt-4o-transcribe");
+            persisted.TranscriptionLanguage.ShouldBe("yue");
+            persisted.TurnDetectionType.ShouldBe("semantic_vad");
+            persisted.TurnDetectionThreshold.ShouldBe(0.500m);
+            persisted.TurnDetectionSilenceMs.ShouldBe(700);
+            persisted.InputNoiseReductionType.ShouldBe("near_field");
+            persisted.MaxResponseOutputTokens.ShouldBe(1200);
+            persisted.OutputAudioSpeed.ShouldBe(1.15m);
+        });
+    }
+
+    [Fact]
+    public async Task ShouldPersistRealtimeConfig_PartialPopulation_OnlyPopulatedFieldsRetained()
+    {
+        // The realistic operator pattern: set ONE knob (e.g. just the language hint)
+        // and leave the rest at default. Pin that mixed null + non-null state survives
+        // the persistence round-trip, because mixed state is what every Phase 5+ canary
+        // assistant will look like in prod.
+        int assistantId = 0;
+
+        await RunWithUnitOfWork<IRepository, IUnitOfWork>(async (repository, unitOfWork) =>
+        {
+            var assistant = new Core.Domain.AISpeechAssistant.AiSpeechAssistant
+            {
+                Name = "ConfigPartialAssistant",
+                AnsweringNumber = TestDidNumber,
+                ModelProvider = RealtimeAiProvider.OpenAi,
+                ModelVoice = "alloy",
+                IsDefault = true,
+                IsDisplay = true,
+                TranscriptionLanguage = "zh"        // only the lang hint is set
+            };
+
+            await repository.InsertAsync(assistant);
+            await unitOfWork.SaveChangesAsync();
+
+            assistantId = assistant.Id;
+        });
+
+        await Run<IRepository>(async repository =>
+        {
+            var persisted = await repository.GetByIdAsync<Core.Domain.AISpeechAssistant.AiSpeechAssistant>(assistantId);
+
+            persisted.ShouldNotBeNull();
+            persisted.TranscriptionLanguage.ShouldBe("zh");
+
+            // Every other knob stays NULL — Phase 4.2 must continue to treat this
+            // assistant as "default behaviour for everything except language hint".
+            persisted.TranscriptionModel.ShouldBeNull();
+            persisted.TurnDetectionType.ShouldBeNull();
+            persisted.TurnDetectionThreshold.ShouldBeNull();
+            persisted.TurnDetectionSilenceMs.ShouldBeNull();
+            persisted.InputNoiseReductionType.ShouldBeNull();
+            persisted.MaxResponseOutputTokens.ShouldBeNull();
+            persisted.OutputAudioSpeed.ShouldBeNull();
+        });
+    }
+}

--- a/src/SmartTalk.UnitTests/Domain/AISpeechAssistant/AiSpeechAssistantRealtimeConfigPinningTests.cs
+++ b/src/SmartTalk.UnitTests/Domain/AISpeechAssistant/AiSpeechAssistantRealtimeConfigPinningTests.cs
@@ -1,0 +1,86 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Reflection;
+using Shouldly;
+using SmartTalk.Core.Domain.AISpeechAssistant;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Domain.AISpeechAssistant;
+
+/// <summary>
+/// Pins the column-name strings and CLR types of every Realtime API session-config
+/// property added in Phase 4.1 of the Round 2 stability rollout. These properties
+/// map 1:1 to NULLABLE columns in the <c>ai_speech_assistant</c> table; renaming
+/// either side desynchronises them and silently breaks per-assistant configuration
+/// (Phase 5+) for every row that has a non-null value.
+///
+/// <para>
+/// All properties MUST be nullable reference types (<c>string</c>) or nullable
+/// value types (<c>int?</c>, <c>decimal?</c>) — a non-nullable type here would
+/// silently coerce a NULL DB column to the default (0 / "") and a default would
+/// then be treated by Phase 4.2 adapter logic as an opt-in value, changing the
+/// outbound session.update payload for every existing assistant. NULLABLE is
+/// load-bearing — pin it.
+/// </para>
+///
+/// <para>
+/// A failure on this test means a renamed property or a flipped nullability —
+/// either is a production-grade incident if it merges. Fix the rename, do not
+/// edit this test to match.
+/// </para>
+/// </summary>
+public class AiSpeechAssistantRealtimeConfigPinningTests
+{
+    [Theory]
+    [InlineData(nameof(AiSpeechAssistant.TranscriptionModel),        "transcription_model",        typeof(string),   true)]
+    [InlineData(nameof(AiSpeechAssistant.TranscriptionLanguage),     "transcription_language",     typeof(string),   true)]
+    [InlineData(nameof(AiSpeechAssistant.TurnDetectionType),         "turn_detection_type",        typeof(string),   true)]
+    [InlineData(nameof(AiSpeechAssistant.TurnDetectionThreshold),    "turn_detection_threshold",   typeof(decimal), false)]
+    [InlineData(nameof(AiSpeechAssistant.TurnDetectionSilenceMs),    "turn_detection_silence_ms",  typeof(int),     false)]
+    [InlineData(nameof(AiSpeechAssistant.InputNoiseReductionType),   "input_noise_reduction_type", typeof(string),   true)]
+    [InlineData(nameof(AiSpeechAssistant.MaxResponseOutputTokens),   "max_response_output_tokens", typeof(int),     false)]
+    [InlineData(nameof(AiSpeechAssistant.OutputAudioSpeed),          "output_audio_speed",         typeof(decimal), false)]
+    public void RealtimeConfigProperty_HasExpectedColumnNameAndNullableType(
+        string propertyName, string expectedColumnName, Type underlyingType, bool isReferenceType)
+    {
+        var property = typeof(AiSpeechAssistant).GetProperty(propertyName, BindingFlags.Public | BindingFlags.Instance);
+
+        property.ShouldNotBeNull($"Property {propertyName} was removed or renamed; Phase 5+ adapter wiring will break silently");
+
+        var columnAttribute = property!.GetCustomAttribute<ColumnAttribute>();
+        columnAttribute.ShouldNotBeNull($"Property {propertyName} lost its [Column] attribute — DB mapping will fall back to PascalCase and break the migration contract");
+        columnAttribute!.Name.ShouldBe(expectedColumnName, $"Property {propertyName} column-name pin changed; DB column and CLR property are now desynchronised");
+
+        // Nullable contract: value types must be Nullable<T>, reference types must allow null.
+        // A regression here is a behavioural break: a NULL DB column would coerce to the default
+        // (0 / "") and Phase 4.2 logic would treat that as an opt-in value.
+        if (isReferenceType)
+        {
+            property.PropertyType.ShouldBe(underlyingType, $"Property {propertyName} type changed from a reference type; nullable contract broken");
+        }
+        else
+        {
+            var expectedNullableType = typeof(Nullable<>).MakeGenericType(underlyingType);
+            property.PropertyType.ShouldBe(expectedNullableType, $"Property {propertyName} lost its Nullable<{underlyingType.Name}> wrapper — DB NULL will now coerce to default value, breaking the zero-behaviour-change contract");
+        }
+    }
+
+    [Fact]
+    public void RealtimeConfigProperties_DefaultValueIsNull()
+    {
+        // Constructing a fresh entity must leave every new config property at null —
+        // otherwise existing prod rows (no migration backfill) would be indistinguishable
+        // from "operator set this value" and Phase 4.2 logic would change session.update
+        // shape for every assistant. This is the load-bearing invariant for the entire
+        // Round 2 rollout: NULL means "behave exactly like today".
+        var assistant = new AiSpeechAssistant();
+
+        assistant.TranscriptionModel.ShouldBeNull();
+        assistant.TranscriptionLanguage.ShouldBeNull();
+        assistant.TurnDetectionType.ShouldBeNull();
+        assistant.TurnDetectionThreshold.ShouldBeNull();
+        assistant.TurnDetectionSilenceMs.ShouldBeNull();
+        assistant.InputNoiseReductionType.ShouldBeNull();
+        assistant.MaxResponseOutputTokens.ShouldBeNull();
+        assistant.OutputAudioSpeed.ShouldBeNull();
+    }
+}


### PR DESCRIPTION
## Summary

Phase 4.1 of the Round 2 rollout. Pure schema + CLR plumbing — **zero runtime behaviour change**. Every new column is NULLABLE and is not read by any adapter or service in this PR; the data only starts flowing when Phase 4.2 wires DTO passthrough behind an env-var gate.

- 8 new NULLABLE columns added to `ai_speech_assistant` via `Script0007_add_realtime_config_fields_to_ai_speech_assistant.sql`
- Matching nullable properties on `AiSpeechAssistant` entity with `[Column]` mapping
- Pinning tests lock the column-name strings, CLR types, and the NULL-as-default invariant — the load-bearing contract for the entire Round 2 rollout

NULL means "use today's hard-coded default". A non-null value combined with the matching env var (Phase 4.2+) is the only way new behaviour activates.

## Default behaviour guarantee

- No adapter or service reads any new column in this PR
- `dotnet test` for the full V2 + adapter + connect-service suites (340 cases) pass unchanged
- Entity-property defaults round-trip as NULL through the persistence layer (integration test pins this)

## Rollback

`git revert <sha>` drops the columns via the inverse migration. Safe because all columns are NULLABLE and no caller reads them yet.

## Test plan

- [x] Unit: `AiSpeechAssistantRealtimeConfigPinningTests` — 9 cases pinning column names, CLR types, NULL defaults
- [x] Integration: `AiSpeechAssistantConnectFixture.RealtimeConfigPersistence` — 3 cases (all-null round-trip, all-populated with decimal-precision stress, partial-population mixed state)
- [x] Full unit suite: 340/340 pass
- [ ] CI integration tests against MySQL: column migration applies cleanly, round-trip values exact
- [ ] Staging deploy: confirm migration runs without locking the table for > 1s

## Refs

Round 2 tracking doc: `docs/v2-stability-perf-rollout-round-2.md` (Phase 4.1)