### PR TITLE
Track Round 2 stability and perf rollout plan

### DIFF
--- a/docs/V2_ROLLOUT_PLAYBOOK.md
+++ b/docs/V2_ROLLOUT_PLAYBOOK.md
@@ -9,6 +9,7 @@
 | `SQUID_SMARTTALK_REALTIME_WS_KEEPALIVE_SECONDS` | PR 2.3 | `15` | default | 提供 OpenAI/Google realtime WebSocket 客戶端的 keep-alive 間隔（秒）。範圍 5–120；越界或非數字回退為 15s。比 .NET 默認 30s 更頻繁，避免 corporate proxy / cloud LB 在 AI 沉默期間 idle-out 連線。 |
 | `SQUID_SMARTTALK_RECORDING_BUFFER_MODE` | PR 3.2 | `unbounded` | default | 錄音 buffer 實現策略。值：`unbounded`（與當前行為一致）或 `rolling`（環形 buffer，超出窗口的舊數據自動丟棄）。任何非 `rolling` 值（含未設）視為 unbounded。 |
 | `SQUID_SMARTTALK_RECORDING_BUFFER_SECONDS` | PR 3.2 | `300` | default | 當 `BUFFER_MODE=rolling` 時的窗口大小（秒）。範圍 30–3600；越界回退 300。300s × 48,000 byte/s = 14.4 MB cap per call。 |
+| `SQUID_SMARTTALK_REALTIME_ASSISTANT_CONFIG_ENFORCEMENT` | PR 4.2 (Round 2) | `off` | default | Per-assistant Realtime API session-config overrides 的總開關。`off`（默認）→ 完全忽略每個 assistant 的新配置欄位（`transcription_language`、`turn_detection_type`、`output_audio_speed` 等），與當前 prod 行為 byte-equivalent。`warn`/`strict`/`enforce`/`1`/`true` → 啟用 per-assistant 覆蓋。所有 Phase 5.* 的 opt-in 都通過此 flag 控制總開關，無需逐個 deploy。緊急回滾命令：`unset SQUID_SMARTTALK_REALTIME_ASSISTANT_CONFIG_ENFORCEMENT && systemctl restart smarttalk` 或設為 `off`。 |
 
 ## 灰度狀態定義
 

--- a/docs/v2-stability-perf-rollout-round-2.md
+++ b/docs/v2-stability-perf-rollout-round-2.md
@@ -1,0 +1,872 @@
+# AiSpeechAssistantConnect V2 — Round 2 詳細實施計劃
+
+> **背景**：Phase 1-3（12 PR）已合入 main，hotfix #934（Beta → GA migration）已合入。本輪在 V2-only-in-prod + GA contract 的新基線上，**極度謹慎**地推進穩定性與品質改進。
+
+> **絕對紅線（每一個 PR 都必須遵守）**：
+> 1. **默認行為與當前線上 byte-equivalent**：所有新代碼路徑在配置為空 / env var 未設時，產生與今天**完全相同**的 JSON 與調用順序。每個 PR 必須附「golden payload」迴歸測試證明。
+> 2. **opt-in 必須顯式**：新行為一律需要 (a) DB 欄位非 null **AND** (b) 對應 env var 不在 `off` 狀態。雙重門才生效。
+> 3. **5 分鐘緊急回滾**：每個 feature 都可單一 env var 切回默認，無需 deploy。
+> 4. **獨立可逆**：每個 PR 單獨 `git revert` 不留資料遷移殘留（DB 欄位都 NULLABLE，drop 安全）。
+> 5. **灰度路徑**：dev → 1 staging assistant → 1 prod canary（低流量）→ 多 prod → 全 prod，每階段觀察 ≥ 48h。
+
+---
+
+## Tracking 總覽
+
+| Phase | PR # | Branch | Title | 默認行為 | 風險 | 工時 | 狀態 |
+|---|---|---|---|---|---|---|---|
+| P0 | P0.1 | — | hotfix #934 prod 48h 觀察 | — | 零 | 觀察 | 🟡 |
+| P0 | P0.2 | — | 處理 PR #929 | — | 零 | 30m | ⚪ |
+| 4 | 4.1 | `feat/v2-assistant-config-fields` | Entity 加 NULLABLE 配置欄位 | **完全不變** | 低 | 90m | ⚪ |
+| 4 | 4.2 | `feat/v2-config-dto-passthrough` | DTO 透傳（null 時走默認分支） | **完全不變** | 低 | 60m | ⚪ |
+| 5 | 5.1 | `feat/v2-transcription-language-hint` | Whisper 語言 hint（混合語） | null → 不變 | 中 | 90m | ⚪ |
+| 5 | 5.2 | `feat/v2-semantic-vad-opt-in` | semantic_vad opt-in | null → server_vad | 中 | 75m | ⚪ |
+| 5 | 5.3 | `feat/v2-noise-reduction-config` | Noise reduction 配置 | null → 不變 | 低 | 60m | ⚪ |
+| 5 | 5.4 | `feat/v2-transcription-model-config` | gpt-4o-transcribe opt-in（成本高） | null → whisper-1 | 低 | 90m | ⚪ |
+| 5 | 5.5 | `feat/v2-max-response-tokens` | `max_response_output_tokens` opt-in | null → unlimited | 低 | 45m | ⚪ |
+| 5 | 5.6 | `feat/v2-audio-output-speed` | `audio.output.speed` opt-in | null → 1.0 | 低 | 45m | ⚪ |
+| 5 | 5.7 | `feat/v2-voice-extended-validation` | Voice 列表擴充 + 驗證 | 列表內 → 不變 | 低 | 60m | ⚪ |
+| 6 | 6.1 | `refactor/v2-function-output-base-type` | Function output 抽象基類（不替換） | 完全不變 | 低 | 90m | ⚪ |
+| 6 | 6.2-6.7 | `refactor/v2-function-output-{name}` | 逐 function 切類型（golden payload 守護） | 完全不變（byte-equiv） | 中 | 60m × 6 | ⚪ |
+| 7 | 7.1 | `refactor/v2-knowledge-fetch-apply-split` | BuildKnowledge fetch/apply 拆分（順序不變） | 完全不變 | 低 | 75m | ⚪ |
+| 7 | 7.2 | `perf/v2-knowledge-parallel-fetch` | 並行 fetch（env flag 默認 off） | env=off → 順序 | 中 | 90m | ⚪ |
+| 8 | 8.1 | `perf/v2-prompt-token-single-pass-regex` | 單次 regex（byte-equiv golden test） | 完全不變 | 低 | 60m | ⚪ |
+| 8 | 8.2 | `perf/v2-config-deserialize-cache` | Tools/TurnDetection cache | env=off → 不 cache | 低 | 90m | ⚪ |
+| 9 | 9.1 | `cleanup/v2-sunset-beta-event-names` | 移除 Beta event-name 雙 case | 2 週觀察後 | 低 | 30m | ⚪ blocked |
+| 9 | 9.2 | `feat/v2-tracing-debug-opt-in` | `session.tracing=auto` opt-in | null → 不發 | 零 | 60m | ⚪ |
+| 9 | 9.3 | `feat/v2-response-usage-tracking` | `response.done.usage` 抽取 + 持久化 | 純讀 + 寫新欄位 | 低 | 90m | ⚪ |
+| 10 | 10.1 | `feat/v2-item-id-tracking-additive` | item_id 追蹤（純增量，不改邏輯） | 完全不變 | 低 | 75m | ⚪ |
+| 10 | 10.2 | `feat/v2-twilio-mark-queue-additive` | Twilio mark queue（純發 mark，不用） | 完全不變 | 低 | 90m | ⚪ |
+| 10 | 10.3 | `feat/v2-barge-in-precise-truncate` | 用 10.1+10.2 做精確 truncate（env flag） | env=off → 不變 | **高** | 90m | ⚪ |
+| 11 | 11.1 | `feat/v2-default-url-realtime-2-canary` | gpt-realtime-2 per-assistant override | 不動 DefaultUrl | 低 | 30m | ⚪ |
+| 11 | 11.2 | `feat/v2-default-url-realtime-2-flip` | 1 週 canary 後 flip DefaultUrl | 線上行為改變 | 中 | 30m | ⚪ blocked |
+
+---
+
+## Phase 0 — Pre-flight（必須先做）
+
+### P0.1 — hotfix #934 prod 48h 觀察
+- **不做代碼改動**
+- **觀察項**（必須全綠才能進入 Phase 4）：
+  - 任何 OpenAI WS 連接的 `invalid_beta` 錯誤 → **必須為 0**
+  - 通話完成率（Twilio CallStatus.completed / total）→ **≥ hotfix 前基線**
+  - 平均通話時長 → **無顯著下降**
+  - 用戶投訴 → **無 GA-related 新投訴**
+- **如有任何項異常**：立即 rollback hotfix（PR #934 是純 V1+V2 對 OpenAI 的修改，revert 後恢復 hotfix 前狀態。但 hotfix 前狀態本身是壞的 — 所以實際是「等 OpenAI 端問題」而不是 revert hotfix）
+
+### P0.2 — PR #929 處理
+- **推薦方案 (c)**：直接 close PR #929，標註「superseded by Phase 11 of round 2」。理由：
+  - PR #929 是在 hotfix 之前做的，base 已過期
+  - gpt-realtime-2 對 transcription/voice/speed 配置敏感；Phase 5 配置可調後一次 A/B
+  - Phase 11.1 重做時 codebase 已是新基線，避免 rebase 衝突
+- **行動**：`gh pr close 929 --comment "Superseded by Phase 11..."`
+
+---
+
+## Phase 4 — 配置面板鋪設（不可見 / 零行為變更）
+
+> **整個 Phase 4 不改變任何用戶可見行為**。只是為 Phase 5 鋪 plumbing。Phase 4 兩個 PR 合入後，所有 assistant 的線上行為與今天 byte-equivalent。
+
+### PR 4.1 — Entity 加 NULLABLE 配置欄位
+
+**動機**：所有 Phase 5 opt-in 需要 per-assistant 配置存儲。本 PR 只加欄位，不讀也不寫。
+
+**修改**：
+- `AiSpeechAssistant.cs` 加以下 nullable 欄位：
+  ```csharp
+  [Column("transcription_model"), StringLength(64)]
+  public string TranscriptionModel { get; set; }              // null → whisper-1 默認
+
+  [Column("transcription_language"), StringLength(8)]
+  public string TranscriptionLanguage { get; set; }            // null → 不發 hint
+
+  [Column("turn_detection_type"), StringLength(32)]
+  public string TurnDetectionType { get; set; }                // null → 走當前 DeserializeFunctionCallConfig 邏輯
+
+  [Column("turn_detection_threshold")]
+  public decimal? TurnDetectionThreshold { get; set; }
+
+  [Column("turn_detection_silence_ms")]
+  public int? TurnDetectionSilenceMs { get; set; }
+
+  [Column("input_noise_reduction_type"), StringLength(32)]
+  public string InputNoiseReductionType { get; set; }          // null → 走當前邏輯
+
+  [Column("max_response_output_tokens")]
+  public int? MaxResponseOutputTokens { get; set; }            // null → 不發
+
+  [Column("output_audio_speed")]
+  public decimal? OutputAudioSpeed { get; set; }               // null → 不發
+  ```
+- **DB Migration**：純 ADD COLUMN，全部 NULLABLE，零 backfill
+
+**默認行為保證**：
+- 本 PR **不修改** `BuildSessionOptions` 或任何 adapter — 新欄位讀都不讀
+- 所有新欄位現有 row 為 null，相當於不存在
+
+**TDD**：
+1. Entity property pinning test（防止重命名）— 8 cases
+2. Integration test：插入 row 帶所有 null + 帶所有非 null 兩種，讀回比對
+3. Migration test：up-then-down 確認 schema 可逆
+
+**回滾**：`drop column` × 8（NULLABLE 故無資料丟失風險）
+
+**驗證信號**：所有現有 unit + integration 測試通過（無新行為，必然通過）
+
+---
+
+### PR 4.2 — DTO + ModelConfig 透傳（默認分支顯式守護）
+
+**動機**：把 4.1 的 entity 欄位流到 `RealtimeAiModelConfig`，並在 adapter 中**顯式守護**「null 時走原邏輯」。
+
+**修改**：
+1. `AiSpeechAssistantDto` 加同名 nullable 欄位
+2. `RealtimeAiModelConfig`（V2 namespace）加同名 nullable 欄位
+3. `BuildSessionOptions` 把 entity → ModelConfig 一條條複製：
+   ```csharp
+   TranscriptionModel = assistant.TranscriptionModel,
+   TranscriptionLanguage = assistant.TranscriptionLanguage,
+   // ...
+   ```
+4. `OpenAiRealtimeAiProviderAdapter.BuildSessionConfig` 在 audio.input / audio.output 構建處**顯式分支**：
+   ```csharp
+   transcription = new
+   {
+       model = modelConfig.TranscriptionModel ?? "whisper-1",
+       // language 僅當非 null 時才加入物件（避免空字串污染）
+   }
+   ```
+
+**默認行為保證**（**這是本 PR 的核心**）：
+- **Golden payload 測試**：當所有新欄位為 null 時，序列化後的 JSON 字符串必須與 hotfix #934 之後的 byte-equivalent
+- 把現有 12 個 `OpenAiRealtimeAiProviderAdapterGaPayloadTests` 全部跑一遍 → 必須全綠
+- 新增 1 個專門的 byte-equivalent golden test：
+  ```csharp
+  [Fact]
+  public void BuildSessionConfig_AllConfigNull_ProducesIdenticalJsonToPreFour()
+  {
+      // 預期 JSON 從 PR 4.2 之前的 git tree 提取出來作為金樣
+      var expected = LoadGoldenJsonFromTestData("session-config-defaults-2026-05-12.json");
+      var actual = JsonConvert.SerializeObject(adapter.BuildSessionConfig(options, codec));
+      actual.ShouldBe(expected);
+  }
+  ```
+
+**Opt-in 守護**：
+- 加 env var `SQUID_SMARTTALK_REALTIME_USE_ASSISTANT_CONFIG_FIELDS=off|warn|strict`（per Rule 11）
+- `off`（生產初始默認）→ 完全忽略 entity 新欄位，使用硬編碼默認
+- `warn` → 讀新欄位但若 invalid 記 warning + 用默認
+- `strict` → 讀新欄位，invalid 直接 throw（測試環境用）
+- 第一個 staging 部署設 `warn`，prod 設 `off`，觀察 1 週後 prod 切 `warn`
+
+**TDD**：
+1. Pinning test：env var 名稱 `EnforcementEnvVar` 常量值不變（Rule 8）
+2. 4.2.A：env=off + config 全 null → 與 4.1 前 byte-equivalent（golden）
+3. 4.2.B：env=off + config 非 null → 仍與 4.1 前 byte-equivalent（off 應忽略）
+4. 4.2.C：env=warn + config 全 null → 與 default 同
+5. 4.2.D：env=warn + config 非 null → 新值生效
+6. 4.2.E：env=strict + config invalid → throw
+
+**回滾**：env var `SQUID_SMARTTALK_REALTIME_USE_ASSISTANT_CONFIG_FIELDS=off`（無需 deploy）
+
+**驗證信號**：staging 上開 `warn`，跑現有 integration test suite 全綠
+
+---
+
+## Phase 5 — 逐個 opt-in（每個 PR 最小化、可獨立回滾）
+
+> **Phase 5 各 PR 嚴格獨立**。一個 PR 即使在 prod 啟用後出問題，也不影響其他 PR 的 opt-in。每個 PR 完整生命週期：dev → staging assistant ID = X 灰度 → 1 prod canary（低流量 assistant）→ 多 prod → 全 prod。
+
+> **Phase 5 內部順序建議**（按穩定性收益遞減）：
+> 1. 5.1 transcription language hint — **混合粵/普/英最大收益**
+> 2. 5.2 semantic_vad — 減少 filler 誤觸打斷
+> 3. 5.3 noise reduction — 通話品質
+> 4. 5.4 transcription model upgrade — 成本敏感，後做
+> 5. 5.5 max tokens — bound runaway
+> 6. 5.6 output speed — UX 調優
+> 7. 5.7 voice extension — 純列表擴充
+
+### PR 5.1 — Transcription Language Hint（**最大穩定性收益**）
+
+**動機**：餐廳場景常見粵語 → 普通話 → 英語混講。Whisper-1 多語自動檢測在 utterance 邊界容易切錯（如「兩個 large size 嘅 pepperoni」可能切到 zh-CN 後丟掉 "large size"）。設置 `language: "zh"` hint 把 Whisper 鎖到中文家族，混入英語單詞仍能識別但不切語言。
+
+**修改**：
+- `OpenAiRealtimeAiProviderAdapter.BuildSessionConfig` 在 `audio.input.transcription` 構建處：
+  ```csharp
+  transcription = BuildTranscriptionConfig(modelConfig)
+
+  // 新私有 method
+  private static object BuildTranscriptionConfig(RealtimeAiModelConfig cfg)
+  {
+      var lang = cfg.TranscriptionLanguage;
+
+      if (string.IsNullOrEmpty(lang))
+          return new { model = cfg.TranscriptionModel ?? "whisper-1" };
+
+      return new { model = cfg.TranscriptionModel ?? "whisper-1", language = lang };
+  }
+  ```
+
+**默認行為保證**：
+- `cfg.TranscriptionLanguage == null` → payload 中 `transcription` 物件不含 `language` key → byte-equivalent 與當前
+- Golden payload test：12 個現有 pinning test 通過 + 新增 `BuildSessionConfig_LanguageNull_NoLanguageKey`
+
+**Opt-in**：
+1. DB column `transcription_language` 非 null（如 `"zh"`、`"yue"`、`"en"`）
+2. env var `SQUID_SMARTTALK_REALTIME_TRANSCRIPTION_HINT=off|warn|strict`（per Rule 11）
+3. value validation：必須是 ISO-639-1 兩字符代碼或 `"yue"`（Cantonese）
+
+**TDD**：
+1. Pinning：env var 常量名 + 預設模式（`off`）
+2. Off：env=off → language 永遠不發
+3. Warn + invalid value（如 `"zh-CN"` 中橫線）→ 記 warning + 不發
+4. Warn + valid value → 發 hint
+5. Strict + invalid → throw
+6. Golden：env=off + config=null → byte-equiv
+
+**灰度路徑**：
+- staging：取一個 100% Cantonese 場景 assistant，設 `"yue"`
+- prod canary：1 個 assistant 設 `"zh"`，觀察 input transcription completeness rate ≥ 同期未啟用 assistant
+- prod batch：5 個 assistants，1 週
+- prod full：全部
+
+**回滾**：env var → `off`，或清空 entity column（任一即可）
+
+**驗證信號**：
+- input transcription rate（成功識別的 user utterance / total user utterance）→ ≥ 基線 +2%
+- mid-utterance language-switch artifacts（人工抽樣）→ 顯著下降
+
+---
+
+### PR 5.2 — Semantic VAD opt-in
+
+**動機**：`server_vad`（音量門檻）會在用戶說「呃...」「嗯...」這類 filler 時誤判 turn-end → AI 提前接話 → 用戶感覺 AI 「插嘴」。GA 引入 `semantic_vad`（語義邊界判斷）顯著改善。
+
+**修改**：
+- `OpenAiRealtimeAiProviderAdapter.BuildSessionConfig` 在 `audio.input.turn_detection` 構建處：
+  ```csharp
+  turn_detection = BuildTurnDetection(modelConfig)
+
+  private static object BuildTurnDetection(RealtimeAiModelConfig cfg)
+  {
+      // 顯式 type 配置優先
+      if (!string.IsNullOrEmpty(cfg.TurnDetectionType))
+      {
+          return new
+          {
+              type = cfg.TurnDetectionType,
+              threshold = cfg.TurnDetectionThreshold,           // null 時不發
+              silence_duration_ms = cfg.TurnDetectionSilenceMs  // null 時不發
+          };
+      }
+
+      // 既有路徑（保持兼容）
+      return cfg.TurnDetection ?? new { type = "server_vad" };
+  }
+  ```
+
+**默認行為保證**：
+- 當 `TurnDetectionType == null` 時，走原 `cfg.TurnDetection ?? server_vad` 路徑 → byte-equivalent
+- Golden test：`BuildSessionConfig_TurnDetectionTypeNull_FallsBackToFunctionCallConfig`
+
+**Opt-in**：
+- DB `turn_detection_type` = `"semantic_vad"`（或 `"server_vad"` 顯式）
+- env var `SQUID_SMARTTALK_REALTIME_VAD_TYPE=off|warn|strict`
+- value validation：必須 ∈ {`server_vad`, `semantic_vad`}
+
+**TDD**：6 cases（同 5.1 pattern + value validation）
+
+**灰度**：
+- staging：assistant 用 semantic_vad 跑模擬通話（含 filler）
+- prod canary：1 個 assistant，觀察「AI premature interrupt rate」（用戶打斷被觸發後 1s 內又 AI 復原）
+
+**回滾**：env var off
+
+**驗證信號**：interrupt false-positive rate 下降
+
+---
+
+### PR 5.3 — Noise Reduction Config
+
+**動機**：手機通話 vs speakerphone vs Bluetooth 噪聲特徵不同。OpenAI GA 提供 `near_field`（手機緊貼耳，低噪）和 `far_field`（speakerphone，環境噪聲多）兩種 NR profile。
+
+**修改**：
+- adapter 中：
+  ```csharp
+  noise_reduction = BuildNoiseReduction(modelConfig)
+
+  private static object BuildNoiseReduction(RealtimeAiModelConfig cfg)
+  {
+      // 顯式配置優先
+      if (!string.IsNullOrEmpty(cfg.InputNoiseReductionType))
+          return new { type = cfg.InputNoiseReductionType };
+
+      // 既有路徑
+      return cfg.InputAudioNoiseReduction;
+  }
+  ```
+
+**默認行為保證**：當 `InputNoiseReductionType == null` 時走 `cfg.InputAudioNoiseReduction` 原路徑
+
+**Opt-in**：DB 欄位非 null + env var on
+
+**value validation**：∈ {`near_field`, `far_field`}
+
+**TDD**：5 cases
+
+**灰度**：默認 `near_field`（多數場景），speakerphone-heavy 餐廳用 `far_field`
+
+**回滾**：env var off
+
+---
+
+### PR 5.4 — Transcription Model Upgrade
+
+**動機**：whisper-1 已上線多年，gpt-4o-transcribe 是 GA-only 新模型，多語混合準確率高，但**成本 4× 更高**。為 high-value 客戶提供。
+
+**修改**：adapter 中 `transcription.model` 從硬編碼 `"whisper-1"` 改為 `cfg.TranscriptionModel ?? "whisper-1"`
+
+**Opt-in**：DB 欄位 `transcription_model` = `"gpt-4o-transcribe"` + env var
+
+**警告機制**：
+- 啟用 `gpt-4o-transcribe` 時，service log warning：「Assistant {id} using premium transcription model, ~4x cost」
+
+**value validation**：∈ {`whisper-1`, `gpt-4o-transcribe`}
+
+**TDD**：5 cases + cost warning assertion
+
+**灰度**：staging 跑一次完整通話比對 transcription accuracy（人工標註 200 utterance）
+
+**回滾**：env var off → whisper-1
+
+---
+
+### PR 5.5 — Max Response Output Tokens
+
+**動機**：當前無 cap，AI 偶爾「滔滔不絕」獨白 30+ 秒，吃 token 又惹用戶反感。
+
+**修改**：adapter session 物件加：
+```csharp
+max_response_output_tokens = cfg.MaxResponseOutputTokens
+// JSON serializer: null 時不發送該 key
+```
+
+**默認**：`null` → GA server 默認 unlimited
+
+**Opt-in**：DB `max_response_output_tokens` 設整數（推薦 800-1500）
+
+**value validation**：1-4096
+
+**TDD**：4 cases
+
+---
+
+### PR 5.6 — Audio Output Speed
+
+**動機**：elderly 客戶聽不清快語速，年輕客戶嫌慢。GA 提供 `audio.output.speed` 0.25-1.5。
+
+**修改**：adapter `audio.output` 構建處加 speed 欄位（null 時不發）
+
+**Opt-in**：DB `output_audio_speed` = decimal（推薦 0.85-1.15）
+
+**value validation**：0.25 ≤ value ≤ 1.5
+
+**TDD**：4 cases
+
+---
+
+### PR 5.7 — Voice List Extended
+
+**動機**：現有 `model_voice` 是 string 字段，但 UI 只暴露 6 個。GA 新增 marin / cedar 等。
+
+**修改**：
+- 純 enum / validator 擴充：列表加 alloy / ash / ballad / coral / echo / fable / onyx / nova / sage / shimmer / verse / marin / cedar
+- UI 開放剩餘選項
+- 任何當前 voice 仍合法（向前兼容）
+
+**TDD**：13 cases（每個 voice name 一個）
+
+**回滾**：移除新 voice option（UI 層）
+
+---
+
+## Phase 6 — Function Output 類型化（純內部 refactor）
+
+> **Phase 6 全程**對 OpenAI / Twilio / 用戶完全不可見。所有 PR 都用 **golden JSON payload test** 守護「byte-equivalent JSON 輸出」。
+
+### PR 6.1 — Function Output 抽象基類（不替換）
+
+**動機**：當前 function call output 用 anonymous object → 每次 hot path serialize 走 reflection。引入類型化後可 cache serializer，省 5-10% CPU。
+
+**修改**：純加類，**不替換現有 caller**：
+```csharp
+public abstract record FunctionCallOutput { /* common fields */ }
+public sealed record ConfirmOrderOutput(...) : FunctionCallOutput;
+// 暫不修改 caller
+```
+
+**默認行為保證**：caller 仍走 anonymous object，零行為變更
+
+**TDD**：抽象基類序列化 vs 同形狀 anonymous object → 兩者 JSON 一致
+
+---
+
+### PR 6.2-6.7 — 逐 Function 切類型
+
+每個 PR 對應一個 function（Hangup / Confirm / RepeatOrder / TransferCall / ...）：
+1. 改 caller 用新類型
+2. **Golden JSON test**：替換前後 JSON byte-equivalent
+3. 獨立可 revert
+
+**默認行為保證**：每個 PR 一個 function，獨立 golden test，無連鎖風險
+
+**TDD**：每 PR 5-10 cases（覆蓋該 function 所有 output 變化）
+
+**灰度**：staging 跑 1 週，prod 一鍵全切（因 byte-equiv）
+
+---
+
+## Phase 7 — Knowledge Build 性能（**最大冷啟動收益**）
+
+> 當前 `BuildKnowledgeAsync` 順序 await 7 個方法，加起來 ~800ms 冷延遲（首次 AI 回應前）。並行化後 ~200ms。
+
+### PR 7.1 — Fetch / Apply 拆分（純 refactor，零行為變更）
+
+**動機**：把每個 `Resolve*Async` 拆成「純讀（fetch）」+「純改 `_ctx`（apply）」兩部分，使後續可並行 fetch。
+
+**修改**（示意）：
+```csharp
+// Before
+private async Task ResolveGreetingAsync(CancellationToken ct)
+{
+    var greeting = await _someDataProvider.GetGreetingAsync(...);
+    _ctx.Prompt = _ctx.Prompt.Replace("{Greeting}", greeting);
+}
+
+// After
+private async Task<string> FetchGreetingAsync(CancellationToken ct)
+    => await _someDataProvider.GetGreetingAsync(...);
+
+private void ApplyGreeting(string greeting)
+    => _ctx.Prompt = _ctx.Prompt.Replace("{Greeting}", greeting);
+
+// Pipeline 順序不變：
+var greeting = await FetchGreetingAsync(ct);
+ApplyGreeting(greeting);
+// ...
+```
+
+**默認行為保證**：
+- 順序仍為 7 個 fetch + 7 個 apply 嚴格串行
+- 每個 fetch 純讀，無 side effect
+- 每個 apply 純改 `_ctx.Prompt`
+- 對外 `BuildKnowledgeAsync` 簽名與行為完全不變
+
+**TDD**：所有現有 prompt-resolution 集成測試通過（行為等價是核心 invariant）
+
+**回滾**：`git revert`
+
+---
+
+### PR 7.2 — 並行 Fetch（feature flag 默認 off）
+
+**動機**：基於 7.1，所有 fetch 都是純讀，可 Task.WhenAll 並行。
+
+**修改**：
+```csharp
+private async Task BuildKnowledgeAsync(CancellationToken ct)
+{
+    await LoadAssistantInfoAsync(ct);  // 必須先做，後續依賴 _ctx.Assistant
+
+    ResolveStaticPromptVariables();
+
+    if (IsParallelFetchEnabled())
+        await BuildKnowledgeParallelAsync(ct);
+    else
+        await BuildKnowledgeSequentialAsync(ct);
+}
+
+private async Task BuildKnowledgeParallelAsync(CancellationToken ct)
+{
+    var greetingTask = FetchGreetingAsync(ct);
+    var customerItemsTask = FetchCustomerItemsAsync(ct);
+    // ... 6 個並行
+
+    await Task.WhenAll(greetingTask, customerItemsTask, ...);
+
+    // 順序 apply（保證 prompt token 替換順序確定）
+    ApplyGreeting(greetingTask.Result);
+    ApplyCustomerItems(customerItemsTask.Result);
+    // ...
+}
+```
+
+**默認行為保證**：
+- env var `SQUID_SMARTTALK_REALTIME_PARALLEL_KNOWLEDGE_FETCH=off|warn|strict`，**默認 off** → 走順序路徑（PR 7.1 結構）
+- `warn`/`strict` 啟用並行
+- 並行/順序 fetch 結果不變（純讀 DB，無 race）
+- Apply 順序與順序路徑相同（保證 prompt 替換順序確定）
+
+**TDD**：
+1. env=off → 走 sequential，所有現有 test 通過
+2. env=warn → 走 parallel，所有現有 test 通過（行為等價）
+3. golden test：env=off vs env=warn 最終 `_ctx.Prompt` byte-equivalent
+4. cancellation test：傳入已 cancel token，並行路徑也尊重
+
+**灰度**：
+- staging：env=warn，跑 1 週
+- prod canary：1 個 assistant 設 env=warn，量測 p50/p95 BuildKnowledgeAsync 延遲
+- prod batch：全 prod 設 warn，1 週
+- 確認穩定後考慮把 default 改 warn（仍可 env=off 緊急回滾）
+
+**回滾**：env var off → 順序
+
+**驗證信號**：
+- p50 BuildKnowledgeAsync 延遲 800ms → < 250ms
+- 任何「prompt token 未替換」warning 仍為 0
+- 任何 NRE 仍為 0
+
+---
+
+## Phase 8 — Hot-Path Micro-Performance
+
+### PR 8.1 — Prompt Token 單次 Regex
+
+**動機**：當前 `ResolveStaticTokens` + `ResolvePosPromptVariables` 等共做 ~10 次 `string.Replace`，每次 O(n)。改為單次 regex 後 O(n)。
+
+**修改**：
+```csharp
+private static readonly Regex PromptTokenRegex = new(
+    @"\{(\w[\w\d_]*)\}|#\{([\w\d_]+)\}",
+    RegexOptions.Compiled);
+
+public static string ApplyTokens(string prompt, Dictionary<string, string> tokens)
+{
+    return PromptTokenRegex.Replace(prompt, m =>
+    {
+        var key = m.Groups[1].Success ? m.Groups[1].Value : m.Groups[2].Value;
+        return tokens.TryGetValue(key, out var value) ? value : m.Value;  // 找不到保留原樣
+    });
+}
+```
+
+**默認行為保證**：
+- Token map 用同樣 key
+- 找不到 token 保留原 placeholder（與當前 `string.Replace` 行為一致 — 找不到不替換）
+- **Golden test**：用實際 prompt 範本 + 完整 token map 比對 byte-equivalent
+
+**TDD**：
+1. 25 cases（每個 token 一個 + 空 prompt + nested token + escape + 重複 token + 大小寫敏感）
+2. Golden replay：取現有 staging 真實 prompt + token map → byte-equivalent
+
+**回滾**：`git revert`
+
+---
+
+### PR 8.2 — Config Deserialize Cache
+
+**動機**：當前每次 ConnectAsync 都 `JsonConvert.DeserializeObject` Tools / TurnDetection 配置，per-assistant 配置很穩定，可 cache。
+
+**修改**：
+```csharp
+public object DeserializeFunctionCallConfig(int functionCallId, string content)
+{
+    if (!IsCacheEnabled()) return JsonConvert.DeserializeObject<object>(content);
+
+    return _cache.GetOrCreate($"fc:{functionCallId}:{ContentHash(content)}", entry =>
+    {
+        entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(5);
+        return JsonConvert.DeserializeObject<object>(content);
+    });
+}
+```
+
+**默認行為保證**：
+- env var `SQUID_SMARTTALK_REALTIME_CONFIG_CACHE=off|warn|strict`，**默認 off** → 不 cache
+- Cache key 含 content hash → DB 變更後自動失效
+- TTL 5 min → 兜底失效
+
+**TDD**：
+1. cache hit/miss/invalidate 各一
+2. content 變更後新 hash → 重新 deserialize
+3. env=off → 永不 cache
+
+**灰度**：staging 1 週後 prod canary
+
+**回滾**：env var off
+
+---
+
+## Phase 9 — GA 觀察 & 收尾
+
+### PR 9.1 — Sunset Beta Event Names（blocked on 2-week obs）
+
+**前提**：hotfix #934 部署後 ≥ 2 週，prod 日誌顯示 OpenAI 完全只發 GA event name（無 `response.audio.delta` 等舊名）。
+
+**修改**：
+- V1 + V2 adapter 中 4 個事件的 dual-case 改為單 case：
+  ```csharp
+  case "response.audio.delta":  // 刪除這行
+  case "response.output_audio.delta":  // 保留
+  ```
+- V1 inline AiSpeechAssistantService 中對應的 `||` 條件改為單名
+
+**默認行為保證**：
+- 前提是 OpenAI 已不發舊名 → 刪除舊名分支無 user-visible 影響
+- 如果 OpenAI 突然又發舊名（極不可能）→ unknown event，記錄但無實際影響（audio 仍正常）
+
+**TDD**：
+1. 現有 dual-name test 改為單 name（assert 新名 → 預期結果，舊名 → unknown）
+2. 全 32 個 pinning test 通過
+
+**回滾**：`git revert`（恢復雙 case）
+
+---
+
+### PR 9.2 — `session.tracing=auto` Opt-in
+
+**動機**：OpenAI Realtime API GA 提供官方 tracing — 啟用後在 https://platform.openai.com/traces 可看完整 session（30 天保留）。對排查偶發問題、客訴是神器。
+
+**修改**：
+- entity 加 `enable_realtime_tracing` (bool, default false)
+- adapter session 物件加 `tracing` 條件欄位（true 時發 `"auto"`，false 時不發）
+
+**默認**：false → 不發 → 與當前 byte-equivalent
+
+**Opt-in**：DB column = true + env var `SQUID_SMARTTALK_REALTIME_TRACING=off|warn|strict`
+
+**使用場景**：客訴期間單個 assistant 開 tracing → 復現後關閉
+
+**TDD**：3 cases
+
+**回滾**：env var off
+
+---
+
+### PR 9.3 — `response.done.usage` 提取與持久化
+
+**動機**：GA 在 `response.done` 帶 usage 物件包含 input_tokens / output_tokens / cached_tokens 等。實時抓取後可
+- 通話成本即時計算
+- token 異常通話告警
+- 每月成本分析
+
+**修改**：
+1. V2 adapter `ParseMessage` 對 `response.done` 抽取 usage：
+   ```csharp
+   case "response.done":
+       var usage = TryExtractUsage(root);
+       return new ParsedRealtimeAiProviderEvent
+       {
+           Type = RealtimeAiWssEventType.ResponseTurnCompleted,
+           Usage = usage,  // 新欄位
+           RawJson = rawMessage
+       };
+   ```
+2. service 端收到後寫入 `AiSpeechAssistantCallReport.TokensUsed`（新欄位）+ `LastResponseUsageJson`
+
+**默認行為保證**：
+- 純讀取 + 寫新欄位
+- 不影響任何現有事件處理路徑
+- 若 usage 缺失（舊模型），fallback 為 null
+
+**TDD**：
+1. 5 cases：usage 完整 / 缺失 / 部分欄位 / 數字超大 / 0 token
+2. golden：原 `ResponseTurnCompleted` 處理路徑無 regress
+
+**回滾**：`git revert`（新 DB 欄位 NULLABLE，drop 安全）
+
+---
+
+## Phase 10 — Barge-in 正確性（**最高風險，最嚴格灰度**）
+
+> Phase 10 是本輪**唯一直接影響用戶體驗的代碼路徑**。每個 PR 必須有 byte-equivalent 默認路徑 + env flag 啟用新行為。
+
+### PR 10.1 — item_id Tracking（純增量，不影響邏輯）
+
+**動機**：當前 `_aiSpeechAssistantStreamContext.LastAssistantItem` 只記最後一個 item_id，多 audio chunk 場景 truncate 不精確。
+
+**修改**：純增加 tracking，**不改任何邏輯**：
+- `_ctx.ActiveAssistantItems` (new field, `Dictionary<string, ItemState>`)
+- 對每個 `response.audio.delta`：populate `ActiveAssistantItems[itemId]`
+- 對每個 `response.done`：mark item complete
+- **不替換** 現有 `LastAssistantItem`
+
+**默認行為保證**：
+- 現有 truncate 邏輯仍用 `LastAssistantItem`
+- `ActiveAssistantItems` 只記錄不被使用
+- 零行為變更
+
+**TDD**：5 cases 驗證 dict 正確 populate
+
+---
+
+### PR 10.2 — Twilio Mark Queue（純增量，不影響邏輯）
+
+**動機**：當前發 audio.delta 給 Twilio 後不知道客戶端實際播了多少。Twilio 支持 mark event 機制：發 mark 後 Twilio 在播完那個 mark 對應位置時回 mark received。
+
+**修改**：純增加機制，**不改任何邏輯**：
+- 對每個發給 Twilio 的 audio.delta 同時發一個 mark：`{ event: "mark", streamSid: ..., mark: { name: itemId + "-" + chunkSeq } }`
+- 處理 Twilio 端「mark received」回調：更新 `_ctx.PlayedMarks` (new field)
+
+**默認行為保證**：
+- mark 是 Twilio 標準支持的 event，不影響音頻播放
+- `PlayedMarks` 只記不用
+- 零行為變更
+
+**TDD**：4 cases 驗證 mark 發送 + 接收記錄
+
+---
+
+### PR 10.3 — 用 10.1 + 10.2 做精確 Truncate（env flag）
+
+**動機**：基於 10.1 + 10.2 數據，interrupt 時知道客戶端實際聽到了哪個 item 的哪個 chunk → 對 OpenAI 發精確的 `conversation.item.truncate` (audio_end_ms)。
+
+**修改**：
+- 在 speech_started 處理中加分支：
+  ```csharp
+  if (IsPreciseBargeInEnabled())
+      HandleSpeechStartedPrecise();
+  else
+      HandleSpeechStartedLegacy();  // 當前行為
+  ```
+- `HandleSpeechStartedPrecise` 用 `ActiveAssistantItems` + `PlayedMarks` 計算精確 truncate 點
+
+**默認行為保證**：
+- env var `SQUID_SMARTTALK_REALTIME_PRECISE_BARGE_IN=off|warn|strict`，**默認 off** → 走 legacy
+- env=off + 10.1 + 10.2 數據存在但不用 → 與當前 byte-equivalent
+
+**TDD**：
+1. env=off：legacy 路徑（現有 test 全綠）
+2. env=warn：precise 路徑，模擬「用戶在 chunk 3 中打斷」→ truncate 點精確到 chunk 3 audio_end_ms
+3. env=warn + 數據缺失（如 mark 未收到）→ fallback to legacy
+4. golden：env=off vs env=warn 在「無打斷」場景行為 byte-equivalent
+
+**灰度**：
+- staging：env=warn，模擬 barge-in 場景
+- prod canary：1 個低流量 assistant 設 env=warn 1 週
+- 觀察項：
+  - AI repeat-after-interrupt 率（用戶打斷後 AI 再說一遍被打斷的句子）→ 應大幅下降
+  - 任何 truncate-related 錯誤 → 應為 0
+- prod batch / full：分階段
+
+**回滾**：env var off
+
+---
+
+## Phase 11 — Model Migration（最後做，依賴 Phase 5）
+
+### PR 11.1 — gpt-realtime-2 Per-Assistant Override（零風險）
+
+**動機**：`AiSpeechAssistant.ModelUrl` 已支持 per-assistant override。本 PR 純文檔 + UI 開放，**不動 DefaultUrl**。
+
+**修改**：
+- UI 開放 ModelUrl 編輯
+- 文檔說明 1.5 → 2 升級指引
+
+**默認**：DefaultUrl 仍為 1.5
+
+**Opt-in**：UI 設置單個 assistant 的 ModelUrl 為 `wss://api.openai.com/v1/realtime?model=gpt-realtime-2`
+
+**灰度**：1 個 staging assistant → 1 prod canary 1 週 → 多 prod canary → 條件達成後進入 11.2
+
+**回滾**：UI 清空 ModelUrl → 走 DefaultUrl
+
+---
+
+### PR 11.2 — DefaultUrl Flip（blocked on 11.1 success）
+
+**前提**：11.1 已有 ≥ 5 個 prod assistant 用 gpt-realtime-2 跑 ≥ 1 週無 regression。
+
+**修改**：`AiSpeechAssistantStore.DefaultUrl` 改為 `gpt-realtime-2`
+
+**默認行為保證**（**這是 user-visible 行為變更**）：
+- env var `SQUID_SMARTTALK_REALTIME_DEFAULT_MODEL_URL` override 允許運維 pin 回 1.5
+- 任何已設 ModelUrl 的 assistant 不受影響（per-assistant override 優先）
+
+**TDD**：
+1. env var unset → 走 gpt-realtime-2
+2. env var = 1.5 URL → 走 1.5（緊急回滾）
+3. assistant 已設 ModelUrl → 用 assistant 的（不受 default 影響）
+
+**灰度**：deploy 後 24h 嚴密觀察，env var 隨時可回滾
+
+**回滾**：env var 設為 1.5 URL（無需 deploy）
+
+---
+
+## 執行順序總覽
+
+```
+P0.1 (48h obs) ─┬─► P0.2 (#929 close)
+                │
+                ├─► Phase 4.1 ─► 4.2 ─┬─► Phase 5.1 (lang hint)  ─┐
+                │                      ├─► Phase 5.2 (semantic_vad)│
+                │                      ├─► Phase 5.3 (noise)       │
+                │                      ├─► Phase 5.4 (model)       ├─► Phase 11.1 ─► 11.2
+                │                      ├─► Phase 5.5 (max tokens)  │
+                │                      ├─► Phase 5.6 (speed)       │
+                │                      └─► Phase 5.7 (voice)       │
+                │                                                   │
+                ├─► Phase 7.1 ─► 7.2                                │
+                ├─► Phase 8.1                                       │
+                ├─► Phase 8.2                                       │
+                ├─► Phase 6.1 ─► 6.2..6.7                           │
+                ├─► Phase 9.2 + 9.3                                 │
+                ├─► Phase 10.1 ─► 10.2 ─► 10.3                      │
+                │                                                   │
+                └─► (2 weeks after hotfix) Phase 9.1                │
+```
+
+**並行可能**：Phase 5、6、7、8、9.2、9.3、10.1、10.2 各 PR 之間獨立，可並行進行（每個 PR 有自己分支）。
+
+**強串行**：
+- 5.* 需在 4.2 之後
+- 7.2 需在 7.1 之後
+- 6.2-6.7 需在 6.1 之後
+- 10.3 需在 10.1 + 10.2 之後
+- 11.2 需在 11.1 灰度成功之後
+- 9.1 需 2 週 observation
+
+---
+
+## 每個 PR 提交前自我檢查清單（**強制**）
+
+### 默認行為保證
+- [ ] env var 未設 + DB 欄位為 null → 與當前 prod byte-equivalent
+- [ ] Golden JSON / 行為金樣測試已寫
+- [ ] 現有所有 unit + integration test 通過
+
+### 安全機制
+- [ ] env var 名稱常量 pinning test (Rule 8)
+- [ ] 3-mode (off/warn/strict) 已實現 (Rule 11)
+- [ ] env var 默認值是「off」或「保持當前行為」
+- [ ] 文檔提到 5 分鐘回滾命令
+
+### 代碼品質
+- [ ] 方法簽名單行（Rule 1）
+- [ ] `.ConfigureAwait(false)` 同行（Rule 2）
+- [ ] 方法 ≤ 25 行 / 50 行絕對上限（Rule 3）
+- [ ] 主管線扁平（Rule 4）
+- [ ] 邏輯塊間有空行（Rule 5）
+
+### 測試
+- [ ] Unit + Integration 雙層覆蓋（Rule 9）
+- [ ] 4 cases 至少：default-path / opt-in valid / opt-in invalid / opt-in invalid + strict throw
+
+### 文檔
+- [ ] PR description 含「默認行為保證」段落
+- [ ] PR description 含「回滾命令」一行
+- [ ] tracking 表格狀態更新
+- [ ] 新 env var 同步至 `V2_ROLLOUT_PLAYBOOK.md`
+- [ ] Retrospective 段填寫
+
+### 灰度路徑
+- [ ] dev / staging / prod canary / prod batch / prod full 路徑明確
+- [ ] 每階段觀察項與門檻量化
+- [ ] 灰度監測指標已對應 dashboard
+
+---
+
+## Retrospective（每個 PR 合併後填寫，逐個追加）
+
+> 先留空，每個 PR 完成後追加一個段落。

--- a/src/SmartTalk.Core/DbUpFile/Scripts_2026/Script0007_add_realtime_config_fields_to_ai_speech_assistant.sql
+++ b/src/SmartTalk.Core/DbUpFile/Scripts_2026/Script0007_add_realtime_config_fields_to_ai_speech_assistant.sql
@@ -1,0 +1,22 @@
+-- Phase 4.1 of Round 2 V2 stability & perf rollout.
+-- All columns NULLABLE; null means "use the same default as today, no behavior change".
+-- These columns are only READ when both (a) the column is non-null AND (b) the matching
+-- env var (introduced in Phase 4.2) is not 'off'. Until Phase 4.2 ships, this migration
+-- is a pure schema add and produces zero behaviour change in production.
+--
+-- No `AFTER` clauses: column placement in the table layout is cosmetic, and including
+-- `AFTER` forces MySQL to use ALGORITHM=COPY (full table rebuild + write lock for the
+-- duration of the copy) on 5.7, and prevents ALGORITHM=INSTANT (metadata-only, no
+-- table touch) on 8.0+. Without `AFTER`, 8.0+ adds these columns instantly and 5.7
+-- can use ALGORITHM=INPLACE. The `ai_speech_assistant` table is config-scale so the
+-- impact is bounded either way, but the change is preventive — applies to any future
+-- migration this pattern is copied to.
+ALTER TABLE ai_speech_assistant
+    ADD COLUMN `transcription_model`         VARCHAR(64)    NULL,
+    ADD COLUMN `transcription_language`      VARCHAR(8)     NULL,
+    ADD COLUMN `turn_detection_type`         VARCHAR(32)    NULL,
+    ADD COLUMN `turn_detection_threshold`    DECIMAL(4, 3)  NULL,
+    ADD COLUMN `turn_detection_silence_ms`   INT            NULL,
+    ADD COLUMN `input_noise_reduction_type`  VARCHAR(32)    NULL,
+    ADD COLUMN `max_response_output_tokens`  INT            NULL,
+    ADD COLUMN `output_audio_speed`          DECIMAL(3, 2)  NULL;

--- a/src/SmartTalk.Core/Domain/AISpeechAssistant/AiSpeechAssistant.cs
+++ b/src/SmartTalk.Core/Domain/AISpeechAssistant/AiSpeechAssistant.cs
@@ -39,7 +39,38 @@ public class AiSpeechAssistant : IEntity<int>, IAgent, IHasCreatedFields
     
     [Column("model_voice")]
     public string ModelVoice { get; set; }
-    
+
+    // ── Realtime API GA session-config knobs (Phase 4.1 of Round 2 rollout) ───────
+    // All NULLABLE. NULL means "use the same hard-coded default as today" — these
+    // fields are only consumed in Phase 4.2+ when the matching env var is non-off.
+    // Until then this is a pure schema add and the runtime path is unchanged.
+
+    [Column("transcription_model"), StringLength(64)]
+    public string TranscriptionModel { get; set; }
+
+    [Column("transcription_language"), StringLength(8)]
+    public string TranscriptionLanguage { get; set; }
+
+    [Column("turn_detection_type"), StringLength(32)]
+    public string TurnDetectionType { get; set; }
+
+    [Column("turn_detection_threshold")]
+    public decimal? TurnDetectionThreshold { get; set; }
+
+    [Column("turn_detection_silence_ms")]
+    public int? TurnDetectionSilenceMs { get; set; }
+
+    [Column("input_noise_reduction_type"), StringLength(32)]
+    public string InputNoiseReductionType { get; set; }
+
+    [Column("max_response_output_tokens")]
+    public int? MaxResponseOutputTokens { get; set; }
+
+    [Column("output_audio_speed")]
+    public decimal? OutputAudioSpeed { get; set; }
+
+    // ─────────────────────────────────────────────────────────────────────────────
+
     [Column("agent_id")]
     public int AgentId { get; set; }
     

--- a/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectService.Build.Session.cs
+++ b/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectService.Build.Session.cs
@@ -32,7 +32,20 @@ public partial class AiSpeechAssistantConnectService
                     .Select(x => JsonConvert.DeserializeObject<object>(x.Content))
                     .ToList(),
                 TurnDetection = DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.TurnDirection),
-                InputAudioNoiseReduction = DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.InputAudioNoiseReduction)
+                InputAudioNoiseReduction = DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.InputAudioNoiseReduction),
+
+                // Per-assistant GA config overrides (Phase 4.2 of Round 2). NULL passthrough is
+                // load-bearing — adapter null-checks each field individually before changing the
+                // outbound payload, so an assistant with all-null config stays byte-equivalent
+                // to today's session.update output.
+                TranscriptionModel       = assistant.TranscriptionModel,
+                TranscriptionLanguage    = assistant.TranscriptionLanguage,
+                TurnDetectionType        = assistant.TurnDetectionType,
+                TurnDetectionThreshold   = assistant.TurnDetectionThreshold,
+                TurnDetectionSilenceMs   = assistant.TurnDetectionSilenceMs,
+                InputNoiseReductionType  = assistant.InputNoiseReductionType,
+                MaxResponseOutputTokens  = assistant.MaxResponseOutputTokens,
+                OutputAudioSpeed         = assistant.OutputAudioSpeed
             },
             ConnectionProfile = new RealtimeAiConnectionProfile
             {

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Providers/OpenAi/OpenAiRealtimeAiProviderAdapter.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Providers/OpenAi/OpenAiRealtimeAiProviderAdapter.cs
@@ -5,6 +5,7 @@ using SmartTalk.Core.Settings.OpenAi;
 using SmartTalk.Messages.Dto.RealtimeAi;
 using SmartTalk.Messages.Enums.AiSpeechAssistant;
 using SmartTalk.Messages.Enums.RealtimeAi;
+using SmartTalk.Messages.Hardening;
 using JsonException = System.Text.Json.JsonException;
 using JsonSerializer = System.Text.Json.JsonSerializer;
 
@@ -12,6 +13,20 @@ namespace SmartTalk.Core.Services.RealtimeAiV2.Adapters.Providers.OpenAi;
 
 public class OpenAiRealtimeAiProviderAdapter : IRealtimeAiProviderAdapter
 {
+    /// <summary>
+    /// Env var that gates per-assistant Realtime API session-config overrides
+    /// (Phase 4.2 of the Round 2 stability rollout). Default mode is
+    /// <see cref="EnforcementMode.Off"/> — until an operator flips this to
+    /// <c>warn</c> or <c>strict</c>, the adapter ignores every per-assistant
+    /// override field and emits the same JSON it does today (byte-equivalent).
+    ///
+    /// <para>
+    /// Renaming this constant breaks every air-gapped operator who pinned this
+    /// flag via env. The literal value is hard-pinned in unit tests (Rule 8).
+    /// </para>
+    /// </summary>
+    public const string AssistantConfigEnforcementEnvVar = "SQUID_SMARTTALK_REALTIME_ASSISTANT_CONFIG_ENFORCEMENT";
+
     private readonly OpenAiSettings _openAiSettings;
 
     public OpenAiRealtimeAiProviderAdapter(OpenAiSettings openAiSettings)
@@ -35,6 +50,7 @@ public class OpenAiRealtimeAiProviderAdapter : IRealtimeAiProviderAdapter
     public object BuildSessionConfig(RealtimeSessionOptions options, RealtimeAiAudioCodec clientCodec)
     {
         var modelConfig = options.ModelConfig;
+        var useOverrides = AreAssistantConfigOverridesEnabled();
 
         // GA session.update payload (post 2026-05-07):
         // - new required `session.type` field ("realtime" | "transcription")
@@ -43,6 +59,12 @@ public class OpenAiRealtimeAiProviderAdapter : IRealtimeAiProviderAdapter
         // - `modalities` → `output_modalities`; `temperature` field dropped
         // Reference: https://platform.openai.com/docs/guides/realtime
         // Canonical sample: https://github.com/twilio-samples/speech-assistant-openai-realtime-api-python
+        //
+        // Phase 4.2 contract: when `useOverrides` is false (env var = off, the default),
+        // every helper below emits exactly the same shape as before, and the additional
+        // session-level fields are null. The outer JsonSerializerSettings.NullValueHandling.Ignore
+        // (RealtimeAiService.Connect.cs:23) then strips those nulls, leaving the payload
+        // byte-equivalent to the pre-4.2 output. Pin tests cover both modes.
         return new
         {
             type = "session.update",
@@ -51,24 +73,82 @@ public class OpenAiRealtimeAiProviderAdapter : IRealtimeAiProviderAdapter
                 type = "realtime",
                 instructions = modelConfig.Prompt,
                 output_modalities = new[] { "audio" },
+                max_response_output_tokens = useOverrides ? modelConfig.MaxResponseOutputTokens : null,
                 audio = new
                 {
                     input = new
                     {
                         format = ConvertCodecToGaFormat(clientCodec),
-                        transcription = new { model = "whisper-1" },
-                        turn_detection = modelConfig.TurnDetection ?? new { type = "server_vad" },
-                        noise_reduction = modelConfig.InputAudioNoiseReduction
+                        transcription = BuildTranscriptionConfig(modelConfig, useOverrides),
+                        turn_detection = BuildTurnDetection(modelConfig, useOverrides),
+                        noise_reduction = BuildNoiseReduction(modelConfig, useOverrides)
                     },
                     output = new
                     {
                         format = ConvertCodecToGaFormat(clientCodec),
-                        voice = string.IsNullOrEmpty(modelConfig.Voice) ? "alloy" : modelConfig.Voice
+                        voice = string.IsNullOrEmpty(modelConfig.Voice) ? "alloy" : modelConfig.Voice,
+                        speed = useOverrides ? modelConfig.OutputAudioSpeed : null
                     }
                 },
                 tools = modelConfig.Tools.Any() ? modelConfig.Tools : null
             }
         };
+    }
+
+    /// <summary>
+    /// Reads the assistant-config enforcement env var and returns true when overrides
+    /// should be honoured. <see cref="EnforcementMode.Off"/> (the default) → false, which
+    /// keeps the outbound session payload byte-equivalent to pre-Phase-4.2.
+    /// </summary>
+    private static bool AreAssistantConfigOverridesEnabled() =>
+        EnforcementModeReader.Read(AssistantConfigEnforcementEnvVar, EnforcementMode.Off) != EnforcementMode.Off;
+
+    /// <summary>
+    /// Builds the <c>audio.input.transcription</c> object. When overrides are disabled,
+    /// returns the exact pre-4.2 shape (<c>{ model = "whisper-1" }</c>) so the JSON is
+    /// byte-equivalent. When enabled, allows per-assistant model override and emits an
+    /// optional <c>language</c> hint (omitted via NullValueHandling.Ignore when null).
+    /// </summary>
+    private static object BuildTranscriptionConfig(RealtimeAiModelConfig cfg, bool useOverrides)
+    {
+        if (!useOverrides)
+            return new { model = "whisper-1" };
+
+        var model = string.IsNullOrEmpty(cfg.TranscriptionModel) ? "whisper-1" : cfg.TranscriptionModel;
+
+        return new { model, language = cfg.TranscriptionLanguage };
+    }
+
+    /// <summary>
+    /// Builds the <c>audio.input.turn_detection</c> object. When overrides are disabled
+    /// OR the assistant has no explicit type override, returns the pre-4.2 fallback
+    /// (<c>modelConfig.TurnDetection ?? { type = "server_vad" }</c>) — preserving every
+    /// existing function-call-based turn-detection configuration on every assistant.
+    /// </summary>
+    private static object BuildTurnDetection(RealtimeAiModelConfig cfg, bool useOverrides)
+    {
+        if (!useOverrides || string.IsNullOrEmpty(cfg.TurnDetectionType))
+            return cfg.TurnDetection ?? new { type = "server_vad" };
+
+        return new
+        {
+            type = cfg.TurnDetectionType,
+            threshold = cfg.TurnDetectionThreshold,
+            silence_duration_ms = cfg.TurnDetectionSilenceMs
+        };
+    }
+
+    /// <summary>
+    /// Builds the <c>audio.input.noise_reduction</c> object. When overrides are disabled
+    /// OR the assistant has no explicit type override, returns the pre-4.2 fallback
+    /// (<c>modelConfig.InputAudioNoiseReduction</c>) — which may itself be null.
+    /// </summary>
+    private static object BuildNoiseReduction(RealtimeAiModelConfig cfg, bool useOverrides)
+    {
+        if (!useOverrides || string.IsNullOrEmpty(cfg.InputNoiseReductionType))
+            return cfg.InputAudioNoiseReduction;
+
+        return new { type = cfg.InputNoiseReductionType };
     }
 
     /// <summary>

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/RealtimeSessionOptions.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/RealtimeSessionOptions.cs
@@ -61,6 +61,60 @@ public class RealtimeAiModelConfig
     /// OpenAI-specific input audio noise reduction configuration. Ignored by other providers.
     /// </summary>
     public object InputAudioNoiseReduction { get; set; }
+
+    // ── Realtime API GA per-assistant config overrides (Phase 4.2 of Round 2) ────
+    // All NULLABLE. NULL means "fall back to today's default branch in the adapter".
+    // A non-null value is only honoured when
+    // `SQUID_SMARTTALK_REALTIME_ASSISTANT_CONFIG_ENFORCEMENT != off`.
+    // See `OpenAiRealtimeAiProviderAdapter.BuildSessionConfig` for the precise
+    // null-vs-value branching contract.
+
+    /// <summary>
+    /// OpenAI transcription model. <c>null</c> → adapter default (<c>whisper-1</c>).
+    /// Non-null values are not validated here; the adapter applies whichever value
+    /// the operator configured. Phase 5.4 adds value validation.
+    /// </summary>
+    public string TranscriptionModel { get; set; }
+
+    /// <summary>
+    /// OpenAI transcription language hint (ISO-639-1 or <c>"yue"</c>).
+    /// <c>null</c> → field omitted from the payload (today's behaviour). Phase 5.1
+    /// adds value validation.
+    /// </summary>
+    public string TranscriptionLanguage { get; set; }
+
+    /// <summary>
+    /// Explicit turn-detection type override (<c>server_vad</c> / <c>semantic_vad</c>).
+    /// <c>null</c> → adapter falls back to <see cref="TurnDetection"/> or
+    /// <c>{ type = "server_vad" }</c>. Phase 5.2 adds value validation.
+    /// </summary>
+    public string TurnDetectionType { get; set; }
+
+    /// <summary>
+    /// Turn-detection threshold (0.0–1.0). <c>null</c> → field omitted.
+    /// </summary>
+    public decimal? TurnDetectionThreshold { get; set; }
+
+    /// <summary>
+    /// Turn-detection silence duration in milliseconds. <c>null</c> → field omitted.
+    /// </summary>
+    public int? TurnDetectionSilenceMs { get; set; }
+
+    /// <summary>
+    /// Input noise-reduction profile (<c>near_field</c> / <c>far_field</c>).
+    /// <c>null</c> → adapter falls back to <see cref="InputAudioNoiseReduction"/>.
+    /// </summary>
+    public string InputNoiseReductionType { get; set; }
+
+    /// <summary>
+    /// Maximum response output tokens. <c>null</c> → field omitted (GA server default).
+    /// </summary>
+    public int? MaxResponseOutputTokens { get; set; }
+
+    /// <summary>
+    /// Output audio playback speed (0.25–1.5). <c>null</c> → field omitted (1.0 default).
+    /// </summary>
+    public decimal? OutputAudioSpeed { get; set; }
 }
 
 /// <summary>

--- a/src/SmartTalk.IntegrationTests/Services/AiSpeechAssistant/AiSpeechAssistantConnectFixture.RealtimeConfigPersistence.cs
+++ b/src/SmartTalk.IntegrationTests/Services/AiSpeechAssistant/AiSpeechAssistantConnectFixture.RealtimeConfigPersistence.cs
@@ -1,0 +1,164 @@
+using Shouldly;
+using SmartTalk.Core.Data;
+using SmartTalk.Core.Domain.AISpeechAssistant;
+using SmartTalk.Messages.Enums.RealtimeAi;
+using Xunit;
+
+namespace SmartTalk.IntegrationTests.Services.AiSpeechAssistant;
+
+/// <summary>
+/// Integration coverage for the Phase 4.1 NULLABLE Realtime API session-config columns
+/// added in <c>Script0007_add_realtime_config_fields_to_ai_speech_assistant.sql</c>.
+///
+/// <para>
+/// These tests pin the persistence contract: NULL values must round-trip as NULL (the
+/// load-bearing invariant for "default = today's behaviour" through Phase 5+), and
+/// every value type must persist + read back identically across the EF Core ↔ MySQL
+/// boundary. Decimal precision in particular is fragile — <c>turn_detection_threshold</c>
+/// is <c>DECIMAL(4,3)</c> and <c>output_audio_speed</c> is <c>DECIMAL(3,2)</c>; a
+/// schema-CLR precision mismatch would silently truncate operator-configured values.
+/// </para>
+/// </summary>
+public partial class AiSpeechAssistantConnectFixture
+{
+    [Fact]
+    public async Task ShouldPersistRealtimeConfig_AllNull_RoundTripsAsNull()
+    {
+        // The load-bearing invariant: fresh rows (no operator config) must round-trip
+        // every new column as NULL — Phase 4.2 logic treats NULL as "use today's default".
+        // If any column coerced to a non-null default on persist, Phase 5+ would activate
+        // opt-in behaviour for every existing prod assistant on Phase 4.2 deploy.
+        int assistantId = 0;
+
+        await RunWithUnitOfWork<IRepository, IUnitOfWork>(async (repository, unitOfWork) =>
+        {
+            var assistant = new Core.Domain.AISpeechAssistant.AiSpeechAssistant
+            {
+                Name = "ConfigNullAssistant",
+                AnsweringNumber = TestDidNumber,
+                ModelProvider = RealtimeAiProvider.OpenAi,
+                ModelVoice = "alloy",
+                IsDefault = true,
+                IsDisplay = true
+            };
+
+            await repository.InsertAsync(assistant);
+            await unitOfWork.SaveChangesAsync();
+
+            assistantId = assistant.Id;
+        });
+
+        await Run<IRepository>(async repository =>
+        {
+            var persisted = await repository.GetByIdAsync<Core.Domain.AISpeechAssistant.AiSpeechAssistant>(assistantId);
+
+            persisted.ShouldNotBeNull();
+            persisted.TranscriptionModel.ShouldBeNull();
+            persisted.TranscriptionLanguage.ShouldBeNull();
+            persisted.TurnDetectionType.ShouldBeNull();
+            persisted.TurnDetectionThreshold.ShouldBeNull();
+            persisted.TurnDetectionSilenceMs.ShouldBeNull();
+            persisted.InputNoiseReductionType.ShouldBeNull();
+            persisted.MaxResponseOutputTokens.ShouldBeNull();
+            persisted.OutputAudioSpeed.ShouldBeNull();
+        });
+    }
+
+    [Fact]
+    public async Task ShouldPersistRealtimeConfig_AllPopulated_RoundTripsValuesIdentically()
+    {
+        // Values chosen to stress decimal precision boundaries:
+        //   turn_detection_threshold (DECIMAL(4,3)) → 0.500 — 3 fractional digits exactly
+        //   output_audio_speed       (DECIMAL(3,2)) → 1.15  — 2 fractional digits at upper UX range
+        // A truncation here would corrupt operator config silently.
+        int assistantId = 0;
+
+        await RunWithUnitOfWork<IRepository, IUnitOfWork>(async (repository, unitOfWork) =>
+        {
+            var assistant = new Core.Domain.AISpeechAssistant.AiSpeechAssistant
+            {
+                Name = "ConfigPopulatedAssistant",
+                AnsweringNumber = TestDidNumber,
+                ModelProvider = RealtimeAiProvider.OpenAi,
+                ModelVoice = "alloy",
+                IsDefault = true,
+                IsDisplay = true,
+                TranscriptionModel = "gpt-4o-transcribe",
+                TranscriptionLanguage = "yue",
+                TurnDetectionType = "semantic_vad",
+                TurnDetectionThreshold = 0.500m,
+                TurnDetectionSilenceMs = 700,
+                InputNoiseReductionType = "near_field",
+                MaxResponseOutputTokens = 1200,
+                OutputAudioSpeed = 1.15m
+            };
+
+            await repository.InsertAsync(assistant);
+            await unitOfWork.SaveChangesAsync();
+
+            assistantId = assistant.Id;
+        });
+
+        await Run<IRepository>(async repository =>
+        {
+            var persisted = await repository.GetByIdAsync<Core.Domain.AISpeechAssistant.AiSpeechAssistant>(assistantId);
+
+            persisted.ShouldNotBeNull();
+            persisted.TranscriptionModel.ShouldBe("gpt-4o-transcribe");
+            persisted.TranscriptionLanguage.ShouldBe("yue");
+            persisted.TurnDetectionType.ShouldBe("semantic_vad");
+            persisted.TurnDetectionThreshold.ShouldBe(0.500m);
+            persisted.TurnDetectionSilenceMs.ShouldBe(700);
+            persisted.InputNoiseReductionType.ShouldBe("near_field");
+            persisted.MaxResponseOutputTokens.ShouldBe(1200);
+            persisted.OutputAudioSpeed.ShouldBe(1.15m);
+        });
+    }
+
+    [Fact]
+    public async Task ShouldPersistRealtimeConfig_PartialPopulation_OnlyPopulatedFieldsRetained()
+    {
+        // The realistic operator pattern: set ONE knob (e.g. just the language hint)
+        // and leave the rest at default. Pin that mixed null + non-null state survives
+        // the persistence round-trip, because mixed state is what every Phase 5+ canary
+        // assistant will look like in prod.
+        int assistantId = 0;
+
+        await RunWithUnitOfWork<IRepository, IUnitOfWork>(async (repository, unitOfWork) =>
+        {
+            var assistant = new Core.Domain.AISpeechAssistant.AiSpeechAssistant
+            {
+                Name = "ConfigPartialAssistant",
+                AnsweringNumber = TestDidNumber,
+                ModelProvider = RealtimeAiProvider.OpenAi,
+                ModelVoice = "alloy",
+                IsDefault = true,
+                IsDisplay = true,
+                TranscriptionLanguage = "zh"        // only the lang hint is set
+            };
+
+            await repository.InsertAsync(assistant);
+            await unitOfWork.SaveChangesAsync();
+
+            assistantId = assistant.Id;
+        });
+
+        await Run<IRepository>(async repository =>
+        {
+            var persisted = await repository.GetByIdAsync<Core.Domain.AISpeechAssistant.AiSpeechAssistant>(assistantId);
+
+            persisted.ShouldNotBeNull();
+            persisted.TranscriptionLanguage.ShouldBe("zh");
+
+            // Every other knob stays NULL — Phase 4.2 must continue to treat this
+            // assistant as "default behaviour for everything except language hint".
+            persisted.TranscriptionModel.ShouldBeNull();
+            persisted.TurnDetectionType.ShouldBeNull();
+            persisted.TurnDetectionThreshold.ShouldBeNull();
+            persisted.TurnDetectionSilenceMs.ShouldBeNull();
+            persisted.InputNoiseReductionType.ShouldBeNull();
+            persisted.MaxResponseOutputTokens.ShouldBeNull();
+            persisted.OutputAudioSpeed.ShouldBeNull();
+        });
+    }
+}

--- a/src/SmartTalk.Messages/Dto/AiSpeechAssistant/AiSpeechAssistantDto.cs
+++ b/src/SmartTalk.Messages/Dto/AiSpeechAssistant/AiSpeechAssistantDto.cs
@@ -26,6 +26,29 @@ public class AiSpeechAssistantDto
     public string ModelVoice { get; set; }
 
     public string ModelLanguage { get; set; }
+
+    // ── Realtime API GA session-config knobs (Phase 4.2 of Round 2 rollout) ───────
+    // All NULLABLE. NULL means "use today's hard-coded default". A non-null value
+    // combined with `SQUID_SMARTTALK_REALTIME_ASSISTANT_CONFIG_ENFORCEMENT != off`
+    // (read by the adapter) activates the per-assistant override.
+
+    public string TranscriptionModel { get; set; }
+
+    public string TranscriptionLanguage { get; set; }
+
+    public string TurnDetectionType { get; set; }
+
+    public decimal? TurnDetectionThreshold { get; set; }
+
+    public int? TurnDetectionSilenceMs { get; set; }
+
+    public string InputNoiseReductionType { get; set; }
+
+    public int? MaxResponseOutputTokens { get; set; }
+
+    public decimal? OutputAudioSpeed { get; set; }
+
+    // ─────────────────────────────────────────────────────────────────────────────
     
     public string CustomRecordAnalyzePrompt { get; set; }
     

--- a/src/SmartTalk.Messages/Hardening/EnforcementMode.cs
+++ b/src/SmartTalk.Messages/Hardening/EnforcementMode.cs
@@ -1,0 +1,29 @@
+namespace SmartTalk.Messages.Hardening;
+
+/// <summary>
+/// Three-mode enforcement for hardening checks (Rule 11 of the project style guide).
+/// Every safety/correctness check that could break existing deploys if it became the
+/// default reads its mode from a single env var. The default in code is <see cref="Warn"/>,
+/// preserving backward compatibility while surfacing the tech debt in structured logs.
+/// </summary>
+public enum EnforcementMode
+{
+    /// <summary>
+    /// Silent allow. The check does not run; invalid values pass through with no log.
+    /// Reserved for dev, tests, and explicit operator opt-out / emergency rollback.
+    /// </summary>
+    Off,
+
+    /// <summary>
+    /// Allow with structured warning. Invalid values pass through but emit a Serilog
+    /// warning naming both the offending value and the env-var name needed to switch
+    /// to <see cref="Strict"/>. Used as the default to preserve backward compatibility.
+    /// </summary>
+    Warn,
+
+    /// <summary>
+    /// Reject (throw) with an actionable error message. Operators opt in for production
+    /// hardening; a future major release flips this to the default.
+    /// </summary>
+    Strict
+}

--- a/src/SmartTalk.Messages/Hardening/EnforcementModeReader.cs
+++ b/src/SmartTalk.Messages/Hardening/EnforcementModeReader.cs
@@ -1,0 +1,42 @@
+namespace SmartTalk.Messages.Hardening;
+
+/// <summary>
+/// Parses a single env var into <see cref="EnforcementMode"/>. Accepts the canonical
+/// names (<c>off</c>, <c>warn</c>, <c>strict</c>) plus a small set of operator-friendly
+/// aliases that map to the same mode.
+///
+/// <para>
+/// Air-gapped / fork operators need to be able to flip one env var to change behaviour
+/// without redeploying code. The single-env-var contract is what makes that possible —
+/// changing the env-var name in code is a hard-pinned compile-time decision (Rule 8).
+/// </para>
+/// </summary>
+public static class EnforcementModeReader
+{
+    /// <summary>
+    /// Reads the env var named <paramref name="envVarName"/> and returns the matching
+    /// <see cref="EnforcementMode"/>. Unrecognised or unset values return
+    /// <paramref name="defaultMode"/> (defaulting to <see cref="EnforcementMode.Warn"/>
+    /// per Rule 11 — Warn preserves backward compatibility).
+    /// </summary>
+    public static EnforcementMode Read(string envVarName, EnforcementMode defaultMode = EnforcementMode.Warn)
+    {
+        var raw = Environment.GetEnvironmentVariable(envVarName);
+
+        if (string.IsNullOrWhiteSpace(raw)) return defaultMode;
+
+        return Parse(raw.Trim(), defaultMode);
+    }
+
+    /// <summary>
+    /// Pure parser exposed for unit testability. Same aliases as <see cref="Read"/>.
+    /// </summary>
+    public static EnforcementMode Parse(string raw, EnforcementMode defaultMode = EnforcementMode.Warn) =>
+        raw.ToLowerInvariant() switch
+        {
+            "off" or "disabled" or "0" or "false" or "no" => EnforcementMode.Off,
+            "warn" or "warning"                            => EnforcementMode.Warn,
+            "strict" or "enforce" or "1" or "true" or "yes" => EnforcementMode.Strict,
+            _                                              => defaultMode
+        };
+}

--- a/src/SmartTalk.UnitTests/Domain/AISpeechAssistant/AiSpeechAssistantRealtimeConfigPinningTests.cs
+++ b/src/SmartTalk.UnitTests/Domain/AISpeechAssistant/AiSpeechAssistantRealtimeConfigPinningTests.cs
@@ -1,0 +1,86 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Reflection;
+using Shouldly;
+using SmartTalk.Core.Domain.AISpeechAssistant;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Domain.AISpeechAssistant;
+
+/// <summary>
+/// Pins the column-name strings and CLR types of every Realtime API session-config
+/// property added in Phase 4.1 of the Round 2 stability rollout. These properties
+/// map 1:1 to NULLABLE columns in the <c>ai_speech_assistant</c> table; renaming
+/// either side desynchronises them and silently breaks per-assistant configuration
+/// (Phase 5+) for every row that has a non-null value.
+///
+/// <para>
+/// All properties MUST be nullable reference types (<c>string</c>) or nullable
+/// value types (<c>int?</c>, <c>decimal?</c>) — a non-nullable type here would
+/// silently coerce a NULL DB column to the default (0 / "") and a default would
+/// then be treated by Phase 4.2 adapter logic as an opt-in value, changing the
+/// outbound session.update payload for every existing assistant. NULLABLE is
+/// load-bearing — pin it.
+/// </para>
+///
+/// <para>
+/// A failure on this test means a renamed property or a flipped nullability —
+/// either is a production-grade incident if it merges. Fix the rename, do not
+/// edit this test to match.
+/// </para>
+/// </summary>
+public class AiSpeechAssistantRealtimeConfigPinningTests
+{
+    [Theory]
+    [InlineData(nameof(AiSpeechAssistant.TranscriptionModel),        "transcription_model",        typeof(string),   true)]
+    [InlineData(nameof(AiSpeechAssistant.TranscriptionLanguage),     "transcription_language",     typeof(string),   true)]
+    [InlineData(nameof(AiSpeechAssistant.TurnDetectionType),         "turn_detection_type",        typeof(string),   true)]
+    [InlineData(nameof(AiSpeechAssistant.TurnDetectionThreshold),    "turn_detection_threshold",   typeof(decimal), false)]
+    [InlineData(nameof(AiSpeechAssistant.TurnDetectionSilenceMs),    "turn_detection_silence_ms",  typeof(int),     false)]
+    [InlineData(nameof(AiSpeechAssistant.InputNoiseReductionType),   "input_noise_reduction_type", typeof(string),   true)]
+    [InlineData(nameof(AiSpeechAssistant.MaxResponseOutputTokens),   "max_response_output_tokens", typeof(int),     false)]
+    [InlineData(nameof(AiSpeechAssistant.OutputAudioSpeed),          "output_audio_speed",         typeof(decimal), false)]
+    public void RealtimeConfigProperty_HasExpectedColumnNameAndNullableType(
+        string propertyName, string expectedColumnName, Type underlyingType, bool isReferenceType)
+    {
+        var property = typeof(AiSpeechAssistant).GetProperty(propertyName, BindingFlags.Public | BindingFlags.Instance);
+
+        property.ShouldNotBeNull($"Property {propertyName} was removed or renamed; Phase 5+ adapter wiring will break silently");
+
+        var columnAttribute = property!.GetCustomAttribute<ColumnAttribute>();
+        columnAttribute.ShouldNotBeNull($"Property {propertyName} lost its [Column] attribute — DB mapping will fall back to PascalCase and break the migration contract");
+        columnAttribute!.Name.ShouldBe(expectedColumnName, $"Property {propertyName} column-name pin changed; DB column and CLR property are now desynchronised");
+
+        // Nullable contract: value types must be Nullable<T>, reference types must allow null.
+        // A regression here is a behavioural break: a NULL DB column would coerce to the default
+        // (0 / "") and Phase 4.2 logic would treat that as an opt-in value.
+        if (isReferenceType)
+        {
+            property.PropertyType.ShouldBe(underlyingType, $"Property {propertyName} type changed from a reference type; nullable contract broken");
+        }
+        else
+        {
+            var expectedNullableType = typeof(Nullable<>).MakeGenericType(underlyingType);
+            property.PropertyType.ShouldBe(expectedNullableType, $"Property {propertyName} lost its Nullable<{underlyingType.Name}> wrapper — DB NULL will now coerce to default value, breaking the zero-behaviour-change contract");
+        }
+    }
+
+    [Fact]
+    public void RealtimeConfigProperties_DefaultValueIsNull()
+    {
+        // Constructing a fresh entity must leave every new config property at null —
+        // otherwise existing prod rows (no migration backfill) would be indistinguishable
+        // from "operator set this value" and Phase 4.2 logic would change session.update
+        // shape for every assistant. This is the load-bearing invariant for the entire
+        // Round 2 rollout: NULL means "behave exactly like today".
+        var assistant = new AiSpeechAssistant();
+
+        assistant.TranscriptionModel.ShouldBeNull();
+        assistant.TranscriptionLanguage.ShouldBeNull();
+        assistant.TurnDetectionType.ShouldBeNull();
+        assistant.TurnDetectionThreshold.ShouldBeNull();
+        assistant.TurnDetectionSilenceMs.ShouldBeNull();
+        assistant.InputNoiseReductionType.ShouldBeNull();
+        assistant.MaxResponseOutputTokens.ShouldBeNull();
+        assistant.OutputAudioSpeed.ShouldBeNull();
+    }
+}

--- a/src/SmartTalk.UnitTests/Hardening/EnforcementModeReaderTests.cs
+++ b/src/SmartTalk.UnitTests/Hardening/EnforcementModeReaderTests.cs
@@ -1,0 +1,94 @@
+using Shouldly;
+using SmartTalk.Messages.Hardening;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Hardening;
+
+/// <summary>
+/// Pins the parsing contract of <see cref="EnforcementModeReader"/>. Operators rely on a
+/// stable set of aliases (case-insensitive, with common synonyms) to drive runtime
+/// behaviour from a single env var. Any silent change here would force every air-gapped
+/// operator to learn the new vocabulary.
+/// </summary>
+public class EnforcementModeReaderTests
+{
+    [Theory]
+    [InlineData("off",       EnforcementMode.Off)]
+    [InlineData("Off",       EnforcementMode.Off)]
+    [InlineData("OFF",       EnforcementMode.Off)]
+    [InlineData("disabled",  EnforcementMode.Off)]
+    [InlineData("0",         EnforcementMode.Off)]
+    [InlineData("false",     EnforcementMode.Off)]
+    [InlineData("no",        EnforcementMode.Off)]
+    [InlineData("warn",      EnforcementMode.Warn)]
+    [InlineData("Warn",      EnforcementMode.Warn)]
+    [InlineData("warning",   EnforcementMode.Warn)]
+    [InlineData("strict",    EnforcementMode.Strict)]
+    [InlineData("Strict",    EnforcementMode.Strict)]
+    [InlineData("enforce",   EnforcementMode.Strict)]
+    [InlineData("1",         EnforcementMode.Strict)]
+    [InlineData("true",      EnforcementMode.Strict)]
+    [InlineData("yes",       EnforcementMode.Strict)]
+    public void Parse_RecognisedAlias_MapsToExpectedMode(string raw, EnforcementMode expected)
+    {
+        EnforcementModeReader.Parse(raw).ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("garbage")]
+    [InlineData("")]
+    [InlineData("WARN ")]                  // trailing whitespace — Parse expects pre-trimmed input
+    [InlineData("on")]                     // ambiguous — not aliased
+    public void Parse_UnrecognisedValue_FallsBackToDefault(string raw)
+    {
+        EnforcementModeReader.Parse(raw, defaultMode: EnforcementMode.Warn).ShouldBe(EnforcementMode.Warn);
+        EnforcementModeReader.Parse(raw, defaultMode: EnforcementMode.Off).ShouldBe(EnforcementMode.Off);
+        EnforcementModeReader.Parse(raw, defaultMode: EnforcementMode.Strict).ShouldBe(EnforcementMode.Strict);
+    }
+
+    [Fact]
+    public void Read_EnvVarUnset_ReturnsDefault()
+    {
+        // Use a unique env var name so concurrent tests do not collide.
+        var envVarName = $"SQUID_TEST_ENFORCEMENT_UNSET_{Guid.NewGuid():N}";
+        Environment.SetEnvironmentVariable(envVarName, null);
+
+        EnforcementModeReader.Read(envVarName, EnforcementMode.Warn).ShouldBe(EnforcementMode.Warn);
+        EnforcementModeReader.Read(envVarName, EnforcementMode.Off).ShouldBe(EnforcementMode.Off);
+    }
+
+    [Fact]
+    public void Read_EnvVarSetToWhitespace_ReturnsDefault()
+    {
+        var envVarName = $"SQUID_TEST_ENFORCEMENT_WHITESPACE_{Guid.NewGuid():N}";
+        Environment.SetEnvironmentVariable(envVarName, "   ");
+
+        try
+        {
+            EnforcementModeReader.Read(envVarName, EnforcementMode.Warn).ShouldBe(EnforcementMode.Warn);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(envVarName, null);
+        }
+    }
+
+    [Theory]
+    [InlineData("off",    EnforcementMode.Off)]
+    [InlineData(" warn ", EnforcementMode.Warn)]   // trimming
+    [InlineData("STRICT", EnforcementMode.Strict)] // case-insensitive
+    public void Read_EnvVarSetToAlias_TrimsAndParses(string envValue, EnforcementMode expected)
+    {
+        var envVarName = $"SQUID_TEST_ENFORCEMENT_ALIAS_{Guid.NewGuid():N}";
+        Environment.SetEnvironmentVariable(envVarName, envValue);
+
+        try
+        {
+            EnforcementModeReader.Read(envVarName, defaultMode: EnforcementMode.Off).ShouldBe(expected);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(envVarName, null);
+        }
+    }
+}

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterAssistantConfigTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterAssistantConfigTests.cs
@@ -1,0 +1,322 @@
+using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NSubstitute;
+using Shouldly;
+using SmartTalk.Core.Services.RealtimeAiV2;
+using SmartTalk.Core.Services.RealtimeAiV2.Adapters.Providers.OpenAi;
+using SmartTalk.Core.Settings.OpenAi;
+using SmartTalk.Messages.Enums.RealtimeAi;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Services.RealtimeAiV2;
+
+/// <summary>
+/// Phase 4.2 contract tests for <see cref="OpenAiRealtimeAiProviderAdapter"/>'s per-assistant
+/// session-config overrides. The single load-bearing invariant: when the env var is unset
+/// (<see cref="SmartTalk.Messages.Hardening.EnforcementMode.Off"/>, the default) OR when
+/// every <c>RealtimeAiModelConfig</c> override field is null, the serialised JSON must be
+/// **byte-equivalent** to the pre-4.2 output. This guards the "no breaking changes" promise
+/// of the Round 2 rollout.
+///
+/// <para>
+/// Tests run with <see cref="JsonSerializerSettings"/> that mirror the production caller
+/// (<c>NullValueHandling.Ignore</c>) — null override fields are stripped at serialisation
+/// time, which is what makes "all-null produces byte-equivalent output" work.
+/// </para>
+/// </summary>
+[Collection("EnvVarSerial")]   // serialised because tests mutate a process-global env var
+public class OpenAiRealtimeAiProviderAdapterAssistantConfigTests : IDisposable
+{
+    private readonly string _envVarOriginalValue;
+
+    public OpenAiRealtimeAiProviderAdapterAssistantConfigTests()
+    {
+        _envVarOriginalValue = Environment.GetEnvironmentVariable(OpenAiRealtimeAiProviderAdapter.AssistantConfigEnforcementEnvVar);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable(OpenAiRealtimeAiProviderAdapter.AssistantConfigEnforcementEnvVar, _envVarOriginalValue);
+    }
+
+    private static readonly JsonSerializerSettings ProductionSerializer = new()
+    {
+        NullValueHandling = NullValueHandling.Ignore
+    };
+
+    private static OpenAiRealtimeAiProviderAdapter NewAdapter() =>
+        new(new OpenAiSettings(Substitute.For<IConfiguration>()));
+
+    private static RealtimeSessionOptions OptionsWithDefaults() =>
+        new()
+        {
+            ModelConfig = new RealtimeAiModelConfig
+            {
+                Prompt = "you are helpful",
+                Voice = "alloy",
+                Tools = new List<object>()
+            }
+        };
+
+    private static JObject SerializeSessionAsProduction(object payload) =>
+        JObject.Parse(JsonConvert.SerializeObject(payload, ProductionSerializer));
+
+    private void SetEnv(string value) =>
+        Environment.SetEnvironmentVariable(OpenAiRealtimeAiProviderAdapter.AssistantConfigEnforcementEnvVar, value);
+
+    // ── Rule 8: env-var name pinning ───────────────────────────────────────
+
+    [Fact]
+    public void AssistantConfigEnforcementEnvVar_ConstantNameIsPinned()
+    {
+        // Renaming this env var breaks every operator who pinned this flag via the
+        // environment. Hard-pin the literal so a rename becomes a compile-time-visible
+        // decision rather than an invisible refactor.
+        OpenAiRealtimeAiProviderAdapter.AssistantConfigEnforcementEnvVar
+            .ShouldBe("SQUID_SMARTTALK_REALTIME_ASSISTANT_CONFIG_ENFORCEMENT");
+    }
+
+    // ── Default mode (env var unset) → byte-equivalent to pre-4.2 ──────────
+
+    [Fact]
+    public void BuildSessionConfig_EnvVarUnset_PayloadByteEquivalentToPreFour()
+    {
+        // The load-bearing invariant: with the env var unset and overrides set on the
+        // model config, the override fields MUST be ignored. This is what makes
+        // 4.2's deploy zero-impact even if Phase 4.1 left non-null values on some row.
+        SetEnv(null);
+        var adapter = NewAdapter();
+        var options = OptionsWithDefaults();
+
+        // Populate overrides to prove they're ignored.
+        options.ModelConfig.TranscriptionModel = "gpt-4o-transcribe";
+        options.ModelConfig.TranscriptionLanguage = "yue";
+        options.ModelConfig.TurnDetectionType = "semantic_vad";
+        options.ModelConfig.TurnDetectionThreshold = 0.5m;
+        options.ModelConfig.TurnDetectionSilenceMs = 700;
+        options.ModelConfig.InputNoiseReductionType = "near_field";
+        options.ModelConfig.MaxResponseOutputTokens = 1200;
+        options.ModelConfig.OutputAudioSpeed = 1.15m;
+
+        var json = SerializeSessionAsProduction(adapter.BuildSessionConfig(options, RealtimeAiAudioCodec.MULAW));
+
+        var session = json["session"]!;
+        session["audio"]!["input"]!["transcription"]!["model"]!.Value<string>().ShouldBe("whisper-1");
+        session["audio"]!["input"]!["transcription"]!["language"].ShouldBeNull();
+        session["audio"]!["input"]!["turn_detection"]!["type"]!.Value<string>().ShouldBe("server_vad");
+        session["audio"]!["input"]!["turn_detection"]!["threshold"].ShouldBeNull();
+        session["audio"]!["input"]!["turn_detection"]!["silence_duration_ms"].ShouldBeNull();
+        session["audio"]!["input"]!["noise_reduction"].ShouldBeNull();
+        session["audio"]!["output"]!["speed"].ShouldBeNull();
+        session["max_response_output_tokens"].ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData("off")]
+    [InlineData("disabled")]
+    [InlineData("0")]
+    [InlineData("false")]
+    public void BuildSessionConfig_EnvVarOffAlias_PayloadByteEquivalentToPreFour(string envValue)
+    {
+        // Operators who explicitly want "no per-assistant overrides" can use any of
+        // these aliases. All MUST behave identically to the unset case — assert the same
+        // depth as BuildSessionConfig_EnvVarUnset_PayloadByteEquivalentToPreFour so a
+        // regression in any single off-alias gets caught, not just the easily-checked
+        // language / speed fields.
+        SetEnv(envValue);
+        var adapter = NewAdapter();
+        var options = OptionsWithDefaults();
+
+        // Populate every override field so any missed null-check would visibly leak.
+        options.ModelConfig.TranscriptionModel = "gpt-4o-transcribe";
+        options.ModelConfig.TranscriptionLanguage = "zh";
+        options.ModelConfig.TurnDetectionType = "semantic_vad";
+        options.ModelConfig.TurnDetectionThreshold = 0.5m;
+        options.ModelConfig.TurnDetectionSilenceMs = 700;
+        options.ModelConfig.InputNoiseReductionType = "near_field";
+        options.ModelConfig.MaxResponseOutputTokens = 1200;
+        options.ModelConfig.OutputAudioSpeed = 1.15m;
+
+        var json = SerializeSessionAsProduction(adapter.BuildSessionConfig(options, RealtimeAiAudioCodec.MULAW));
+
+        var session = json["session"]!;
+        session["audio"]!["input"]!["transcription"]!["model"]!.Value<string>().ShouldBe("whisper-1");
+        session["audio"]!["input"]!["transcription"]!["language"].ShouldBeNull();
+        session["audio"]!["input"]!["turn_detection"]!["type"]!.Value<string>().ShouldBe("server_vad");
+        session["audio"]!["input"]!["turn_detection"]!["threshold"].ShouldBeNull();
+        session["audio"]!["input"]!["turn_detection"]!["silence_duration_ms"].ShouldBeNull();
+        session["audio"]!["input"]!["noise_reduction"].ShouldBeNull();
+        session["audio"]!["output"]!["speed"].ShouldBeNull();
+        session["max_response_output_tokens"].ShouldBeNull();
+    }
+
+    [Fact]
+    public void BuildSessionConfig_EnvVarUnset_AllOriginalGaFieldsPreserved()
+    {
+        // Sanity-check that no Phase 4.2 wiring perturbed the existing GA contract.
+        // If any of these break, Phase 4.2 is silently breaking already-deployed
+        // assistants — the entire round-2 promise depends on this staying green.
+        SetEnv(null);
+        var adapter = NewAdapter();
+
+        var json = SerializeSessionAsProduction(adapter.BuildSessionConfig(OptionsWithDefaults(), RealtimeAiAudioCodec.MULAW));
+
+        var session = json["session"]!;
+        json["type"]!.Value<string>().ShouldBe("session.update");
+        session["type"]!.Value<string>().ShouldBe("realtime");
+        session["instructions"]!.Value<string>().ShouldBe("you are helpful");
+        session["output_modalities"]!.Values<string>().ShouldBe(new[] { "audio" });
+        session["modalities"].ShouldBeNull();
+        session["temperature"].ShouldBeNull();
+        session["audio"]!["input"]!["format"]!["type"]!.Value<string>().ShouldBe("audio/pcmu");
+        session["audio"]!["input"]!["transcription"]!["model"]!.Value<string>().ShouldBe("whisper-1");
+        session["audio"]!["input"]!["turn_detection"]!["type"]!.Value<string>().ShouldBe("server_vad");
+        session["audio"]!["output"]!["voice"]!.Value<string>().ShouldBe("alloy");
+    }
+
+    // ── Warn / strict mode + non-null overrides → fields activated ────────
+
+    [Theory]
+    [InlineData("warn")]
+    [InlineData("strict")]
+    [InlineData("enforce")]
+    [InlineData("1")]
+    public void BuildSessionConfig_EnvVarEnabled_TranscriptionLanguageActivates(string envValue)
+    {
+        SetEnv(envValue);
+        var adapter = NewAdapter();
+        var options = OptionsWithDefaults();
+        options.ModelConfig.TranscriptionLanguage = "yue";
+
+        var json = SerializeSessionAsProduction(adapter.BuildSessionConfig(options, RealtimeAiAudioCodec.MULAW));
+
+        json["session"]!["audio"]!["input"]!["transcription"]!["language"]!.Value<string>().ShouldBe("yue");
+    }
+
+    [Fact]
+    public void BuildSessionConfig_EnvVarEnabled_TranscriptionModelOverrideActivates()
+    {
+        SetEnv("warn");
+        var adapter = NewAdapter();
+        var options = OptionsWithDefaults();
+        options.ModelConfig.TranscriptionModel = "gpt-4o-transcribe";
+
+        var json = SerializeSessionAsProduction(adapter.BuildSessionConfig(options, RealtimeAiAudioCodec.MULAW));
+
+        json["session"]!["audio"]!["input"]!["transcription"]!["model"]!.Value<string>().ShouldBe("gpt-4o-transcribe");
+    }
+
+    [Fact]
+    public void BuildSessionConfig_EnvVarEnabled_TurnDetectionTypeActivatesWithThresholdAndSilence()
+    {
+        SetEnv("warn");
+        var adapter = NewAdapter();
+        var options = OptionsWithDefaults();
+        options.ModelConfig.TurnDetectionType = "semantic_vad";
+        options.ModelConfig.TurnDetectionThreshold = 0.5m;
+        options.ModelConfig.TurnDetectionSilenceMs = 700;
+
+        var json = SerializeSessionAsProduction(adapter.BuildSessionConfig(options, RealtimeAiAudioCodec.MULAW));
+
+        var td = json["session"]!["audio"]!["input"]!["turn_detection"]!;
+        td["type"]!.Value<string>().ShouldBe("semantic_vad");
+        td["threshold"]!.Value<decimal>().ShouldBe(0.5m);
+        td["silence_duration_ms"]!.Value<int>().ShouldBe(700);
+    }
+
+    [Fact]
+    public void BuildSessionConfig_EnvVarEnabled_TurnDetectionTypeNull_FallsBackToFunctionCallConfig()
+    {
+        // Even with enforcement enabled, an assistant that hasn't opted in (TurnDetectionType
+        // is null) MUST get the pre-4.2 fallback: either the function-call config or default
+        // server_vad. This is the "opt-in is per-field" invariant — Phase 5 picks one field
+        // at a time, never auto-activates everything.
+        SetEnv("warn");
+        var adapter = NewAdapter();
+        var options = OptionsWithDefaults();
+        options.ModelConfig.TurnDetection = new { type = "server_vad", threshold = 0.99m };
+        // TurnDetectionType is null (opt-in not exercised)
+
+        var json = SerializeSessionAsProduction(adapter.BuildSessionConfig(options, RealtimeAiAudioCodec.MULAW));
+
+        json["session"]!["audio"]!["input"]!["turn_detection"]!["type"]!.Value<string>().ShouldBe("server_vad");
+        json["session"]!["audio"]!["input"]!["turn_detection"]!["threshold"]!.Value<decimal>().ShouldBe(0.99m);
+    }
+
+    [Fact]
+    public void BuildSessionConfig_EnvVarEnabled_NoiseReductionTypeActivates()
+    {
+        SetEnv("warn");
+        var adapter = NewAdapter();
+        var options = OptionsWithDefaults();
+        options.ModelConfig.InputNoiseReductionType = "near_field";
+
+        var json = SerializeSessionAsProduction(adapter.BuildSessionConfig(options, RealtimeAiAudioCodec.MULAW));
+
+        json["session"]!["audio"]!["input"]!["noise_reduction"]!["type"]!.Value<string>().ShouldBe("near_field");
+    }
+
+    [Fact]
+    public void BuildSessionConfig_EnvVarEnabled_NoiseReductionNull_FallsBackToFunctionCallConfig()
+    {
+        SetEnv("warn");
+        var adapter = NewAdapter();
+        var options = OptionsWithDefaults();
+        options.ModelConfig.InputAudioNoiseReduction = new { type = "far_field" };
+        // InputNoiseReductionType is null (opt-in not exercised)
+
+        var json = SerializeSessionAsProduction(adapter.BuildSessionConfig(options, RealtimeAiAudioCodec.MULAW));
+
+        json["session"]!["audio"]!["input"]!["noise_reduction"]!["type"]!.Value<string>().ShouldBe("far_field");
+    }
+
+    [Fact]
+    public void BuildSessionConfig_EnvVarEnabled_MaxResponseOutputTokensActivates()
+    {
+        SetEnv("warn");
+        var adapter = NewAdapter();
+        var options = OptionsWithDefaults();
+        options.ModelConfig.MaxResponseOutputTokens = 1200;
+
+        var json = SerializeSessionAsProduction(adapter.BuildSessionConfig(options, RealtimeAiAudioCodec.MULAW));
+
+        json["session"]!["max_response_output_tokens"]!.Value<int>().ShouldBe(1200);
+    }
+
+    [Fact]
+    public void BuildSessionConfig_EnvVarEnabled_OutputAudioSpeedActivates()
+    {
+        SetEnv("warn");
+        var adapter = NewAdapter();
+        var options = OptionsWithDefaults();
+        options.ModelConfig.OutputAudioSpeed = 0.85m;
+
+        var json = SerializeSessionAsProduction(adapter.BuildSessionConfig(options, RealtimeAiAudioCodec.MULAW));
+
+        json["session"]!["audio"]!["output"]!["speed"]!.Value<decimal>().ShouldBe(0.85m);
+    }
+
+    [Fact]
+    public void BuildSessionConfig_EnvVarEnabled_AllConfigNull_StillByteEquivalentToPreFour()
+    {
+        // The other half of the "no breaking" promise: even with enforcement enabled,
+        // an assistant that has not configured ANY overrides (every column is NULL —
+        // the realistic state for every existing prod row) MUST still produce a
+        // byte-equivalent session.update payload.
+        SetEnv("warn");
+        var adapter = NewAdapter();
+
+        var json = SerializeSessionAsProduction(adapter.BuildSessionConfig(OptionsWithDefaults(), RealtimeAiAudioCodec.MULAW));
+
+        var session = json["session"]!;
+        session["audio"]!["input"]!["transcription"]!["model"]!.Value<string>().ShouldBe("whisper-1");
+        session["audio"]!["input"]!["transcription"]!["language"].ShouldBeNull();
+        session["audio"]!["input"]!["turn_detection"]!["type"]!.Value<string>().ShouldBe("server_vad");
+        session["audio"]!["input"]!["turn_detection"]!["threshold"].ShouldBeNull();
+        session["audio"]!["input"]!["turn_detection"]!["silence_duration_ms"].ShouldBeNull();
+        session["audio"]!["input"]!["noise_reduction"].ShouldBeNull();
+        session["audio"]!["output"]!["speed"].ShouldBeNull();
+        session["max_response_output_tokens"].ShouldBeNull();
+    }
+}

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterGaPayloadTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterGaPayloadTests.cs
@@ -15,6 +15,14 @@ namespace SmartTalk.UnitTests.Services.RealtimeAiV2;
 /// Pins the OpenAI Realtime API GA contract (post 2026-05-07).
 /// Beta-era fields that would now be rejected by the server MUST stay out of the payload.
 /// </summary>
+/// <remarks>
+/// Serialised with <see cref="OpenAiRealtimeAiProviderAdapterAssistantConfigTests"/> via
+/// the <c>EnvVarSerial</c> collection: the sibling class mutates the process-global
+/// <c>SQUID_SMARTTALK_REALTIME_ASSISTANT_CONFIG_ENFORCEMENT</c> env var; without the
+/// barrier, xUnit could run these GA assertions while that var is temporarily set to
+/// <c>warn</c>, silently exercising the override-enabled branch instead of the default.
+/// </remarks>
+[Collection("EnvVarSerial")]
 public class OpenAiRealtimeAiProviderAdapterGaPayloadTests
 {
     private static OpenAiRealtimeAiProviderAdapter NewAdapter() =>


### PR DESCRIPTION
## Summary

Tracking branch for the second round of V2 stability and quality improvements, built on the post-GA (hotfix #934) and V2-only-in-prod baseline.

This PR ships **only** the planning document — no production code. The actual work lands as stacked sub-PRs (e.g. #945, #946 already open) each targeting this branch as base. Once a batch of sub-PRs is merged and observed, this branch goes into main as a single atomic merge — same pattern as Round 1 (#922).

## Scope

`docs/v2-stability-perf-rollout-round-2.md`: 24 sub-PRs across Phases 4–11 with strict non-breaking guardrails. Every PR must keep default behaviour byte-equivalent to current prod when env vars are unset and DB columns are null. New behaviour is gated by a double check (DB column populated AND env var not set to `off`), with a < 5-minute env-var rollback per feature.

Phases ordered by stability return:

- **Phase 4** — config plumbing (zero behaviour change, pure DB + DTO add)
- **Phase 5** — per-assistant opt-ins (transcription language hint first — biggest impact on mixed Cantonese/Mandarin/English)
- **Phase 6** — function-output type-safety (internal refactor)
- **Phase 7** — knowledge-build perf (parallel fetch — largest cold-call win)
- **Phase 8** — hot-path micro-perf
- **Phase 9** — GA observability + Beta event-name sunset
- **Phase 10** — barge-in correctness (highest risk, strictest canary)
- **Phase 11** — `gpt-realtime-2` default flip (last, after Phase 5 fully landed)

## Default behaviour guarantee

Every PR merged here MUST satisfy two independent paths to byte-equivalent prod output:
1. Env var unset / `off` → adapter ignores every override and emits today's JSON
2. Env var enabled but assistant config all NULL → per-field fallbacks return today's JSON

The golden-payload pinning tests from hotfix #934 (`OpenAiRealtimeAiProviderAdapterGaPayloadTests`, 12 cases) act as the regression boundary for every sub-PR.

## Stacked sub-PRs

- #945 — Phase 4.1 (entity + migration)
- #946 — Phase 4.2 (DTO passthrough + adapter null guard + env-var gate)

## Test plan

- [x] Tracking doc compiles (markdown only, no code)
- [ ] Each sub-PR meets its own test plan
- [ ] Hotfix #934 observed healthy in prod for ≥ 48h before merging this branch to main