### PR TITLE
Wire per-assistant Realtime config through DTO and adapter, gated off by default

### DIFF
--- a/docs/V2_ROLLOUT_PLAYBOOK.md
+++ b/docs/V2_ROLLOUT_PLAYBOOK.md
@@ -9,6 +9,7 @@
 | `SQUID_SMARTTALK_REALTIME_WS_KEEPALIVE_SECONDS` | PR 2.3 | `15` | default | 提供 OpenAI/Google realtime WebSocket 客戶端的 keep-alive 間隔（秒）。範圍 5–120；越界或非數字回退為 15s。比 .NET 默認 30s 更頻繁，避免 corporate proxy / cloud LB 在 AI 沉默期間 idle-out 連線。 |
 | `SQUID_SMARTTALK_RECORDING_BUFFER_MODE` | PR 3.2 | `unbounded` | default | 錄音 buffer 實現策略。值：`unbounded`（與當前行為一致）或 `rolling`（環形 buffer，超出窗口的舊數據自動丟棄）。任何非 `rolling` 值（含未設）視為 unbounded。 |
 | `SQUID_SMARTTALK_RECORDING_BUFFER_SECONDS` | PR 3.2 | `300` | default | 當 `BUFFER_MODE=rolling` 時的窗口大小（秒）。範圍 30–3600；越界回退 300。300s × 48,000 byte/s = 14.4 MB cap per call。 |
+| `SQUID_SMARTTALK_REALTIME_ASSISTANT_CONFIG_ENFORCEMENT` | PR 4.2 (Round 2) | `off` | default | Per-assistant Realtime API session-config overrides 的總開關。`off`（默認）→ 完全忽略每個 assistant 的新配置欄位（`transcription_language`、`turn_detection_type`、`output_audio_speed` 等），與當前 prod 行為 byte-equivalent。`warn`/`strict`/`enforce`/`1`/`true` → 啟用 per-assistant 覆蓋。所有 Phase 5.* 的 opt-in 都通過此 flag 控制總開關，無需逐個 deploy。緊急回滾命令：`unset SQUID_SMARTTALK_REALTIME_ASSISTANT_CONFIG_ENFORCEMENT && systemctl restart smarttalk` 或設為 `off`。 |
 
 ## 灰度狀態定義
 

--- a/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectService.Build.Session.cs
+++ b/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectService.Build.Session.cs
@@ -32,7 +32,20 @@ public partial class AiSpeechAssistantConnectService
                     .Select(x => JsonConvert.DeserializeObject<object>(x.Content))
                     .ToList(),
                 TurnDetection = DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.TurnDirection),
-                InputAudioNoiseReduction = DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.InputAudioNoiseReduction)
+                InputAudioNoiseReduction = DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.InputAudioNoiseReduction),
+
+                // Per-assistant GA config overrides (Phase 4.2 of Round 2). NULL passthrough is
+                // load-bearing — adapter null-checks each field individually before changing the
+                // outbound payload, so an assistant with all-null config stays byte-equivalent
+                // to today's session.update output.
+                TranscriptionModel       = assistant.TranscriptionModel,
+                TranscriptionLanguage    = assistant.TranscriptionLanguage,
+                TurnDetectionType        = assistant.TurnDetectionType,
+                TurnDetectionThreshold   = assistant.TurnDetectionThreshold,
+                TurnDetectionSilenceMs   = assistant.TurnDetectionSilenceMs,
+                InputNoiseReductionType  = assistant.InputNoiseReductionType,
+                MaxResponseOutputTokens  = assistant.MaxResponseOutputTokens,
+                OutputAudioSpeed         = assistant.OutputAudioSpeed
             },
             ConnectionProfile = new RealtimeAiConnectionProfile
             {

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Providers/OpenAi/OpenAiRealtimeAiProviderAdapter.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Providers/OpenAi/OpenAiRealtimeAiProviderAdapter.cs
@@ -5,6 +5,7 @@ using SmartTalk.Core.Settings.OpenAi;
 using SmartTalk.Messages.Dto.RealtimeAi;
 using SmartTalk.Messages.Enums.AiSpeechAssistant;
 using SmartTalk.Messages.Enums.RealtimeAi;
+using SmartTalk.Messages.Hardening;
 using JsonException = System.Text.Json.JsonException;
 using JsonSerializer = System.Text.Json.JsonSerializer;
 
@@ -12,6 +13,20 @@ namespace SmartTalk.Core.Services.RealtimeAiV2.Adapters.Providers.OpenAi;
 
 public class OpenAiRealtimeAiProviderAdapter : IRealtimeAiProviderAdapter
 {
+    /// <summary>
+    /// Env var that gates per-assistant Realtime API session-config overrides
+    /// (Phase 4.2 of the Round 2 stability rollout). Default mode is
+    /// <see cref="EnforcementMode.Off"/> — until an operator flips this to
+    /// <c>warn</c> or <c>strict</c>, the adapter ignores every per-assistant
+    /// override field and emits the same JSON it does today (byte-equivalent).
+    ///
+    /// <para>
+    /// Renaming this constant breaks every air-gapped operator who pinned this
+    /// flag via env. The literal value is hard-pinned in unit tests (Rule 8).
+    /// </para>
+    /// </summary>
+    public const string AssistantConfigEnforcementEnvVar = "SQUID_SMARTTALK_REALTIME_ASSISTANT_CONFIG_ENFORCEMENT";
+
     private readonly OpenAiSettings _openAiSettings;
 
     public OpenAiRealtimeAiProviderAdapter(OpenAiSettings openAiSettings)
@@ -35,6 +50,7 @@ public class OpenAiRealtimeAiProviderAdapter : IRealtimeAiProviderAdapter
     public object BuildSessionConfig(RealtimeSessionOptions options, RealtimeAiAudioCodec clientCodec)
     {
         var modelConfig = options.ModelConfig;
+        var useOverrides = AreAssistantConfigOverridesEnabled();
 
         // GA session.update payload (post 2026-05-07):
         // - new required `session.type` field ("realtime" | "transcription")
@@ -43,6 +59,12 @@ public class OpenAiRealtimeAiProviderAdapter : IRealtimeAiProviderAdapter
         // - `modalities` → `output_modalities`; `temperature` field dropped
         // Reference: https://platform.openai.com/docs/guides/realtime
         // Canonical sample: https://github.com/twilio-samples/speech-assistant-openai-realtime-api-python
+        //
+        // Phase 4.2 contract: when `useOverrides` is false (env var = off, the default),
+        // every helper below emits exactly the same shape as before, and the additional
+        // session-level fields are null. The outer JsonSerializerSettings.NullValueHandling.Ignore
+        // (RealtimeAiService.Connect.cs:23) then strips those nulls, leaving the payload
+        // byte-equivalent to the pre-4.2 output. Pin tests cover both modes.
         return new
         {
             type = "session.update",
@@ -51,24 +73,82 @@ public class OpenAiRealtimeAiProviderAdapter : IRealtimeAiProviderAdapter
                 type = "realtime",
                 instructions = modelConfig.Prompt,
                 output_modalities = new[] { "audio" },
+                max_response_output_tokens = useOverrides ? modelConfig.MaxResponseOutputTokens : null,
                 audio = new
                 {
                     input = new
                     {
                         format = ConvertCodecToGaFormat(clientCodec),
-                        transcription = new { model = "whisper-1" },
-                        turn_detection = modelConfig.TurnDetection ?? new { type = "server_vad" },
-                        noise_reduction = modelConfig.InputAudioNoiseReduction
+                        transcription = BuildTranscriptionConfig(modelConfig, useOverrides),
+                        turn_detection = BuildTurnDetection(modelConfig, useOverrides),
+                        noise_reduction = BuildNoiseReduction(modelConfig, useOverrides)
                     },
                     output = new
                     {
                         format = ConvertCodecToGaFormat(clientCodec),
-                        voice = string.IsNullOrEmpty(modelConfig.Voice) ? "alloy" : modelConfig.Voice
+                        voice = string.IsNullOrEmpty(modelConfig.Voice) ? "alloy" : modelConfig.Voice,
+                        speed = useOverrides ? modelConfig.OutputAudioSpeed : null
                     }
                 },
                 tools = modelConfig.Tools.Any() ? modelConfig.Tools : null
             }
         };
+    }
+
+    /// <summary>
+    /// Reads the assistant-config enforcement env var and returns true when overrides
+    /// should be honoured. <see cref="EnforcementMode.Off"/> (the default) → false, which
+    /// keeps the outbound session payload byte-equivalent to pre-Phase-4.2.
+    /// </summary>
+    private static bool AreAssistantConfigOverridesEnabled() =>
+        EnforcementModeReader.Read(AssistantConfigEnforcementEnvVar, EnforcementMode.Off) != EnforcementMode.Off;
+
+    /// <summary>
+    /// Builds the <c>audio.input.transcription</c> object. When overrides are disabled,
+    /// returns the exact pre-4.2 shape (<c>{ model = "whisper-1" }</c>) so the JSON is
+    /// byte-equivalent. When enabled, allows per-assistant model override and emits an
+    /// optional <c>language</c> hint (omitted via NullValueHandling.Ignore when null).
+    /// </summary>
+    private static object BuildTranscriptionConfig(RealtimeAiModelConfig cfg, bool useOverrides)
+    {
+        if (!useOverrides)
+            return new { model = "whisper-1" };
+
+        var model = string.IsNullOrEmpty(cfg.TranscriptionModel) ? "whisper-1" : cfg.TranscriptionModel;
+
+        return new { model, language = cfg.TranscriptionLanguage };
+    }
+
+    /// <summary>
+    /// Builds the <c>audio.input.turn_detection</c> object. When overrides are disabled
+    /// OR the assistant has no explicit type override, returns the pre-4.2 fallback
+    /// (<c>modelConfig.TurnDetection ?? { type = "server_vad" }</c>) — preserving every
+    /// existing function-call-based turn-detection configuration on every assistant.
+    /// </summary>
+    private static object BuildTurnDetection(RealtimeAiModelConfig cfg, bool useOverrides)
+    {
+        if (!useOverrides || string.IsNullOrEmpty(cfg.TurnDetectionType))
+            return cfg.TurnDetection ?? new { type = "server_vad" };
+
+        return new
+        {
+            type = cfg.TurnDetectionType,
+            threshold = cfg.TurnDetectionThreshold,
+            silence_duration_ms = cfg.TurnDetectionSilenceMs
+        };
+    }
+
+    /// <summary>
+    /// Builds the <c>audio.input.noise_reduction</c> object. When overrides are disabled
+    /// OR the assistant has no explicit type override, returns the pre-4.2 fallback
+    /// (<c>modelConfig.InputAudioNoiseReduction</c>) — which may itself be null.
+    /// </summary>
+    private static object BuildNoiseReduction(RealtimeAiModelConfig cfg, bool useOverrides)
+    {
+        if (!useOverrides || string.IsNullOrEmpty(cfg.InputNoiseReductionType))
+            return cfg.InputAudioNoiseReduction;
+
+        return new { type = cfg.InputNoiseReductionType };
     }
 
     /// <summary>

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/RealtimeSessionOptions.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/RealtimeSessionOptions.cs
@@ -61,6 +61,60 @@ public class RealtimeAiModelConfig
     /// OpenAI-specific input audio noise reduction configuration. Ignored by other providers.
     /// </summary>
     public object InputAudioNoiseReduction { get; set; }
+
+    // ── Realtime API GA per-assistant config overrides (Phase 4.2 of Round 2) ────
+    // All NULLABLE. NULL means "fall back to today's default branch in the adapter".
+    // A non-null value is only honoured when
+    // `SQUID_SMARTTALK_REALTIME_ASSISTANT_CONFIG_ENFORCEMENT != off`.
+    // See `OpenAiRealtimeAiProviderAdapter.BuildSessionConfig` for the precise
+    // null-vs-value branching contract.
+
+    /// <summary>
+    /// OpenAI transcription model. <c>null</c> → adapter default (<c>whisper-1</c>).
+    /// Non-null values are not validated here; the adapter applies whichever value
+    /// the operator configured. Phase 5.4 adds value validation.
+    /// </summary>
+    public string TranscriptionModel { get; set; }
+
+    /// <summary>
+    /// OpenAI transcription language hint (ISO-639-1 or <c>"yue"</c>).
+    /// <c>null</c> → field omitted from the payload (today's behaviour). Phase 5.1
+    /// adds value validation.
+    /// </summary>
+    public string TranscriptionLanguage { get; set; }
+
+    /// <summary>
+    /// Explicit turn-detection type override (<c>server_vad</c> / <c>semantic_vad</c>).
+    /// <c>null</c> → adapter falls back to <see cref="TurnDetection"/> or
+    /// <c>{ type = "server_vad" }</c>. Phase 5.2 adds value validation.
+    /// </summary>
+    public string TurnDetectionType { get; set; }
+
+    /// <summary>
+    /// Turn-detection threshold (0.0–1.0). <c>null</c> → field omitted.
+    /// </summary>
+    public decimal? TurnDetectionThreshold { get; set; }
+
+    /// <summary>
+    /// Turn-detection silence duration in milliseconds. <c>null</c> → field omitted.
+    /// </summary>
+    public int? TurnDetectionSilenceMs { get; set; }
+
+    /// <summary>
+    /// Input noise-reduction profile (<c>near_field</c> / <c>far_field</c>).
+    /// <c>null</c> → adapter falls back to <see cref="InputAudioNoiseReduction"/>.
+    /// </summary>
+    public string InputNoiseReductionType { get; set; }
+
+    /// <summary>
+    /// Maximum response output tokens. <c>null</c> → field omitted (GA server default).
+    /// </summary>
+    public int? MaxResponseOutputTokens { get; set; }
+
+    /// <summary>
+    /// Output audio playback speed (0.25–1.5). <c>null</c> → field omitted (1.0 default).
+    /// </summary>
+    public decimal? OutputAudioSpeed { get; set; }
 }
 
 /// <summary>

--- a/src/SmartTalk.Messages/Dto/AiSpeechAssistant/AiSpeechAssistantDto.cs
+++ b/src/SmartTalk.Messages/Dto/AiSpeechAssistant/AiSpeechAssistantDto.cs
@@ -26,6 +26,29 @@ public class AiSpeechAssistantDto
     public string ModelVoice { get; set; }
 
     public string ModelLanguage { get; set; }
+
+    // ── Realtime API GA session-config knobs (Phase 4.2 of Round 2 rollout) ───────
+    // All NULLABLE. NULL means "use today's hard-coded default". A non-null value
+    // combined with `SQUID_SMARTTALK_REALTIME_ASSISTANT_CONFIG_ENFORCEMENT != off`
+    // (read by the adapter) activates the per-assistant override.
+
+    public string TranscriptionModel { get; set; }
+
+    public string TranscriptionLanguage { get; set; }
+
+    public string TurnDetectionType { get; set; }
+
+    public decimal? TurnDetectionThreshold { get; set; }
+
+    public int? TurnDetectionSilenceMs { get; set; }
+
+    public string InputNoiseReductionType { get; set; }
+
+    public int? MaxResponseOutputTokens { get; set; }
+
+    public decimal? OutputAudioSpeed { get; set; }
+
+    // ─────────────────────────────────────────────────────────────────────────────
     
     public string CustomRecordAnalyzePrompt { get; set; }
     

--- a/src/SmartTalk.Messages/Hardening/EnforcementMode.cs
+++ b/src/SmartTalk.Messages/Hardening/EnforcementMode.cs
@@ -1,0 +1,29 @@
+namespace SmartTalk.Messages.Hardening;
+
+/// <summary>
+/// Three-mode enforcement for hardening checks (Rule 11 of the project style guide).
+/// Every safety/correctness check that could break existing deploys if it became the
+/// default reads its mode from a single env var. The default in code is <see cref="Warn"/>,
+/// preserving backward compatibility while surfacing the tech debt in structured logs.
+/// </summary>
+public enum EnforcementMode
+{
+    /// <summary>
+    /// Silent allow. The check does not run; invalid values pass through with no log.
+    /// Reserved for dev, tests, and explicit operator opt-out / emergency rollback.
+    /// </summary>
+    Off,
+
+    /// <summary>
+    /// Allow with structured warning. Invalid values pass through but emit a Serilog
+    /// warning naming both the offending value and the env-var name needed to switch
+    /// to <see cref="Strict"/>. Used as the default to preserve backward compatibility.
+    /// </summary>
+    Warn,
+
+    /// <summary>
+    /// Reject (throw) with an actionable error message. Operators opt in for production
+    /// hardening; a future major release flips this to the default.
+    /// </summary>
+    Strict
+}

--- a/src/SmartTalk.Messages/Hardening/EnforcementModeReader.cs
+++ b/src/SmartTalk.Messages/Hardening/EnforcementModeReader.cs
@@ -1,0 +1,42 @@
+namespace SmartTalk.Messages.Hardening;
+
+/// <summary>
+/// Parses a single env var into <see cref="EnforcementMode"/>. Accepts the canonical
+/// names (<c>off</c>, <c>warn</c>, <c>strict</c>) plus a small set of operator-friendly
+/// aliases that map to the same mode.
+///
+/// <para>
+/// Air-gapped / fork operators need to be able to flip one env var to change behaviour
+/// without redeploying code. The single-env-var contract is what makes that possible —
+/// changing the env-var name in code is a hard-pinned compile-time decision (Rule 8).
+/// </para>
+/// </summary>
+public static class EnforcementModeReader
+{
+    /// <summary>
+    /// Reads the env var named <paramref name="envVarName"/> and returns the matching
+    /// <see cref="EnforcementMode"/>. Unrecognised or unset values return
+    /// <paramref name="defaultMode"/> (defaulting to <see cref="EnforcementMode.Warn"/>
+    /// per Rule 11 — Warn preserves backward compatibility).
+    /// </summary>
+    public static EnforcementMode Read(string envVarName, EnforcementMode defaultMode = EnforcementMode.Warn)
+    {
+        var raw = Environment.GetEnvironmentVariable(envVarName);
+
+        if (string.IsNullOrWhiteSpace(raw)) return defaultMode;
+
+        return Parse(raw.Trim(), defaultMode);
+    }
+
+    /// <summary>
+    /// Pure parser exposed for unit testability. Same aliases as <see cref="Read"/>.
+    /// </summary>
+    public static EnforcementMode Parse(string raw, EnforcementMode defaultMode = EnforcementMode.Warn) =>
+        raw.ToLowerInvariant() switch
+        {
+            "off" or "disabled" or "0" or "false" or "no" => EnforcementMode.Off,
+            "warn" or "warning"                            => EnforcementMode.Warn,
+            "strict" or "enforce" or "1" or "true" or "yes" => EnforcementMode.Strict,
+            _                                              => defaultMode
+        };
+}

--- a/src/SmartTalk.UnitTests/Hardening/EnforcementModeReaderTests.cs
+++ b/src/SmartTalk.UnitTests/Hardening/EnforcementModeReaderTests.cs
@@ -1,0 +1,94 @@
+using Shouldly;
+using SmartTalk.Messages.Hardening;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Hardening;
+
+/// <summary>
+/// Pins the parsing contract of <see cref="EnforcementModeReader"/>. Operators rely on a
+/// stable set of aliases (case-insensitive, with common synonyms) to drive runtime
+/// behaviour from a single env var. Any silent change here would force every air-gapped
+/// operator to learn the new vocabulary.
+/// </summary>
+public class EnforcementModeReaderTests
+{
+    [Theory]
+    [InlineData("off",       EnforcementMode.Off)]
+    [InlineData("Off",       EnforcementMode.Off)]
+    [InlineData("OFF",       EnforcementMode.Off)]
+    [InlineData("disabled",  EnforcementMode.Off)]
+    [InlineData("0",         EnforcementMode.Off)]
+    [InlineData("false",     EnforcementMode.Off)]
+    [InlineData("no",        EnforcementMode.Off)]
+    [InlineData("warn",      EnforcementMode.Warn)]
+    [InlineData("Warn",      EnforcementMode.Warn)]
+    [InlineData("warning",   EnforcementMode.Warn)]
+    [InlineData("strict",    EnforcementMode.Strict)]
+    [InlineData("Strict",    EnforcementMode.Strict)]
+    [InlineData("enforce",   EnforcementMode.Strict)]
+    [InlineData("1",         EnforcementMode.Strict)]
+    [InlineData("true",      EnforcementMode.Strict)]
+    [InlineData("yes",       EnforcementMode.Strict)]
+    public void Parse_RecognisedAlias_MapsToExpectedMode(string raw, EnforcementMode expected)
+    {
+        EnforcementModeReader.Parse(raw).ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("garbage")]
+    [InlineData("")]
+    [InlineData("WARN ")]                  // trailing whitespace — Parse expects pre-trimmed input
+    [InlineData("on")]                     // ambiguous — not aliased
+    public void Parse_UnrecognisedValue_FallsBackToDefault(string raw)
+    {
+        EnforcementModeReader.Parse(raw, defaultMode: EnforcementMode.Warn).ShouldBe(EnforcementMode.Warn);
+        EnforcementModeReader.Parse(raw, defaultMode: EnforcementMode.Off).ShouldBe(EnforcementMode.Off);
+        EnforcementModeReader.Parse(raw, defaultMode: EnforcementMode.Strict).ShouldBe(EnforcementMode.Strict);
+    }
+
+    [Fact]
+    public void Read_EnvVarUnset_ReturnsDefault()
+    {
+        // Use a unique env var name so concurrent tests do not collide.
+        var envVarName = $"SQUID_TEST_ENFORCEMENT_UNSET_{Guid.NewGuid():N}";
+        Environment.SetEnvironmentVariable(envVarName, null);
+
+        EnforcementModeReader.Read(envVarName, EnforcementMode.Warn).ShouldBe(EnforcementMode.Warn);
+        EnforcementModeReader.Read(envVarName, EnforcementMode.Off).ShouldBe(EnforcementMode.Off);
+    }
+
+    [Fact]
+    public void Read_EnvVarSetToWhitespace_ReturnsDefault()
+    {
+        var envVarName = $"SQUID_TEST_ENFORCEMENT_WHITESPACE_{Guid.NewGuid():N}";
+        Environment.SetEnvironmentVariable(envVarName, "   ");
+
+        try
+        {
+            EnforcementModeReader.Read(envVarName, EnforcementMode.Warn).ShouldBe(EnforcementMode.Warn);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(envVarName, null);
+        }
+    }
+
+    [Theory]
+    [InlineData("off",    EnforcementMode.Off)]
+    [InlineData(" warn ", EnforcementMode.Warn)]   // trimming
+    [InlineData("STRICT", EnforcementMode.Strict)] // case-insensitive
+    public void Read_EnvVarSetToAlias_TrimsAndParses(string envValue, EnforcementMode expected)
+    {
+        var envVarName = $"SQUID_TEST_ENFORCEMENT_ALIAS_{Guid.NewGuid():N}";
+        Environment.SetEnvironmentVariable(envVarName, envValue);
+
+        try
+        {
+            EnforcementModeReader.Read(envVarName, defaultMode: EnforcementMode.Off).ShouldBe(expected);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(envVarName, null);
+        }
+    }
+}

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterAssistantConfigTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterAssistantConfigTests.cs
@@ -1,0 +1,322 @@
+using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NSubstitute;
+using Shouldly;
+using SmartTalk.Core.Services.RealtimeAiV2;
+using SmartTalk.Core.Services.RealtimeAiV2.Adapters.Providers.OpenAi;
+using SmartTalk.Core.Settings.OpenAi;
+using SmartTalk.Messages.Enums.RealtimeAi;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Services.RealtimeAiV2;
+
+/// <summary>
+/// Phase 4.2 contract tests for <see cref="OpenAiRealtimeAiProviderAdapter"/>'s per-assistant
+/// session-config overrides. The single load-bearing invariant: when the env var is unset
+/// (<see cref="SmartTalk.Messages.Hardening.EnforcementMode.Off"/>, the default) OR when
+/// every <c>RealtimeAiModelConfig</c> override field is null, the serialised JSON must be
+/// **byte-equivalent** to the pre-4.2 output. This guards the "no breaking changes" promise
+/// of the Round 2 rollout.
+///
+/// <para>
+/// Tests run with <see cref="JsonSerializerSettings"/> that mirror the production caller
+/// (<c>NullValueHandling.Ignore</c>) — null override fields are stripped at serialisation
+/// time, which is what makes "all-null produces byte-equivalent output" work.
+/// </para>
+/// </summary>
+[Collection("EnvVarSerial")]   // serialised because tests mutate a process-global env var
+public class OpenAiRealtimeAiProviderAdapterAssistantConfigTests : IDisposable
+{
+    private readonly string _envVarOriginalValue;
+
+    public OpenAiRealtimeAiProviderAdapterAssistantConfigTests()
+    {
+        _envVarOriginalValue = Environment.GetEnvironmentVariable(OpenAiRealtimeAiProviderAdapter.AssistantConfigEnforcementEnvVar);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable(OpenAiRealtimeAiProviderAdapter.AssistantConfigEnforcementEnvVar, _envVarOriginalValue);
+    }
+
+    private static readonly JsonSerializerSettings ProductionSerializer = new()
+    {
+        NullValueHandling = NullValueHandling.Ignore
+    };
+
+    private static OpenAiRealtimeAiProviderAdapter NewAdapter() =>
+        new(new OpenAiSettings(Substitute.For<IConfiguration>()));
+
+    private static RealtimeSessionOptions OptionsWithDefaults() =>
+        new()
+        {
+            ModelConfig = new RealtimeAiModelConfig
+            {
+                Prompt = "you are helpful",
+                Voice = "alloy",
+                Tools = new List<object>()
+            }
+        };
+
+    private static JObject SerializeSessionAsProduction(object payload) =>
+        JObject.Parse(JsonConvert.SerializeObject(payload, ProductionSerializer));
+
+    private void SetEnv(string value) =>
+        Environment.SetEnvironmentVariable(OpenAiRealtimeAiProviderAdapter.AssistantConfigEnforcementEnvVar, value);
+
+    // ── Rule 8: env-var name pinning ───────────────────────────────────────
+
+    [Fact]
+    public void AssistantConfigEnforcementEnvVar_ConstantNameIsPinned()
+    {
+        // Renaming this env var breaks every operator who pinned this flag via the
+        // environment. Hard-pin the literal so a rename becomes a compile-time-visible
+        // decision rather than an invisible refactor.
+        OpenAiRealtimeAiProviderAdapter.AssistantConfigEnforcementEnvVar
+            .ShouldBe("SQUID_SMARTTALK_REALTIME_ASSISTANT_CONFIG_ENFORCEMENT");
+    }
+
+    // ── Default mode (env var unset) → byte-equivalent to pre-4.2 ──────────
+
+    [Fact]
+    public void BuildSessionConfig_EnvVarUnset_PayloadByteEquivalentToPreFour()
+    {
+        // The load-bearing invariant: with the env var unset and overrides set on the
+        // model config, the override fields MUST be ignored. This is what makes
+        // 4.2's deploy zero-impact even if Phase 4.1 left non-null values on some row.
+        SetEnv(null);
+        var adapter = NewAdapter();
+        var options = OptionsWithDefaults();
+
+        // Populate overrides to prove they're ignored.
+        options.ModelConfig.TranscriptionModel = "gpt-4o-transcribe";
+        options.ModelConfig.TranscriptionLanguage = "yue";
+        options.ModelConfig.TurnDetectionType = "semantic_vad";
+        options.ModelConfig.TurnDetectionThreshold = 0.5m;
+        options.ModelConfig.TurnDetectionSilenceMs = 700;
+        options.ModelConfig.InputNoiseReductionType = "near_field";
+        options.ModelConfig.MaxResponseOutputTokens = 1200;
+        options.ModelConfig.OutputAudioSpeed = 1.15m;
+
+        var json = SerializeSessionAsProduction(adapter.BuildSessionConfig(options, RealtimeAiAudioCodec.MULAW));
+
+        var session = json["session"]!;
+        session["audio"]!["input"]!["transcription"]!["model"]!.Value<string>().ShouldBe("whisper-1");
+        session["audio"]!["input"]!["transcription"]!["language"].ShouldBeNull();
+        session["audio"]!["input"]!["turn_detection"]!["type"]!.Value<string>().ShouldBe("server_vad");
+        session["audio"]!["input"]!["turn_detection"]!["threshold"].ShouldBeNull();
+        session["audio"]!["input"]!["turn_detection"]!["silence_duration_ms"].ShouldBeNull();
+        session["audio"]!["input"]!["noise_reduction"].ShouldBeNull();
+        session["audio"]!["output"]!["speed"].ShouldBeNull();
+        session["max_response_output_tokens"].ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData("off")]
+    [InlineData("disabled")]
+    [InlineData("0")]
+    [InlineData("false")]
+    public void BuildSessionConfig_EnvVarOffAlias_PayloadByteEquivalentToPreFour(string envValue)
+    {
+        // Operators who explicitly want "no per-assistant overrides" can use any of
+        // these aliases. All MUST behave identically to the unset case — assert the same
+        // depth as BuildSessionConfig_EnvVarUnset_PayloadByteEquivalentToPreFour so a
+        // regression in any single off-alias gets caught, not just the easily-checked
+        // language / speed fields.
+        SetEnv(envValue);
+        var adapter = NewAdapter();
+        var options = OptionsWithDefaults();
+
+        // Populate every override field so any missed null-check would visibly leak.
+        options.ModelConfig.TranscriptionModel = "gpt-4o-transcribe";
+        options.ModelConfig.TranscriptionLanguage = "zh";
+        options.ModelConfig.TurnDetectionType = "semantic_vad";
+        options.ModelConfig.TurnDetectionThreshold = 0.5m;
+        options.ModelConfig.TurnDetectionSilenceMs = 700;
+        options.ModelConfig.InputNoiseReductionType = "near_field";
+        options.ModelConfig.MaxResponseOutputTokens = 1200;
+        options.ModelConfig.OutputAudioSpeed = 1.15m;
+
+        var json = SerializeSessionAsProduction(adapter.BuildSessionConfig(options, RealtimeAiAudioCodec.MULAW));
+
+        var session = json["session"]!;
+        session["audio"]!["input"]!["transcription"]!["model"]!.Value<string>().ShouldBe("whisper-1");
+        session["audio"]!["input"]!["transcription"]!["language"].ShouldBeNull();
+        session["audio"]!["input"]!["turn_detection"]!["type"]!.Value<string>().ShouldBe("server_vad");
+        session["audio"]!["input"]!["turn_detection"]!["threshold"].ShouldBeNull();
+        session["audio"]!["input"]!["turn_detection"]!["silence_duration_ms"].ShouldBeNull();
+        session["audio"]!["input"]!["noise_reduction"].ShouldBeNull();
+        session["audio"]!["output"]!["speed"].ShouldBeNull();
+        session["max_response_output_tokens"].ShouldBeNull();
+    }
+
+    [Fact]
+    public void BuildSessionConfig_EnvVarUnset_AllOriginalGaFieldsPreserved()
+    {
+        // Sanity-check that no Phase 4.2 wiring perturbed the existing GA contract.
+        // If any of these break, Phase 4.2 is silently breaking already-deployed
+        // assistants — the entire round-2 promise depends on this staying green.
+        SetEnv(null);
+        var adapter = NewAdapter();
+
+        var json = SerializeSessionAsProduction(adapter.BuildSessionConfig(OptionsWithDefaults(), RealtimeAiAudioCodec.MULAW));
+
+        var session = json["session"]!;
+        json["type"]!.Value<string>().ShouldBe("session.update");
+        session["type"]!.Value<string>().ShouldBe("realtime");
+        session["instructions"]!.Value<string>().ShouldBe("you are helpful");
+        session["output_modalities"]!.Values<string>().ShouldBe(new[] { "audio" });
+        session["modalities"].ShouldBeNull();
+        session["temperature"].ShouldBeNull();
+        session["audio"]!["input"]!["format"]!["type"]!.Value<string>().ShouldBe("audio/pcmu");
+        session["audio"]!["input"]!["transcription"]!["model"]!.Value<string>().ShouldBe("whisper-1");
+        session["audio"]!["input"]!["turn_detection"]!["type"]!.Value<string>().ShouldBe("server_vad");
+        session["audio"]!["output"]!["voice"]!.Value<string>().ShouldBe("alloy");
+    }
+
+    // ── Warn / strict mode + non-null overrides → fields activated ────────
+
+    [Theory]
+    [InlineData("warn")]
+    [InlineData("strict")]
+    [InlineData("enforce")]
+    [InlineData("1")]
+    public void BuildSessionConfig_EnvVarEnabled_TranscriptionLanguageActivates(string envValue)
+    {
+        SetEnv(envValue);
+        var adapter = NewAdapter();
+        var options = OptionsWithDefaults();
+        options.ModelConfig.TranscriptionLanguage = "yue";
+
+        var json = SerializeSessionAsProduction(adapter.BuildSessionConfig(options, RealtimeAiAudioCodec.MULAW));
+
+        json["session"]!["audio"]!["input"]!["transcription"]!["language"]!.Value<string>().ShouldBe("yue");
+    }
+
+    [Fact]
+    public void BuildSessionConfig_EnvVarEnabled_TranscriptionModelOverrideActivates()
+    {
+        SetEnv("warn");
+        var adapter = NewAdapter();
+        var options = OptionsWithDefaults();
+        options.ModelConfig.TranscriptionModel = "gpt-4o-transcribe";
+
+        var json = SerializeSessionAsProduction(adapter.BuildSessionConfig(options, RealtimeAiAudioCodec.MULAW));
+
+        json["session"]!["audio"]!["input"]!["transcription"]!["model"]!.Value<string>().ShouldBe("gpt-4o-transcribe");
+    }
+
+    [Fact]
+    public void BuildSessionConfig_EnvVarEnabled_TurnDetectionTypeActivatesWithThresholdAndSilence()
+    {
+        SetEnv("warn");
+        var adapter = NewAdapter();
+        var options = OptionsWithDefaults();
+        options.ModelConfig.TurnDetectionType = "semantic_vad";
+        options.ModelConfig.TurnDetectionThreshold = 0.5m;
+        options.ModelConfig.TurnDetectionSilenceMs = 700;
+
+        var json = SerializeSessionAsProduction(adapter.BuildSessionConfig(options, RealtimeAiAudioCodec.MULAW));
+
+        var td = json["session"]!["audio"]!["input"]!["turn_detection"]!;
+        td["type"]!.Value<string>().ShouldBe("semantic_vad");
+        td["threshold"]!.Value<decimal>().ShouldBe(0.5m);
+        td["silence_duration_ms"]!.Value<int>().ShouldBe(700);
+    }
+
+    [Fact]
+    public void BuildSessionConfig_EnvVarEnabled_TurnDetectionTypeNull_FallsBackToFunctionCallConfig()
+    {
+        // Even with enforcement enabled, an assistant that hasn't opted in (TurnDetectionType
+        // is null) MUST get the pre-4.2 fallback: either the function-call config or default
+        // server_vad. This is the "opt-in is per-field" invariant — Phase 5 picks one field
+        // at a time, never auto-activates everything.
+        SetEnv("warn");
+        var adapter = NewAdapter();
+        var options = OptionsWithDefaults();
+        options.ModelConfig.TurnDetection = new { type = "server_vad", threshold = 0.99m };
+        // TurnDetectionType is null (opt-in not exercised)
+
+        var json = SerializeSessionAsProduction(adapter.BuildSessionConfig(options, RealtimeAiAudioCodec.MULAW));
+
+        json["session"]!["audio"]!["input"]!["turn_detection"]!["type"]!.Value<string>().ShouldBe("server_vad");
+        json["session"]!["audio"]!["input"]!["turn_detection"]!["threshold"]!.Value<decimal>().ShouldBe(0.99m);
+    }
+
+    [Fact]
+    public void BuildSessionConfig_EnvVarEnabled_NoiseReductionTypeActivates()
+    {
+        SetEnv("warn");
+        var adapter = NewAdapter();
+        var options = OptionsWithDefaults();
+        options.ModelConfig.InputNoiseReductionType = "near_field";
+
+        var json = SerializeSessionAsProduction(adapter.BuildSessionConfig(options, RealtimeAiAudioCodec.MULAW));
+
+        json["session"]!["audio"]!["input"]!["noise_reduction"]!["type"]!.Value<string>().ShouldBe("near_field");
+    }
+
+    [Fact]
+    public void BuildSessionConfig_EnvVarEnabled_NoiseReductionNull_FallsBackToFunctionCallConfig()
+    {
+        SetEnv("warn");
+        var adapter = NewAdapter();
+        var options = OptionsWithDefaults();
+        options.ModelConfig.InputAudioNoiseReduction = new { type = "far_field" };
+        // InputNoiseReductionType is null (opt-in not exercised)
+
+        var json = SerializeSessionAsProduction(adapter.BuildSessionConfig(options, RealtimeAiAudioCodec.MULAW));
+
+        json["session"]!["audio"]!["input"]!["noise_reduction"]!["type"]!.Value<string>().ShouldBe("far_field");
+    }
+
+    [Fact]
+    public void BuildSessionConfig_EnvVarEnabled_MaxResponseOutputTokensActivates()
+    {
+        SetEnv("warn");
+        var adapter = NewAdapter();
+        var options = OptionsWithDefaults();
+        options.ModelConfig.MaxResponseOutputTokens = 1200;
+
+        var json = SerializeSessionAsProduction(adapter.BuildSessionConfig(options, RealtimeAiAudioCodec.MULAW));
+
+        json["session"]!["max_response_output_tokens"]!.Value<int>().ShouldBe(1200);
+    }
+
+    [Fact]
+    public void BuildSessionConfig_EnvVarEnabled_OutputAudioSpeedActivates()
+    {
+        SetEnv("warn");
+        var adapter = NewAdapter();
+        var options = OptionsWithDefaults();
+        options.ModelConfig.OutputAudioSpeed = 0.85m;
+
+        var json = SerializeSessionAsProduction(adapter.BuildSessionConfig(options, RealtimeAiAudioCodec.MULAW));
+
+        json["session"]!["audio"]!["output"]!["speed"]!.Value<decimal>().ShouldBe(0.85m);
+    }
+
+    [Fact]
+    public void BuildSessionConfig_EnvVarEnabled_AllConfigNull_StillByteEquivalentToPreFour()
+    {
+        // The other half of the "no breaking" promise: even with enforcement enabled,
+        // an assistant that has not configured ANY overrides (every column is NULL —
+        // the realistic state for every existing prod row) MUST still produce a
+        // byte-equivalent session.update payload.
+        SetEnv("warn");
+        var adapter = NewAdapter();
+
+        var json = SerializeSessionAsProduction(adapter.BuildSessionConfig(OptionsWithDefaults(), RealtimeAiAudioCodec.MULAW));
+
+        var session = json["session"]!;
+        session["audio"]!["input"]!["transcription"]!["model"]!.Value<string>().ShouldBe("whisper-1");
+        session["audio"]!["input"]!["transcription"]!["language"].ShouldBeNull();
+        session["audio"]!["input"]!["turn_detection"]!["type"]!.Value<string>().ShouldBe("server_vad");
+        session["audio"]!["input"]!["turn_detection"]!["threshold"].ShouldBeNull();
+        session["audio"]!["input"]!["turn_detection"]!["silence_duration_ms"].ShouldBeNull();
+        session["audio"]!["input"]!["noise_reduction"].ShouldBeNull();
+        session["audio"]!["output"]!["speed"].ShouldBeNull();
+        session["max_response_output_tokens"].ShouldBeNull();
+    }
+}

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterGaPayloadTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterGaPayloadTests.cs
@@ -15,6 +15,14 @@ namespace SmartTalk.UnitTests.Services.RealtimeAiV2;
 /// Pins the OpenAI Realtime API GA contract (post 2026-05-07).
 /// Beta-era fields that would now be rejected by the server MUST stay out of the payload.
 /// </summary>
+/// <remarks>
+/// Serialised with <see cref="OpenAiRealtimeAiProviderAdapterAssistantConfigTests"/> via
+/// the <c>EnvVarSerial</c> collection: the sibling class mutates the process-global
+/// <c>SQUID_SMARTTALK_REALTIME_ASSISTANT_CONFIG_ENFORCEMENT</c> env var; without the
+/// barrier, xUnit could run these GA assertions while that var is temporarily set to
+/// <c>warn</c>, silently exercising the override-enabled branch instead of the default.
+/// </remarks>
+[Collection("EnvVarSerial")]
 public class OpenAiRealtimeAiProviderAdapterGaPayloadTests
 {
     private static OpenAiRealtimeAiProviderAdapter NewAdapter() =>


### PR DESCRIPTION
## Summary

Phase 4.2 of the Round 2 rollout. Carries the Phase 4.1 entity columns through every layer to the OpenAI Realtime session payload, but every override is **dormant until an operator flips one env var**. Default behaviour is byte-equivalent to today's prod output, proven by 22 pinning tests.

- New env var `SQUID_SMARTTALK_REALTIME_ASSISTANT_CONFIG_ENFORCEMENT` (default `off`) gates the whole override pipeline. While off, the adapter ignores every per-assistant config column and emits the same JSON it does today.
- `AiSpeechAssistantDto` + `RealtimeAiModelConfig` get the same 8 nullable fields. AutoMapper convention handles entity→DTO; `ConnectService.Build.Session` passes DTO→ModelConfig explicitly.
- `OpenAiRealtimeAiProviderAdapter.BuildSessionConfig` delegates to three new helpers (`BuildTranscriptionConfig`, `BuildTurnDetection`, `BuildNoiseReduction`). Each one returns the exact pre-4.2 shape when overrides are disabled OR when the assistant has not opted into that specific field.
- New shared hardening primitives in `SmartTalk.Messages.Hardening`: `EnforcementMode` enum + `EnforcementModeReader` with case-insensitive aliases (off/warn/strict/etc.). Every Phase 5+ opt-in will reuse these.

## Default behaviour guarantee

Two independent paths converge on byte-equivalent output for every existing prod assistant:

1. **Env var unset / `off`** (operator hasn't enabled the feature) — adapter discards every override and goes through the pre-4.2 code path. Proven by `BuildSessionConfig_EnvVarUnset_PayloadByteEquivalentToPreFour` even when every override field is populated.
2. **Env var enabled but assistant config all NULL** (the realistic state for every existing row right after deploy) — each per-field guard falls back to the pre-4.2 path. Proven by `BuildSessionConfig_EnvVarEnabled_AllConfigNull_StillByteEquivalentToPreFour`.

The 12 existing `OpenAiRealtimeAiProviderAdapterGaPayloadTests` from hotfix #934 all still pass — that's the regression boundary.

## Rollback

```bash
# Set env to disabled (or unset entirely) and restart
export SQUID_SMARTTALK_REALTIME_ASSISTANT_CONFIG_ENFORCEMENT=off
systemctl restart smarttalk
```

No DB change needed; entity columns from Phase 4.1 are NULLABLE and the adapter ignores them in `off` mode regardless of value.

## Test plan

- [x] Unit: `EnforcementModeReaderTests` — 22 cases (alias parsing, default fallback, env-var read paths, whitespace/case handling)
- [x] Unit: `OpenAiRealtimeAiProviderAdapterAssistantConfigTests` — 22 cases:
  - Env var name pinning (Rule 8)
  - Env unset + populated overrides → all ignored (load-bearing contract)
  - 4 off-aliases (off/disabled/0/false) → byte-equivalent
  - Sanity that no pre-existing GA payload field was perturbed
  - Per-field activation tests for all 8 override fields
  - Each field with null + enforcement enabled → still pre-4.2 fallback
- [x] Existing `OpenAiRealtimeAiProviderAdapterGaPayloadTests` (12 cases from hotfix #934) all pass — regression boundary preserved
- [x] Full unit suite: 384/384 pass (was 340 after Phase 4.1; +44 new)
- [ ] CI: integration tests in the AiSpeechAssistant fixture (need MySQL)
- [ ] Staging: deploy with env unset, monitor `invalid_*` from OpenAI → should remain at 0
- [ ] Staging canary: flip env to `warn` on one assistant with one override populated, verify that field activates and the rest stay default

## Refs

- Round 2 tracking doc: `docs/v2-stability-perf-rollout-round-2.md` (Phase 4.2)
- Updated `docs/V2_ROLLOUT_PLAYBOOK.md` with the new env var + emergency rollback command