### PR TITLE
Round 2 stability and perf overhaul (base)

### DIFF
--- a/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectService.Build.Knowledge.cs
+++ b/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectService.Build.Knowledge.cs
@@ -102,67 +102,146 @@ public partial class AiSpeechAssistantConnectService
         return from.StartsWith("+1") ? from[2..] : from;
     }
 
+    // ── Greeting ──────────────────────────────────────────────────────────
+    //
+    // Each ResolveX preserves the original check-fetch-apply order so the
+    // cross-token cascade (see ShouldResolveCrossTokenCascade_* in the
+    // KnowledgeBase fixture) continues to work: any token literal an earlier
+    // Resolve injects into _ctx.Prompt is processed by a later Resolve.
+    // Internal split into FetchX + ApplyX is a pure structural refactor —
+    // no externally observable change, byte-equivalent prompt output.
+
+    private sealed record GreetingFetchResult(string FetchedGreeting);
+
     private async Task ResolveGreetingAsync(CancellationToken cancellationToken)
     {
-        if (!_ctx.NumberId.HasValue || !_ctx.Prompt.Contains("#{greeting}")) return;
+        var fetched = await FetchGreetingAsync(cancellationToken).ConfigureAwait(false);
+        ApplyGreeting(fetched);
+    }
 
-        var greeting = await _smartiesClient
+    private async Task<GreetingFetchResult> FetchGreetingAsync(CancellationToken cancellationToken)
+    {
+        if (!_ctx.NumberId.HasValue || !_ctx.Prompt.Contains("#{greeting}")) return null;
+
+        var response = await _smartiesClient
             .GetSaleAutoCallNumberAsync(new GetSaleAutoCallNumberRequest { Id = _ctx.NumberId.Value }, cancellationToken).ConfigureAwait(false);
 
-        if (!string.IsNullOrEmpty(greeting.Data.Number.Greeting))
-            _ctx.Knowledge.Greetings = greeting.Data.Number.Greeting;
-        
+        return new GreetingFetchResult(response.Data.Number.Greeting);
+    }
+
+    private void ApplyGreeting(GreetingFetchResult result)
+    {
+        if (result == null) return;
+
+        if (!string.IsNullOrEmpty(result.FetchedGreeting))
+            _ctx.Knowledge.Greetings = result.FetchedGreeting;
+
         _ctx.Prompt = _ctx.Prompt.Replace("#{greeting}", _ctx.Knowledge.Greetings ?? string.Empty);
     }
 
+    // ── Customer items (HiFood / customer_items) ──────────────────────────
+
     private async Task ResolveCustomerItemsAsync(CancellationToken cancellationToken)
     {
+        var fetched = await FetchCustomerItemsAsync(cancellationToken).ConfigureAwait(false);
+        ApplyCustomerItems(fetched);
+    }
 
+    private async Task<string> FetchCustomerItemsAsync(CancellationToken cancellationToken)
+    {
         var hasCustomerItemsToken = _ctx.Prompt.Contains("#{customer_items}", StringComparison.OrdinalIgnoreCase);
-        
         var hasHiFoodItemsToken = _ctx.Prompt.Contains("{HiFood_商品_商品数据}", StringComparison.OrdinalIgnoreCase);
-        
-        if (!hasCustomerItemsToken && !hasHiFoodItemsToken) return;
+
+        if (!hasCustomerItemsToken && !hasHiFoodItemsToken) return null;
 
         var caches = await _salesDataProvider.GetCustomerItemsCacheByAssistantNameAsync(_ctx.Assistant.Name, cancellationToken).ConfigureAwait(false);
         var customerItems = caches.Where(c => !string.IsNullOrEmpty(c.CacheValue)).Select(c => c.CacheValue.Trim()).Distinct().ToList();
 
-        var value = customerItems.Count > 0
+        return customerItems.Count > 0
             ? string.Join(Environment.NewLine + Environment.NewLine, customerItems.Take(50))
             : " ";
+    }
+
+    private void ApplyCustomerItems(string value)
+    {
+        if (value == null) return;
 
         _ctx.Prompt = _ctx.Prompt
             .Replace("#{customer_items}", value)
             .Replace("{HiFood_商品_商品数据}", value);
     }
 
+    // ── Menu items ────────────────────────────────────────────────────────
+
+    private sealed record MenuItemsFetchResult(string MenuItems);
+
     private async Task ResolveMenuItemsAsync(CancellationToken cancellationToken)
     {
-        if (!_ctx.Prompt.Contains("#{menu_items}", StringComparison.OrdinalIgnoreCase)) return;
+        var fetched = await FetchMenuItemsAsync(cancellationToken).ConfigureAwait(false);
+        ApplyMenuItems(fetched);
+    }
+
+    private async Task<MenuItemsFetchResult> FetchMenuItemsAsync(CancellationToken cancellationToken)
+    {
+        if (!_ctx.Prompt.Contains("#{menu_items}", StringComparison.OrdinalIgnoreCase)) return null;
 
         var menuItems = await GenerateMenuItemsAsync(cancellationToken).ConfigureAwait(false);
 
-        _ctx.Prompt = _ctx.Prompt.Replace("#{menu_items}", menuItems ?? "");
+        // Wrap so a null/empty fetch result is still distinguishable from "fetch was skipped".
+        return new MenuItemsFetchResult(menuItems);
     }
+
+    private void ApplyMenuItems(MenuItemsFetchResult result)
+    {
+        if (result == null) return;
+
+        _ctx.Prompt = _ctx.Prompt.Replace("#{menu_items}", result.MenuItems ?? "");
+    }
+
+    // ── Customer info (CRM / customer_info) ───────────────────────────────
 
     private async Task ResolveCustomerInfoAsync(CancellationToken cancellationToken)
     {
+        var fetched = await FetchCustomerInfoAsync(cancellationToken).ConfigureAwait(false);
+        ApplyCustomerInfo(fetched);
+    }
+
+    private async Task<string> FetchCustomerInfoAsync(CancellationToken cancellationToken)
+    {
         var hasCustomerInfoToken = _ctx.Prompt.Contains("#{customer_info}", StringComparison.OrdinalIgnoreCase);
-        
         var hasCrmCustomerToken = _ctx.Prompt.Contains("{CRM_客户_客户数据}", StringComparison.OrdinalIgnoreCase);
-        
-        if (!hasCustomerInfoToken && !hasCrmCustomerToken) return;
+
+        if (!hasCustomerInfoToken && !hasCrmCustomerToken) return null;
 
         var cache = await _salesDataProvider.GetCustomerInfoCacheByPhoneNumberAsync(_ctx.From, cancellationToken).ConfigureAwait(false);
 
-        var value = cache?.CacheValue?.Trim() ?? " ";
+        return cache?.CacheValue?.Trim() ?? " ";
+    }
+
+    private void ApplyCustomerInfo(string value)
+    {
+        if (value == null) return;
 
         _ctx.Prompt = _ctx.Prompt
             .Replace("#{customer_info}", value)
             .Replace("{CRM_客户_客户数据}", value);
     }
 
+    // ── POS prompt variables (products + store hours) ─────────────────────
+
+    private sealed record PosPromptFetchResult(
+        bool NeedProducts,
+        bool NeedStoreHours,
+        List<PosMenuProductBriefDto> Products,
+        string StoreHours);
+
     private async Task ResolvePosPromptVariablesAsync(CancellationToken cancellationToken)
+    {
+        var fetched = await FetchPosPromptVariablesAsync(cancellationToken).ConfigureAwait(false);
+        ApplyPosPromptVariables(fetched);
+    }
+
+    private async Task<PosPromptFetchResult> FetchPosPromptVariablesAsync(CancellationToken cancellationToken)
     {
         var needProducts = HasPromptToken("{POS_菜单_商品名称}")
                            || HasPromptToken("{POS_菜单_商品类别}")
@@ -172,25 +251,33 @@ public partial class AiSpeechAssistantConnectService
                            || HasPromptToken("{POS_菜单_菜单时间}");
         var needStoreHours = HasPromptToken("{POS_店铺信息_营业时间}");
 
-        if (!needProducts && !needStoreHours) return;
+        if (!needProducts && !needStoreHours) return null;
 
         var language = ResolvePosPromptLanguage();
         var products = needProducts
             ? await _posUtilService.GetPosMenuProductBriefsAsync(_ctx.AgentId, language, cancellationToken).ConfigureAwait(false)
-            : [];
+            : new List<PosMenuProductBriefDto>();
 
-        ResolvePosMenuProductNames(products);
-        ResolvePosMenuProductCategories(products);
-        ResolvePosMenuProductSpecifications(products);
-        ResolvePosMenuProductTaxes(products);
-        ResolvePosMenuProductPrices(products);
-        ResolvePosMenuProductTimes(products);
+        var storeHours = needStoreHours
+            ? await _posUtilService.GetPosStoreTimePeriodsAsync(_ctx.AgentId, language, cancellationToken).ConfigureAwait(false)
+            : null;
 
-        if (needStoreHours)
-        {
-            var storeHours = await _posUtilService.GetPosStoreTimePeriodsAsync(_ctx.AgentId, language, cancellationToken).ConfigureAwait(false);
-            ResolvePosStoreBusinessHours(storeHours);
-        }
+        return new PosPromptFetchResult(needProducts, needStoreHours, products, storeHours);
+    }
+
+    private void ApplyPosPromptVariables(PosPromptFetchResult result)
+    {
+        if (result == null) return;
+
+        ResolvePosMenuProductNames(result.Products);
+        ResolvePosMenuProductCategories(result.Products);
+        ResolvePosMenuProductSpecifications(result.Products);
+        ResolvePosMenuProductTaxes(result.Products);
+        ResolvePosMenuProductPrices(result.Products);
+        ResolvePosMenuProductTimes(result.Products);
+
+        if (result.NeedStoreHours)
+            ResolvePosStoreBusinessHours(result.StoreHours);
     }
 
     private void ResolvePosMenuProductNames(List<PosMenuProductBriefDto> products)
@@ -342,13 +429,30 @@ public partial class AiSpeechAssistantConnectService
         };
     }
 
+    // ── Delivery info (CRM 送货日 / delivery_info) ─────────────────────────
+
+    private sealed record DeliveryInfoFetchResult(string DeliveryValue);
+
     private async Task ResolveDeliveryInfoAsync(CancellationToken cancellationToken)
     {
-        if (!HasDeliveryInfoToken(_ctx.Prompt)) return;
+        var fetched = await FetchDeliveryInfoAsync(cancellationToken).ConfigureAwait(false);
+        ApplyDeliveryInfo(fetched);
+    }
+
+    private async Task<DeliveryInfoFetchResult> FetchDeliveryInfoAsync(CancellationToken cancellationToken)
+    {
+        if (!HasDeliveryInfoToken(_ctx.Prompt)) return null;
 
         var cache = await _salesDataProvider.GetDeliveryInfoCacheByPhoneNumberAsync(_ctx.From, cancellationToken).ConfigureAwait(false);
 
-        _ctx.Prompt = ApplyDeliveryInfoTokens(_ctx.Prompt, cache?.CacheValue?.Trim());
+        return new DeliveryInfoFetchResult(cache?.CacheValue?.Trim());
+    }
+
+    private void ApplyDeliveryInfo(DeliveryInfoFetchResult result)
+    {
+        if (result == null) return;
+
+        _ctx.Prompt = ApplyDeliveryInfoTokens(_ctx.Prompt, result.DeliveryValue);
     }
 
     /// <summary>

--- a/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectService.Build.Session.cs
+++ b/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectService.Build.Session.cs
@@ -36,7 +36,8 @@ public partial class AiSpeechAssistantConnectService
                 InputAudioNoiseReduction = DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.InputAudioNoiseReduction),
                 TranscriptionLanguage = ParseTranscriptionLanguage(DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.TranscriptionLanguage)),
                 TranscriptionModel = ParseTranscriptionModel(DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.TranscriptionModel)),
-                MaxResponseOutputTokens = ParseMaxResponseOutputTokens(DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.MaxResponseOutputTokens))
+                MaxResponseOutputTokens = ParseMaxResponseOutputTokens(DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.MaxResponseOutputTokens)),
+                OutputAudioSpeed = ParseOutputAudioSpeed(DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.OutputAudioSpeed))
             },
             ConnectionProfile = new RealtimeAiConnectionProfile
             {
@@ -143,6 +144,31 @@ public partial class AiSpeechAssistantConnectService
         if (token == null || token.Type != JTokenType.Integer) return null;
 
         var value = token.Value<int>();
+
+        return value > 0 ? value : null;
+    }
+
+    /// <summary>
+    /// Extracts the <c>value</c> decimal from a deserialised
+    /// <see cref="AiSpeechAssistantSessionConfigType.OutputAudioSpeed"/> config object.
+    /// Returns <c>null</c> for every shape that should leave the speed unset (so
+    /// OpenAI uses 1.0, current behaviour): null input, non-JObject input, missing
+    /// <c>value</c> property, non-numeric value, or non-positive value. The parser
+    /// does NOT enforce OpenAI's range (currently 0.25 – 1.5) — operators who set
+    /// out-of-range values are rejected by OpenAI server-side with a clear error,
+    /// rather than the adapter silently clamping into a different speed than the
+    /// operator intended.
+    /// Public static so the schema-interpretation rules can be exhaustively unit tested.
+    /// </summary>
+    public static decimal? ParseOutputAudioSpeed(object deserialisedConfig)
+    {
+        if (deserialisedConfig is not JObject obj) return null;
+
+        var token = obj["value"];
+
+        if (token == null || (token.Type != JTokenType.Float && token.Type != JTokenType.Integer)) return null;
+
+        var value = token.Value<decimal>();
 
         return value > 0 ? value : null;
     }

--- a/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectService.Build.Session.cs
+++ b/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectService.Build.Session.cs
@@ -1,8 +1,10 @@
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using Serilog;
 using SmartTalk.Core.Services.RealtimeAiV2;
 using SmartTalk.Core.Services.AiSpeechAssistant;
 using SmartTalk.Messages.Constants;
+using SmartTalk.Messages.Dto.RealtimeAi;
 using SmartTalk.Messages.Enums.RealtimeAi;
 using SmartTalk.Messages.Enums.AiSpeechAssistant;
 
@@ -54,8 +56,29 @@ public partial class AiSpeechAssistantConnectService
             OnSessionEndedAsync = HandleSessionEndedAsync,
             OnTranscriptionsCompletedAsync = HandleTranscriptionsCompletedAsync,
             OnRecordingCompleteAsync = HandleRecordingCompleteAsync,
-            OnFunctionCallAsync = (data, actions) => OnFunctionCallAsync(data, actions, CancellationToken.None)
+            OnFunctionCallAsync = (data, actions) => OnFunctionCallAsync(data, actions, CancellationToken.None),
+            OnResponseUsageReceivedAsync = HandleResponseUsageReceivedAsync
         };
+    }
+
+    /// <summary>
+    /// Logs per-turn OpenAI token usage with assistant + call context so cost reports
+    /// can be reconstructed from structured Serilog properties. Intentionally fire-and-
+    /// forget — never throws to the realtime event loop. Future work can route the same
+    /// payload to a cost-tracking sink (e.g. AiSpeechAssistantCallReport.TokensUsed)
+    /// without touching the adapter side.
+    /// </summary>
+    private Task HandleResponseUsageReceivedAsync(RealtimeAiWssUsageData usage)
+    {
+        Log.Information(
+            "[AiAssistant] Token usage, AssistantId: {AssistantId}, CallSid: {CallSid}, " +
+            "Total: {Total}, Input: {Input}, Output: {Output}, Cached: {Cached}, " +
+            "InputAudio: {InputAudio}, InputText: {InputText}, OutputAudio: {OutputAudio}, OutputText: {OutputText}",
+            _ctx.Assistant?.Id, _ctx.CallSid,
+            usage.TotalTokens, usage.InputTokens, usage.OutputTokens, usage.CachedTokens,
+            usage.InputAudioTokens, usage.InputTextTokens, usage.OutputAudioTokens, usage.OutputTextTokens);
+
+        return Task.CompletedTask;
     }
 
     private RealtimeSessionIdleFollowUp BuildIdleFollowUp()

--- a/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectService.Build.Session.cs
+++ b/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectService.Build.Session.cs
@@ -37,7 +37,8 @@ public partial class AiSpeechAssistantConnectService
                 TranscriptionLanguage = ParseTranscriptionLanguage(DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.TranscriptionLanguage)),
                 TranscriptionModel = ParseTranscriptionModel(DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.TranscriptionModel)),
                 MaxResponseOutputTokens = ParseMaxResponseOutputTokens(DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.MaxResponseOutputTokens)),
-                OutputAudioSpeed = ParseOutputAudioSpeed(DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.OutputAudioSpeed))
+                OutputAudioSpeed = ParseOutputAudioSpeed(DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.OutputAudioSpeed)),
+                EnableRealtimeTracing = ParseEnableRealtimeTracing(DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.RealtimeTracing))
             },
             ConnectionProfile = new RealtimeAiConnectionProfile
             {
@@ -171,5 +172,26 @@ public partial class AiSpeechAssistantConnectService
         var value = token.Value<decimal>();
 
         return value > 0 ? value : null;
+    }
+
+    /// <summary>
+    /// Extracts the <c>enabled</c> boolean from a deserialised
+    /// <see cref="AiSpeechAssistantSessionConfigType.RealtimeTracing"/> config object.
+    /// Returns <c>null</c> for every shape that should leave tracing off (current
+    /// behaviour): null input, non-JObject input, missing <c>enabled</c> property,
+    /// non-boolean value, or explicit <c>false</c>. Only an explicit <c>true</c>
+    /// activates tracing; the parser distinguishes <c>false</c> from <c>null</c> so
+    /// an operator can persist an explicit "off" state alongside the inactive flag.
+    /// Public static so the schema-interpretation rules can be exhaustively unit tested.
+    /// </summary>
+    public static bool? ParseEnableRealtimeTracing(object deserialisedConfig)
+    {
+        if (deserialisedConfig is not JObject obj) return null;
+
+        var token = obj["enabled"];
+
+        if (token == null || token.Type != JTokenType.Boolean) return null;
+
+        return token.Value<bool>() ? true : null;
     }
 }

--- a/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectService.Build.Session.cs
+++ b/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectService.Build.Session.cs
@@ -34,7 +34,8 @@ public partial class AiSpeechAssistantConnectService
                     .ToList(),
                 TurnDetection = DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.TurnDirection),
                 InputAudioNoiseReduction = DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.InputAudioNoiseReduction),
-                TranscriptionLanguage = ParseTranscriptionLanguage(DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.TranscriptionLanguage))
+                TranscriptionLanguage = ParseTranscriptionLanguage(DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.TranscriptionLanguage)),
+                TranscriptionModel = ParseTranscriptionModel(DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.TranscriptionModel))
             },
             ConnectionProfile = new RealtimeAiConnectionProfile
             {
@@ -98,5 +99,25 @@ public partial class AiSpeechAssistantConnectService
         var language = obj["language"]?.Value<string>();
 
         return string.IsNullOrWhiteSpace(language) ? null : language;
+    }
+
+    /// <summary>
+    /// Extracts the <c>model</c> string from a deserialised
+    /// <see cref="AiSpeechAssistantSessionConfigType.TranscriptionModel"/> config object.
+    /// Returns <c>null</c> for every shape that should leave the adapter on its
+    /// compile-time default: null input, non-JObject input, missing <c>model</c>
+    /// property, or empty / whitespace value. The string itself is NOT validated
+    /// against a known list — operators may opt into future OpenAI models without
+    /// a code change, and OpenAI rejects unknown values server-side rather than us
+    /// silently falling back.
+    /// Public static so the schema-interpretation rules can be exhaustively unit tested.
+    /// </summary>
+    public static string ParseTranscriptionModel(object deserialisedConfig)
+    {
+        if (deserialisedConfig is not JObject obj) return null;
+
+        var model = obj["model"]?.Value<string>();
+
+        return string.IsNullOrWhiteSpace(model) ? null : model;
     }
 }

--- a/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectService.Build.Session.cs
+++ b/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectService.Build.Session.cs
@@ -1,4 +1,5 @@
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using SmartTalk.Core.Services.RealtimeAiV2;
 using SmartTalk.Core.Services.AiSpeechAssistant;
 using SmartTalk.Messages.Constants;
@@ -32,7 +33,8 @@ public partial class AiSpeechAssistantConnectService
                     .Select(x => JsonConvert.DeserializeObject<object>(x.Content))
                     .ToList(),
                 TurnDetection = DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.TurnDirection),
-                InputAudioNoiseReduction = DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.InputAudioNoiseReduction)
+                InputAudioNoiseReduction = DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.InputAudioNoiseReduction),
+                TranscriptionLanguage = ParseTranscriptionLanguage(DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.TranscriptionLanguage))
             },
             ConnectionProfile = new RealtimeAiConnectionProfile
             {
@@ -77,5 +79,24 @@ public partial class AiSpeechAssistantConnectService
         var content = _ctx.FunctionCalls.FirstOrDefault(x => x.Type == type && !string.IsNullOrWhiteSpace(x.Content))?.Content;
 
         return content != null ? JsonConvert.DeserializeObject<object>(content) : null;
+    }
+
+    /// <summary>
+    /// Extracts the <c>language</c> string from a deserialised
+    /// <see cref="AiSpeechAssistantSessionConfigType.TranscriptionLanguage"/> config object.
+    /// Returns <c>null</c> for every shape that should leave the transcription payload
+    /// byte-equivalent to the pre-hint behaviour: null input, non-JObject input,
+    /// missing <c>language</c> property, or empty / whitespace value. This is the only
+    /// place that interprets the JSON schema for the language hint — the adapter just
+    /// reads the resulting nullable string.
+    /// Public static so the schema-interpretation rules can be exhaustively unit tested.
+    /// </summary>
+    public static string ParseTranscriptionLanguage(object deserialisedConfig)
+    {
+        if (deserialisedConfig is not JObject obj) return null;
+
+        var language = obj["language"]?.Value<string>();
+
+        return string.IsNullOrWhiteSpace(language) ? null : language;
     }
 }

--- a/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectService.Build.Session.cs
+++ b/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectService.Build.Session.cs
@@ -35,7 +35,8 @@ public partial class AiSpeechAssistantConnectService
                 TurnDetection = DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.TurnDirection),
                 InputAudioNoiseReduction = DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.InputAudioNoiseReduction),
                 TranscriptionLanguage = ParseTranscriptionLanguage(DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.TranscriptionLanguage)),
-                TranscriptionModel = ParseTranscriptionModel(DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.TranscriptionModel))
+                TranscriptionModel = ParseTranscriptionModel(DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.TranscriptionModel)),
+                MaxResponseOutputTokens = ParseMaxResponseOutputTokens(DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.MaxResponseOutputTokens))
             },
             ConnectionProfile = new RealtimeAiConnectionProfile
             {
@@ -119,5 +120,30 @@ public partial class AiSpeechAssistantConnectService
         var model = obj["model"]?.Value<string>();
 
         return string.IsNullOrWhiteSpace(model) ? null : model;
+    }
+
+    /// <summary>
+    /// Extracts the <c>value</c> integer from a deserialised
+    /// <see cref="AiSpeechAssistantSessionConfigType.MaxResponseOutputTokens"/> config object.
+    /// Returns <c>null</c> for every shape that should leave the response cap unset
+    /// (so OpenAI uses its server-side default): null input, non-JObject input,
+    /// missing <c>value</c> property, non-integer value, or non-positive integer.
+    /// Non-positive caps are rejected here rather than passed through because they
+    /// would either be rejected by OpenAI server-side anyway (zero / negative) or
+    /// silently truncate AI responses to an empty turn (one), which is worse than
+    /// the default.
+    /// Public static so the schema-interpretation rules can be exhaustively unit tested.
+    /// </summary>
+    public static int? ParseMaxResponseOutputTokens(object deserialisedConfig)
+    {
+        if (deserialisedConfig is not JObject obj) return null;
+
+        var token = obj["value"];
+
+        if (token == null || token.Type != JTokenType.Integer) return null;
+
+        var value = token.Value<int>();
+
+        return value > 0 ? value : null;
     }
 }

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Providers/OpenAi/OpenAiRealtimeAiProviderAdapter.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Providers/OpenAi/OpenAiRealtimeAiProviderAdapter.cs
@@ -56,7 +56,12 @@ public class OpenAiRealtimeAiProviderAdapter : IRealtimeAiProviderAdapter
                     input = new
                     {
                         format = ConvertCodecToGaFormat(clientCodec),
-                        transcription = new { model = "whisper-1" },
+                        // `language` is null for every assistant with no TranscriptionLanguage
+                        // row in ai_speech_assistant_function_call; the caller's
+                        // NullValueHandling.Ignore (RealtimeAiService.Connect.cs:23) strips
+                        // the key entirely, so the transcription object stays byte-equivalent
+                        // to `{ model: "whisper-1" }` for every existing prod row.
+                        transcription = new { model = "whisper-1", language = modelConfig.TranscriptionLanguage },
                         turn_detection = modelConfig.TurnDetection ?? new { type = "server_vad" },
                         noise_reduction = modelConfig.InputAudioNoiseReduction
                     },

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Providers/OpenAi/OpenAiRealtimeAiProviderAdapter.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Providers/OpenAi/OpenAiRealtimeAiProviderAdapter.cs
@@ -288,7 +288,15 @@ public class OpenAiRealtimeAiProviderAdapter : IRealtimeAiProviderAdapter
 
                 case "response.done":
                     var functionCalls = ExtractFunctionCalls(root);
-                    return functionCalls != null ? Result(RealtimeAiWssEventType.FunctionCallSuggested, functionCalls) : Result(RealtimeAiWssEventType.ResponseTurnCompleted);
+                    // Usage is attached to BOTH event variants because both originate from
+                    // the same provider message. Consumers handle the variant they care
+                    // about and read Usage off the event independently.
+                    var usage = ExtractUsage(root);
+                    var doneEvent = functionCalls != null
+                        ? Result(RealtimeAiWssEventType.FunctionCallSuggested, functionCalls)
+                        : Result(RealtimeAiWssEventType.ResponseTurnCompleted);
+                    doneEvent.Usage = usage;
+                    return doneEvent;
 
                 case "error":
                     var errorCode = ExtractErrorCode(root);
@@ -365,6 +373,73 @@ public class OpenAiRealtimeAiProviderAdapter : IRealtimeAiProviderAdapter
             return lastCodeProp.GetString();
 
         return null;
+    }
+
+    /// <summary>
+    /// Extracts the OpenAI token-usage breakdown from a <c>response.done</c> payload
+    /// (shape: <c>{ response: { usage: { input_tokens, output_tokens, total_tokens,
+    /// input_token_details: { cached_tokens, audio_tokens, text_tokens },
+    /// output_token_details: { audio_tokens, text_tokens } } } }</c>).
+    ///
+    /// <para>
+    /// Returns <c>null</c> when the message has no usage block (older provider snapshots),
+    /// or when the response object is missing. Individual sub-fields are returned as
+    /// <c>null</c> when absent — consumers must treat missing values as "not reported"
+    /// rather than zero, because zero is a meaningful answer (an empty AI turn).
+    /// </para>
+    ///
+    /// <para>
+    /// Public static (matches the other parser helpers in this codebase) so unit
+    /// tests can pin the schema interpretation directly without driving a full
+    /// ParseMessage path.
+    /// </para>
+    /// </summary>
+    public static RealtimeAiWssUsageData ExtractUsage(JsonElement root)
+    {
+        if (!root.TryGetProperty("response", out var response) ||
+            response.ValueKind != JsonValueKind.Object ||
+            !response.TryGetProperty("usage", out var usage) ||
+            usage.ValueKind != JsonValueKind.Object)
+            return null;
+
+        return new RealtimeAiWssUsageData
+        {
+            TotalTokens = ReadOptionalInt(usage, "total_tokens"),
+            InputTokens = ReadOptionalInt(usage, "input_tokens"),
+            OutputTokens = ReadOptionalInt(usage, "output_tokens"),
+            CachedTokens = ReadOptionalInt(usage, "input_token_details", "cached_tokens"),
+            InputAudioTokens = ReadOptionalInt(usage, "input_token_details", "audio_tokens"),
+            InputTextTokens = ReadOptionalInt(usage, "input_token_details", "text_tokens"),
+            OutputAudioTokens = ReadOptionalInt(usage, "output_token_details", "audio_tokens"),
+            OutputTextTokens = ReadOptionalInt(usage, "output_token_details", "text_tokens")
+        };
+    }
+
+    /// <summary>
+    /// Reads a nullable integer at <paramref name="path"/> from <paramref name="parent"/>.
+    /// Returns null if any segment is missing, not an object on the way down, or
+    /// the final value is not a JSON number / integer-compatible value. Tolerates
+    /// the provider returning long / double for what we treat as int.
+    /// </summary>
+    private static int? ReadOptionalInt(JsonElement parent, params string[] path)
+    {
+        var current = parent;
+
+        for (var i = 0; i < path.Length - 1; i++)
+        {
+            if (current.ValueKind != JsonValueKind.Object ||
+                !current.TryGetProperty(path[i], out var next))
+                return null;
+
+            current = next;
+        }
+
+        if (current.ValueKind != JsonValueKind.Object ||
+            !current.TryGetProperty(path[^1], out var leaf) ||
+            leaf.ValueKind != JsonValueKind.Number)
+            return null;
+
+        return leaf.TryGetInt32(out var i32) ? i32 : (int?)null;
     }
 
     private static bool IsRecoverableError(string errorCode, string errorMessage)

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Providers/OpenAi/OpenAiRealtimeAiProviderAdapter.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Providers/OpenAi/OpenAiRealtimeAiProviderAdapter.cs
@@ -37,6 +37,41 @@ public class OpenAiRealtimeAiProviderAdapter : IRealtimeAiProviderAdapter
     /// </summary>
     public const string EnabledTracingMode = "auto";
 
+    /// <summary>
+    /// Compile-time default <c>audio.output.voice</c> when an assistant has no explicit
+    /// <see cref="RealtimeAiModelConfig.Voice"/> override. Matches OpenAI's historical
+    /// default and is one of the values in <see cref="SupportedVoices"/>.
+    /// </summary>
+    public const string DefaultVoice = "alloy";
+
+    /// <summary>
+    /// The voice IDs OpenAI's Realtime API accepts as of 2026-05-20. The adapter does
+    /// NOT enforce this list — operators can opt into a future OpenAI voice without a
+    /// code change, and OpenAI rejects unknown values server-side. The pin exists so
+    /// (a) UI / operator tooling has a single source of truth for the dropdown and
+    /// (b) a unit test asserts every entry stays in sync with the OpenAI docs.
+    ///
+    /// <para>
+    /// Source: https://platform.openai.com/docs/guides/realtime — Voice Options.
+    /// </para>
+    /// </summary>
+    public static readonly IReadOnlyList<string> SupportedVoices = new[]
+    {
+        "alloy",
+        "ash",
+        "ballad",
+        "coral",
+        "echo",
+        "fable",
+        "onyx",
+        "nova",
+        "sage",
+        "shimmer",
+        "verse",
+        "marin",
+        "cedar"
+    };
+
     private readonly OpenAiSettings _openAiSettings;
 
     public OpenAiRealtimeAiProviderAdapter(OpenAiSettings openAiSettings)
@@ -114,7 +149,11 @@ public class OpenAiRealtimeAiProviderAdapter : IRealtimeAiProviderAdapter
                     output = new
                     {
                         format = ConvertCodecToGaFormat(clientCodec),
-                        voice = string.IsNullOrEmpty(modelConfig.Voice) ? "alloy" : modelConfig.Voice,
+                        // Single source of truth for the default; SupportedVoices documents
+                        // the full operator-selectable list. The adapter does NOT validate
+                        // against the list — operators can opt into a future OpenAI voice
+                        // without a code change, and OpenAI rejects unknown ones server-side.
+                        voice = string.IsNullOrEmpty(modelConfig.Voice) ? DefaultVoice : modelConfig.Voice,
                         // null for every assistant without an OutputAudioSpeed row; the
                         // caller's NullValueHandling.Ignore (RealtimeAiService.Connect.cs:23)
                         // strips the key entirely, so OpenAI uses its default 1.0.

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Providers/OpenAi/OpenAiRealtimeAiProviderAdapter.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Providers/OpenAi/OpenAiRealtimeAiProviderAdapter.cs
@@ -12,6 +12,22 @@ namespace SmartTalk.Core.Services.RealtimeAiV2.Adapters.Providers.OpenAi;
 
 public class OpenAiRealtimeAiProviderAdapter : IRealtimeAiProviderAdapter
 {
+    /// <summary>
+    /// Compile-time default for the OpenAI transcription model. As of 2026-05-19
+    /// <c>gpt-4o-transcribe</c> is OpenAI's most capable transcription model and is
+    /// priced identically to the legacy <c>whisper-1</c> ($0.006/min), so this is a
+    /// strict quality upgrade with no operating-cost change.
+    /// <para>
+    /// This is the ONE place to change when OpenAI ships a stronger default. Per-
+    /// assistant override goes through <see cref="RealtimeAiModelConfig.TranscriptionModel"/>
+    /// — operators who need to pin a specific assistant to <c>whisper-1</c> or to
+    /// <c>gpt-4o-mini-transcribe</c> (cheaper) do so by inserting a
+    /// <see cref="SmartTalk.Messages.Enums.AiSpeechAssistant.AiSpeechAssistantSessionConfigType.TranscriptionModel"/>
+    /// row in <c>ai_speech_assistant_function_call</c>.
+    /// </para>
+    /// </summary>
+    public const string DefaultTranscriptionModel = "gpt-4o-transcribe";
+
     private readonly OpenAiSettings _openAiSettings;
 
     public OpenAiRealtimeAiProviderAdapter(OpenAiSettings openAiSettings)
@@ -56,12 +72,22 @@ public class OpenAiRealtimeAiProviderAdapter : IRealtimeAiProviderAdapter
                     input = new
                     {
                         format = ConvertCodecToGaFormat(clientCodec),
-                        // `language` is null for every assistant with no TranscriptionLanguage
-                        // row in ai_speech_assistant_function_call; the caller's
-                        // NullValueHandling.Ignore (RealtimeAiService.Connect.cs:23) strips
-                        // the key entirely, so the transcription object stays byte-equivalent
-                        // to `{ model: "whisper-1" }` for every existing prod row.
-                        transcription = new { model = "whisper-1", language = modelConfig.TranscriptionLanguage },
+                        // model defaults to DefaultTranscriptionModel (currently gpt-4o-transcribe);
+                        // operators downgrade specific assistants to whisper-1 or gpt-4o-mini-transcribe
+                        // by populating a TranscriptionModel row in ai_speech_assistant_function_call.
+                        //
+                        // language is null when no TranscriptionLanguage row exists for the assistant;
+                        // the caller's NullValueHandling.Ignore (RealtimeAiService.Connect.cs:23) strips
+                        // the key entirely, keeping the transcription object byte-equivalent to
+                        // `{ model: <default> }` for every assistant without the language hint.
+                        transcription = new
+                        {
+                            // IsNullOrWhiteSpace (not IsNullOrEmpty) so an accidental " " or "\t"
+                            // in the config row also falls back to the adapter default rather than
+                            // being forwarded as an invalid model literal and rejected by OpenAI.
+                            model = string.IsNullOrWhiteSpace(modelConfig.TranscriptionModel) ? DefaultTranscriptionModel : modelConfig.TranscriptionModel,
+                            language = modelConfig.TranscriptionLanguage
+                        },
                         turn_detection = modelConfig.TurnDetection ?? new { type = "server_vad" },
                         noise_reduction = modelConfig.InputAudioNoiseReduction
                     },

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Providers/OpenAi/OpenAiRealtimeAiProviderAdapter.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Providers/OpenAi/OpenAiRealtimeAiProviderAdapter.cs
@@ -67,6 +67,11 @@ public class OpenAiRealtimeAiProviderAdapter : IRealtimeAiProviderAdapter
                 type = "realtime",
                 instructions = modelConfig.Prompt,
                 output_modalities = new[] { "audio" },
+                // null for every assistant without a MaxResponseOutputTokens row; the
+                // caller's NullValueHandling.Ignore (RealtimeAiService.Connect.cs:23)
+                // strips the key entirely, so OpenAI uses its server-side default
+                // (effectively unlimited within the session budget).
+                max_response_output_tokens = modelConfig.MaxResponseOutputTokens,
                 audio = new
                 {
                     input = new

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Providers/OpenAi/OpenAiRealtimeAiProviderAdapter.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Providers/OpenAi/OpenAiRealtimeAiProviderAdapter.cs
@@ -99,7 +99,11 @@ public class OpenAiRealtimeAiProviderAdapter : IRealtimeAiProviderAdapter
                     output = new
                     {
                         format = ConvertCodecToGaFormat(clientCodec),
-                        voice = string.IsNullOrEmpty(modelConfig.Voice) ? "alloy" : modelConfig.Voice
+                        voice = string.IsNullOrEmpty(modelConfig.Voice) ? "alloy" : modelConfig.Voice,
+                        // null for every assistant without an OutputAudioSpeed row; the
+                        // caller's NullValueHandling.Ignore (RealtimeAiService.Connect.cs:23)
+                        // strips the key entirely, so OpenAI uses its default 1.0.
+                        speed = modelConfig.OutputAudioSpeed
                     }
                 },
                 tools = modelConfig.Tools.Any() ? modelConfig.Tools : null

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Providers/OpenAi/OpenAiRealtimeAiProviderAdapter.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Providers/OpenAi/OpenAiRealtimeAiProviderAdapter.cs
@@ -28,6 +28,15 @@ public class OpenAiRealtimeAiProviderAdapter : IRealtimeAiProviderAdapter
     /// </summary>
     public const string DefaultTranscriptionModel = "gpt-4o-transcribe";
 
+    /// <summary>
+    /// Wire value emitted under <c>session.tracing</c> when an assistant opts into
+    /// OpenAI's official session tracing. As of 2026-05-20 OpenAI documents <c>"auto"</c>
+    /// as the no-config opt-in: OpenAI picks sensible defaults for workflow grouping
+    /// and retention. Operators see the captured sessions at
+    /// <c>https://platform.openai.com/traces</c>.
+    /// </summary>
+    public const string EnabledTracingMode = "auto";
+
     private readonly OpenAiSettings _openAiSettings;
 
     public OpenAiRealtimeAiProviderAdapter(OpenAiSettings openAiSettings)
@@ -72,6 +81,12 @@ public class OpenAiRealtimeAiProviderAdapter : IRealtimeAiProviderAdapter
                 // strips the key entirely, so OpenAI uses its server-side default
                 // (effectively unlimited within the session budget).
                 max_response_output_tokens = modelConfig.MaxResponseOutputTokens,
+                // null for every assistant without an opt-in RealtimeTracing row; the
+                // serializer strips the key, so OpenAI does not retain a trace
+                // (current behaviour). Setting EnableRealtimeTracing = true emits
+                // `tracing = "auto"` and the session shows up in the OpenAI
+                // traces dashboard for 30 days — escalation-debug tool.
+                tracing = modelConfig.EnableRealtimeTracing == true ? EnabledTracingMode : null,
                 audio = new
                 {
                     input = new

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Providers/OpenAi/OpenAiRealtimeAiProviderAdapter.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Providers/OpenAi/OpenAiRealtimeAiProviderAdapter.cs
@@ -254,15 +254,18 @@ public class OpenAiRealtimeAiProviderAdapter : IRealtimeAiProviderAdapter
                 case "session.updated":
                     return Result(RealtimeAiWssEventType.SessionInitialized, rawMessage);
 
-                // GA renamed several audio events; accept BOTH the old beta name and the new GA
-                // name so the deploy is robust to any leftover preview snapshots and to the GA
-                // models. https://learn.microsoft.com/en-us/azure/foundry/openai/how-to/realtime-audio-preview-api-migration-guide
-                case "response.audio.delta":
+                // Beta-era event names (`response.audio.delta`, `response.audio.done`,
+                // `response.audio_transcript.delta`, `response.audio_transcript.done`) were
+                // accepted alongside the GA names during the hotfix #934 transition window.
+                // OpenAI completed the GA cutover on 2026-05-07 and has not emitted Beta names
+                // in production logs for ≥ 2 weeks; the dual-case branches are removed here so
+                // a Beta-named event surfaces as Unknown (= operator-visible Serilog warning)
+                // rather than silently working — that surface signal is required to detect any
+                // future provider regression that would re-emit Beta names.
                 case "response.output_audio.delta":
                     var audioPayload = root.TryGetProperty("delta", out var deltaProp) ? deltaProp.GetString() : null;
                     return Result(RealtimeAiWssEventType.ResponseAudioDelta, new RealtimeAiWssAudioData { Base64Payload = audioPayload, ItemId = itemId });
 
-                case "response.audio.done":
                 case "response.output_audio.done":
                     return Result(RealtimeAiWssEventType.ResponseAudioDone);
 
@@ -278,11 +281,9 @@ public class OpenAiRealtimeAiProviderAdapter : IRealtimeAiProviderAdapter
                 case "conversation.item.input_audio_transcription.completed":
                     return Result(RealtimeAiWssEventType.InputAudioTranscriptionCompleted, Transcription("transcript", AiSpeechAssistantSpeaker.User));
 
-                case "response.audio_transcript.delta":
                 case "response.output_audio_transcript.delta":
                     return Result(RealtimeAiWssEventType.OutputAudioTranscriptionPartial, Transcription("delta", AiSpeechAssistantSpeaker.Ai));
 
-                case "response.audio_transcript.done":
                 case "response.output_audio_transcript.done":
                     return Result(RealtimeAiWssEventType.OutputAudioTranscriptionCompleted, Transcription("transcript", AiSpeechAssistantSpeaker.Ai));
 

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/RealtimeSessionOptions.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/RealtimeSessionOptions.cs
@@ -83,6 +83,15 @@ public class RealtimeAiModelConfig
     /// than the adapter silently falling back.
     /// </summary>
     public string TranscriptionModel { get; set; }
+
+    /// <summary>
+    /// Optional cap on the response output tokens for a single AI turn, sent under
+    /// <c>session.max_response_output_tokens</c>. <c>null</c> → the field is omitted
+    /// from the payload (the caller's <see cref="Newtonsoft.Json.NullValueHandling.Ignore"/>
+    /// strips it), so OpenAI uses its server-side default. Positive integer → caps a
+    /// runaway monologue; OpenAI rejects non-positive integers server-side.
+    /// </summary>
+    public int? MaxResponseOutputTokens { get; set; }
 }
 
 /// <summary>

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/RealtimeSessionOptions.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/RealtimeSessionOptions.cs
@@ -61,6 +61,17 @@ public class RealtimeAiModelConfig
     /// OpenAI-specific input audio noise reduction configuration. Ignored by other providers.
     /// </summary>
     public object InputAudioNoiseReduction { get; set; }
+
+    /// <summary>
+    /// Optional ISO-639-1 language code (or <c>"yue"</c> for Cantonese) hinted to
+    /// OpenAI's transcription model. <c>null</c> or empty → no hint emitted, leaving
+    /// the GA <c>session.audio.input.transcription</c> object byte-equivalent to the
+    /// pre-hint payload. A non-null value is appended as the <c>language</c> property
+    /// next to <c>model</c>; the adapter relies on the caller's
+    /// <see cref="Newtonsoft.Json.NullValueHandling.Ignore"/> setting (active in
+    /// <c>RealtimeAiService.Connect</c>) to strip the property when the value is null.
+    /// </summary>
+    public string TranscriptionLanguage { get; set; }
 }
 
 /// <summary>

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/RealtimeSessionOptions.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/RealtimeSessionOptions.cs
@@ -92,6 +92,15 @@ public class RealtimeAiModelConfig
     /// runaway monologue; OpenAI rejects non-positive integers server-side.
     /// </summary>
     public int? MaxResponseOutputTokens { get; set; }
+
+    /// <summary>
+    /// Optional playback-speed multiplier for the AI's audio output, sent under
+    /// <c>session.audio.output.speed</c>. <c>null</c> → the field is omitted (so
+    /// OpenAI uses 1.0, current behaviour). Range supported by OpenAI is 0.25 – 1.5
+    /// (1.0 = natural). Values outside the range are rejected by OpenAI server-side
+    /// rather than the adapter silently clamping.
+    /// </summary>
+    public decimal? OutputAudioSpeed { get; set; }
 }
 
 /// <summary>

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/RealtimeSessionOptions.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/RealtimeSessionOptions.cs
@@ -72,6 +72,17 @@ public class RealtimeAiModelConfig
     /// <c>RealtimeAiService.Connect</c>) to strip the property when the value is null.
     /// </summary>
     public string TranscriptionLanguage { get; set; }
+
+    /// <summary>
+    /// Optional override of the OpenAI transcription model string sent under
+    /// <c>session.audio.input.transcription.model</c>. <c>null</c> or empty →
+    /// adapter uses its compile-time default (currently <c>gpt-4o-transcribe</c>).
+    /// Recognised operator values: <c>"whisper-1"</c>, <c>"gpt-4o-mini-transcribe"</c>,
+    /// <c>"gpt-4o-transcribe"</c>. Unrecognised values are passed through verbatim
+    /// (operator's responsibility) — OpenAI will reject them server-side rather
+    /// than the adapter silently falling back.
+    /// </summary>
+    public string TranscriptionModel { get; set; }
 }
 
 /// <summary>

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/RealtimeSessionOptions.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/RealtimeSessionOptions.cs
@@ -101,6 +101,15 @@ public class RealtimeAiModelConfig
     /// rather than the adapter silently clamping.
     /// </summary>
     public decimal? OutputAudioSpeed { get; set; }
+
+    /// <summary>
+    /// Optional opt-in to OpenAI's official session tracing. <c>true</c> → adapter
+    /// emits <c>session.tracing = "auto"</c>, telling OpenAI to retain the session
+    /// in their trace dashboard for 30 days. <c>null</c> or <c>false</c> → the
+    /// <c>tracing</c> field is omitted (current behaviour). Use during customer
+    /// escalations to capture an intermittent reproduction; disable afterwards.
+    /// </summary>
+    public bool? EnableRealtimeTracing { get; set; }
 }
 
 /// <summary>

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/RealtimeSessionOptions.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/RealtimeSessionOptions.cs
@@ -222,6 +222,15 @@ public class RealtimeSessionOptions
     /// Parameters: (sessionId, wavBytes).
     /// </summary>
     public Func<string, byte[], Task> OnRecordingCompleteAsync { get; set; }
+
+    /// <summary>
+    /// Called when the provider reports token usage for an AI turn (currently OpenAI's
+    /// <c>response.done.response.usage</c>). Invoked once per turn that includes a usage
+    /// block. <c>null</c> callback skips the notification entirely — older provider
+    /// snapshots without usage data continue to work transparently. Use to log
+    /// per-call costs or push to a cost-tracking dashboard.
+    /// </summary>
+    public Func<RealtimeAiWssUsageData, Task> OnResponseUsageReceivedAsync { get; set; }
 }
 
 public class RealtimeSessionIdleFollowUp

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Services/RealtimeAiService.Event.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Services/RealtimeAiService.Event.cs
@@ -47,6 +47,8 @@ public partial class RealtimeAiService
                 case RealtimeAiWssEventType.ResponseTurnCompleted:
                     if (parsedEvent.Data is List<RealtimeAiWssFunctionCallData> functionCalls)
                         await OnFunctionCallsReceivedAsync(functionCalls).ConfigureAwait(false);
+                    if (parsedEvent.Usage != null)
+                        await OnResponseUsageReceivedAsync(parsedEvent.Usage).ConfigureAwait(false);
                     await OnAiTurnCompletedAsync().ConfigureAwait(false);
                     break;
 
@@ -163,6 +165,23 @@ public partial class RealtimeAiService
         await SendToClientAsync(_ctx.ClientAdapter.BuildTranscriptionMessage(eventType, transcriptionData, _ctx.SessionId)).ConfigureAwait(false);
     }
     
+    private async Task OnResponseUsageReceivedAsync(RealtimeAiWssUsageData usage)
+    {
+        // Always log the breakdown — gives ops a free cost-tracking signal in
+        // structured Serilog properties even when the consumer doesn't wire a callback.
+        Log.Information(
+            "[RealtimeAi] Token usage reported, SessionId: {SessionId}, Round: {Round}, " +
+            "Total: {Total}, Input: {Input}, Output: {Output}, Cached: {Cached}, " +
+            "InputAudio: {InputAudio}, InputText: {InputText}, OutputAudio: {OutputAudio}, OutputText: {OutputText}",
+            _ctx.SessionId, _ctx.Round,
+            usage.TotalTokens, usage.InputTokens, usage.OutputTokens, usage.CachedTokens,
+            usage.InputAudioTokens, usage.InputTextTokens, usage.OutputAudioTokens, usage.OutputTextTokens);
+
+        if (_ctx.Options.OnResponseUsageReceivedAsync == null) return;
+
+        await _ctx.Options.OnResponseUsageReceivedAsync(usage).ConfigureAwait(false);
+    }
+
     private async Task OnFunctionCallsReceivedAsync(List<RealtimeAiWssFunctionCallData> functionCalls)
     {
         if (_ctx.Options.OnFunctionCallAsync == null) return;

--- a/src/SmartTalk.Core/Services/Timer/InactivityTimerManager.cs
+++ b/src/SmartTalk.Core/Services/Timer/InactivityTimerManager.cs
@@ -67,6 +67,11 @@ public class InactivityTimerManager : IInactivityTimerManager
         try
         {
             await Task.Delay(entry.Timeout, entry.Cts.Token).ConfigureAwait(false);
+            
+            // The timer may have been replaced for the same sessionId while this task
+            // was waiting. Only the current active entry is allowed to invoke callback.
+            if (!_timers.TryGetValue(sessionId, out var activeEntry) || !ReferenceEquals(activeEntry, entry)) return;
+            
             await entry.OnTimeout().ConfigureAwait(false);
         }
         catch (OperationCanceledException) { }
@@ -80,10 +85,9 @@ public class InactivityTimerManager : IInactivityTimerManager
         }
         finally
         {
-            // Remove only if the current dictionary value is exactly this timer entry.
-            // Prevents an older timer's finally from removing a newer timer for the same session.
-            ((ICollection<KeyValuePair<string, TimerEntry>>)_timers)
-                .Remove(new KeyValuePair<string, TimerEntry>(sessionId, entry));
+            // Remove only if this exact entry is still mapped. Avoid deleting a newer
+            // timer that might have been started for the same session in the meantime.
+            _timers.TryRemove(new KeyValuePair<string, TimerEntry>(sessionId, entry));
         }
     }
 }

--- a/src/SmartTalk.IntegrationTests/Services/AiSpeechAssistant/AiSpeechAssistantConnectFixture.FunctionCalls.cs
+++ b/src/SmartTalk.IntegrationTests/Services/AiSpeechAssistant/AiSpeechAssistantConnectFixture.FunctionCalls.cs
@@ -530,7 +530,7 @@ public partial class AiSpeechAssistantConnectFixture
         openaiWs.EnqueueMessage(JsonConvert.SerializeObject(new { type = "session.updated" }));
         openaiWs.EnqueueMessage(JsonConvert.SerializeObject(new
         {
-            type = "response.audio.delta",
+            type = "response.output_audio.delta",
             delta = "dGVzdGF1ZGlvZGF0YQ==",
             item_id = "item_delta_001"
         }));

--- a/src/SmartTalk.IntegrationTests/Services/AiSpeechAssistant/AiSpeechAssistantConnectFixture.KnowledgeBase.cs
+++ b/src/SmartTalk.IntegrationTests/Services/AiSpeechAssistant/AiSpeechAssistantConnectFixture.KnowledgeBase.cs
@@ -13,6 +13,7 @@ using SmartTalk.Core.Services.Jobs;
 using SmartTalk.IntegrationTests.Mocks;
 using SmartTalk.Messages.Commands.AiSpeechAssistant;
 using SmartTalk.Messages.Dto.Agent;
+using SmartTalk.Messages.Dto.Smarties;
 using SmartTalk.Messages.Enums.AiSpeechAssistant;
 using SmartTalk.Messages.Enums.RealtimeAi;
 using Xunit;
@@ -223,6 +224,131 @@ public partial class AiSpeechAssistantConnectFixture
 
         // Session update sent to OpenAI proves the service proceeded past the service hours check
         openaiWs.SentMessages.ShouldNotBeEmpty();
+    }
+
+    [Fact]
+    public async Task ShouldResolveCrossTokenCascade_GreetingContainingCustomerItemsToken_NestedTokenAlsoResolved()
+    {
+        // ── Characterization test for the cross-token cascade invariant ──────────
+        //
+        // The original BuildKnowledgeAsync ran each ResolveX sequentially:
+        //   ResolveGreeting injects greeting text → mutates _ctx.Prompt
+        //   ResolveCustomerItems then re-reads _ctx.Prompt and processes any tokens
+        //   that the greeting injection introduced.
+        //
+        // This test pins that emergent behaviour: an operator who configures a
+        // SaleAutoCallNumber greeting containing `#{customer_items}` expects the
+        // customer items to actually appear in the final prompt, NOT a raw
+        // `#{customer_items}` literal that the LLM would treat as broken markup.
+        //
+        // Any refactor that pre-collects token-presence checks (e.g. a hypothetical
+        // "all fetches first, then all applies" rearrangement) would break this
+        // cascade because the customer-items token-presence check would run against
+        // the pre-greeting prompt and find no token — the greeting injection later
+        // would then leak the raw `#{customer_items}` literal.
+        //
+        // The Resolve order in BuildKnowledgeAsync is: Greeting → CustomerItems →
+        // MenuItems → CustomerInfo → POS → Delivery. Cascade only chains FORWARDS
+        // in that order — a greeting can inject any downstream token; CustomerInfo
+        // cannot inject `#{greeting}` (Greeting already ran). This test exercises
+        // the most-reachable cascade: Greeting → CustomerItems.
+
+        await RunWithUnitOfWork<IRepository, IUnitOfWork>(async (repository, unitOfWork) =>
+        {
+            var agent = new Agent { Name = "TestAgent", IsReceiveCall = true, Type = AgentType.Assistant };
+            await repository.InsertAsync(agent);
+
+            var assistant = new Core.Domain.AISpeechAssistant.AiSpeechAssistant
+            {
+                Name = "CascadeAssistant",
+                AnsweringNumber = TestDidNumber,
+                ModelProvider = RealtimeAiProvider.OpenAi,
+                ModelVoice = "alloy",
+                IsDefault = true,
+                IsDisplay = true
+            };
+            await repository.InsertAsync(assistant);
+            await unitOfWork.SaveChangesAsync();
+
+            await repository.InsertAsync(new AgentAssistant { AgentId = agent.Id, AssistantId = assistant.Id });
+            await repository.InsertAsync(new AiSpeechAssistantKnowledge
+            {
+                AssistantId = assistant.Id,
+                Prompt = "Greeting: #{greeting} End.",
+                IsActive = true,
+                Version = "1.0"
+            });
+
+            // Customer-items cache that the cascade should reach. Distinct literals
+            // so the assertion can confirm the cascade actually resolved the token
+            // (not just that the raw literal happens to be absent for some other reason).
+            // The cache row is keyed by the fixed "customer_items" CacheKey + the
+            // assistant Name in Filter — see SalesDataProvider.CustomerItemsCacheKey.
+            await repository.InsertAsync(new Core.Domain.Sales.AiSpeechAssistantKnowledgeVariableCache
+            {
+                CacheKey = "customer_items",
+                Filter = "CascadeAssistant",
+                CacheValue = "CASCADE_MARKER_PIZZA_LARGE"
+            });
+        });
+
+        // Smarties returns a greeting that EMBEDS the downstream token literal.
+        // The original code's cascade then processes that token when ResolveCustomerItems runs.
+        var smartiesMock = Substitute.For<ISmartiesClient>();
+        smartiesMock.GetSaleAutoCallNumberAsync(Arg.Any<GetSaleAutoCallNumberRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new GetSaleAutoCallNumberResponse
+            {
+                Data = new GetSaleAutoCallNumberResponseData
+                {
+                    Number = new SettingNumberDto
+                    {
+                        Greeting = "Welcome! Today's items: #{customer_items}"
+                    }
+                }
+            });
+
+        var twilioWs = new MockWebSocket();
+        twilioWs.EnqueueMessage(JsonConvert.SerializeObject(new
+        {
+            @event = "start",
+            start = new { callSid = "CA_CASCADE_TEST", streamSid = "MZ_CASCADE_TEST" }
+        }));
+
+        var openaiWs = CreateProviderMock();
+        openaiWs.EnqueueMessage(JsonConvert.SerializeObject(new { type = "session.updated" }));
+
+        var command = new ConnectAiSpeechAssistantCommand
+        {
+            From = TestCallerNumber,
+            To = TestDidNumber,
+            Host = TestHost,
+            TwilioWebSocket = twilioWs,
+            NumberId = 42   // Must be non-null so ResolveGreetingAsync fires
+        };
+
+        await Run<IMediator>(async mediator =>
+        {
+            await mediator.SendAsync(command);
+        }, builder =>
+        {
+            builder.RegisterInstance(Substitute.For<ISmartTalkBackgroundJobClient>()).As<ISmartTalkBackgroundJobClient>();
+            builder.RegisterInstance(smartiesMock).AsImplementedInterfaces();
+            openaiWs.Register(builder);
+        });
+
+        openaiWs.SentMessages.ShouldNotBeEmpty();
+        var sessionUpdate = Encoding.UTF8.GetString(openaiWs.SentMessages.First());
+
+        // Greeting was injected
+        sessionUpdate.ShouldContain("Welcome!");
+
+        // CASCADE invariant: the downstream token embedded in the greeting MUST
+        // have been resolved. The raw `#{customer_items}` literal MUST NOT remain.
+        sessionUpdate.ShouldNotContain("#{customer_items}");
+
+        // The customer-items cache value MUST appear in the final prompt — the
+        // proof that the cascade actually fetched and substituted, not just stripped.
+        sessionUpdate.ShouldContain("CASCADE_MARKER_PIZZA_LARGE");
     }
 
     [Fact]

--- a/src/SmartTalk.Messages/Dto/RealtimeAi/RealtimeAiWssDto.cs
+++ b/src/SmartTalk.Messages/Dto/RealtimeAi/RealtimeAiWssDto.cs
@@ -46,12 +46,54 @@ public class RealtimeAiFunctionCallResult
 public class ParsedRealtimeAiProviderEvent
 {
     public RealtimeAiWssEventType Type { get; set; }
-    
+
     public object Data { get; set; }
-    
+
     public string RawJson { get; set; }
-    
+
     public string ItemId { get; set; }
+
+    /// <summary>
+    /// Token usage for the AI turn, populated by the provider adapter when the
+    /// provider emits usage data alongside the turn-completion event (currently
+    /// OpenAI's <c>response.done.response.usage</c>). <c>null</c> when the
+    /// underlying message has no usage block (older provider snapshots) or when
+    /// the event type does not carry usage. Sits on the event rather than on
+    /// <see cref="Data"/> so it can coexist with function-call payloads.
+    /// </summary>
+    public RealtimeAiWssUsageData Usage { get; set; }
+}
+
+/// <summary>
+/// Per-turn token-usage breakdown reported by the AI provider on turn completion.
+/// All fields nullable because providers may omit individual sub-counts; consumers
+/// should treat missing values as "not reported" rather than zero.
+/// </summary>
+public class RealtimeAiWssUsageData
+{
+    /// <summary>Total tokens consumed for this turn (input + output).</summary>
+    public int? TotalTokens { get; set; }
+
+    /// <summary>Tokens consumed from the prompt / conversation history.</summary>
+    public int? InputTokens { get; set; }
+
+    /// <summary>Tokens produced by the AI in this turn.</summary>
+    public int? OutputTokens { get; set; }
+
+    /// <summary>Subset of input tokens served from the provider's prompt cache.</summary>
+    public int? CachedTokens { get; set; }
+
+    /// <summary>Subset of input tokens classified as audio (rather than text).</summary>
+    public int? InputAudioTokens { get; set; }
+
+    /// <summary>Subset of input tokens classified as text.</summary>
+    public int? InputTextTokens { get; set; }
+
+    /// <summary>Subset of output tokens classified as audio (rather than text).</summary>
+    public int? OutputAudioTokens { get; set; }
+
+    /// <summary>Subset of output tokens classified as text.</summary>
+    public int? OutputTextTokens { get; set; }
 }
 
 public class RealtimeAiErrorData

--- a/src/SmartTalk.Messages/Enums/AiSpeechAssistant/AiSpeechAssistantSessionConfigType.cs
+++ b/src/SmartTalk.Messages/Enums/AiSpeechAssistant/AiSpeechAssistantSessionConfigType.cs
@@ -25,5 +25,16 @@ public enum AiSpeechAssistantSessionConfigType
     /// Unrecognised values are passed through verbatim — OpenAI will reject
     /// them server-side rather than the adapter silently substituting.
     /// </summary>
-    TranscriptionModel
+    TranscriptionModel,
+
+    /// <summary>
+    /// Optional per-assistant cap on the response output token count. Row
+    /// content is a JSON object with a single <c>value</c> property holding a
+    /// positive integer. Example: <c>{ "value": 1200 }</c>. Absent / inactive
+    /// row → no <c>max_response_output_tokens</c> field is sent, so OpenAI
+    /// uses its server-side default (effectively unlimited within the session
+    /// budget). Caps a single AI turn — useful when an assistant occasionally
+    /// monologues and delays the user's next prompt.
+    /// </summary>
+    MaxResponseOutputTokens
 }

--- a/src/SmartTalk.Messages/Enums/AiSpeechAssistant/AiSpeechAssistantSessionConfigType.cs
+++ b/src/SmartTalk.Messages/Enums/AiSpeechAssistant/AiSpeechAssistantSessionConfigType.cs
@@ -4,5 +4,14 @@ public enum AiSpeechAssistantSessionConfigType
 {
     Tool,
     TurnDirection,
-    InputAudioNoiseReduction
+    InputAudioNoiseReduction,
+
+    /// <summary>
+    /// Optional hint for OpenAI's transcription model. Row content is a JSON
+    /// object with a single <c>language</c> property — ISO-639-1 code or
+    /// <c>"yue"</c> for Cantonese. Example:
+    /// <c>{ "language": "yue" }</c>.
+    /// Absent / inactive row → no hint sent (current default behaviour).
+    /// </summary>
+    TranscriptionLanguage
 }

--- a/src/SmartTalk.Messages/Enums/AiSpeechAssistant/AiSpeechAssistantSessionConfigType.cs
+++ b/src/SmartTalk.Messages/Enums/AiSpeechAssistant/AiSpeechAssistantSessionConfigType.cs
@@ -47,5 +47,18 @@ public enum AiSpeechAssistantSessionConfigType
     /// Absent / inactive row → no <c>speed</c> field is sent, so OpenAI uses
     /// 1.0 (current behaviour).
     /// </summary>
-    OutputAudioSpeed
+    OutputAudioSpeed,
+
+    /// <summary>
+    /// Optional per-assistant opt-in to OpenAI's official session tracing.
+    /// Row content is a JSON object with a single boolean <c>enabled</c>
+    /// property. Example: <c>{ "enabled": true }</c>. Absent / inactive row
+    /// or <c>{ "enabled": false }</c> → no <c>tracing</c> field is sent, so
+    /// OpenAI does not retain a session trace (current behaviour). When
+    /// enabled the adapter sends <c>tracing = "auto"</c>, which makes OpenAI
+    /// retain the session in <c>platform.openai.com/traces</c> for 30 days —
+    /// essential for diagnosing intermittent calls during customer
+    /// escalations. Disable after capturing the reproduction.
+    /// </summary>
+    RealtimeTracing
 }

--- a/src/SmartTalk.Messages/Enums/AiSpeechAssistant/AiSpeechAssistantSessionConfigType.cs
+++ b/src/SmartTalk.Messages/Enums/AiSpeechAssistant/AiSpeechAssistantSessionConfigType.cs
@@ -36,5 +36,16 @@ public enum AiSpeechAssistantSessionConfigType
     /// budget). Caps a single AI turn — useful when an assistant occasionally
     /// monologues and delays the user's next prompt.
     /// </summary>
-    MaxResponseOutputTokens
+    MaxResponseOutputTokens,
+
+    /// <summary>
+    /// Optional per-assistant playback-speed multiplier for the AI's audio
+    /// output. Row content is a JSON object with a single <c>value</c>
+    /// property holding a decimal in the range supported by OpenAI (currently
+    /// 0.25 – 1.5; 1.0 = natural). Example: <c>{ "value": 0.9 }</c> for
+    /// elderly customers, <c>{ "value": 1.1 }</c> for fast-paced ones.
+    /// Absent / inactive row → no <c>speed</c> field is sent, so OpenAI uses
+    /// 1.0 (current behaviour).
+    /// </summary>
+    OutputAudioSpeed
 }

--- a/src/SmartTalk.Messages/Enums/AiSpeechAssistant/AiSpeechAssistantSessionConfigType.cs
+++ b/src/SmartTalk.Messages/Enums/AiSpeechAssistant/AiSpeechAssistantSessionConfigType.cs
@@ -13,5 +13,17 @@ public enum AiSpeechAssistantSessionConfigType
     /// <c>{ "language": "yue" }</c>.
     /// Absent / inactive row → no hint sent (current default behaviour).
     /// </summary>
-    TranscriptionLanguage
+    TranscriptionLanguage,
+
+    /// <summary>
+    /// Optional per-assistant override of the OpenAI transcription model. Row
+    /// content is a JSON object with a single <c>model</c> property. Example:
+    /// <c>{ "model": "whisper-1" }</c> (downgrade) or
+    /// <c>{ "model": "gpt-4o-mini-transcribe" }</c> (cheaper variant).
+    /// Absent / inactive row → adapter falls back to its compile-time default
+    /// (<c>gpt-4o-transcribe</c>, OpenAI's most capable transcription model).
+    /// Unrecognised values are passed through verbatim — OpenAI will reject
+    /// them server-side rather than the adapter silently substituting.
+    /// </summary>
+    TranscriptionModel
 }

--- a/src/SmartTalk.UnitTests/Services/AiSpeechAssistantConnect/ParseEnableRealtimeTracingTests.cs
+++ b/src/SmartTalk.UnitTests/Services/AiSpeechAssistantConnect/ParseEnableRealtimeTracingTests.cs
@@ -1,0 +1,100 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Shouldly;
+using SmartTalk.Core.Services.AiSpeechAssistantConnect;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Services.AiSpeechAssistantConnect;
+
+/// <summary>
+/// Exercises every input shape <see cref="AiSpeechAssistantConnectService.ParseEnableRealtimeTracing"/>
+/// might receive from the deserialised <c>ai_speech_assistant_function_call.content</c> JSON.
+///
+/// <para>
+/// The single load-bearing invariant: anything that should leave tracing OFF
+/// (current behaviour — OpenAI does NOT retain a session trace) MUST return
+/// <c>null</c>. Only an explicit <c>{ "enabled": true }</c> activates tracing.
+/// An explicit <c>{ "enabled": false }</c> also returns null — operators can
+/// persist the row in the inactive state without accidentally enabling tracing,
+/// distinguishing "deliberately off" from "no row" semantically.
+/// </para>
+/// </summary>
+public class ParseEnableRealtimeTracingTests
+{
+    private static object DeserializeContent(string json) => JsonConvert.DeserializeObject<object>(json);
+
+    // ── Default-path inputs (every one of these must return null) ──────────
+
+    [Fact]
+    public void ParseEnableRealtimeTracing_NullInput_ReturnsNull()
+    {
+        AiSpeechAssistantConnectService.ParseEnableRealtimeTracing(null).ShouldBeNull();
+    }
+
+    [Fact]
+    public void ParseEnableRealtimeTracing_NonJObjectInput_ReturnsNull()
+    {
+        AiSpeechAssistantConnectService.ParseEnableRealtimeTracing(JArray.Parse("[true]")).ShouldBeNull();
+        AiSpeechAssistantConnectService.ParseEnableRealtimeTracing(true).ShouldBeNull();
+        AiSpeechAssistantConnectService.ParseEnableRealtimeTracing("true").ShouldBeNull();
+    }
+
+    [Fact]
+    public void ParseEnableRealtimeTracing_EmptyJsonObject_ReturnsNull()
+    {
+        AiSpeechAssistantConnectService.ParseEnableRealtimeTracing(DeserializeContent("{}")).ShouldBeNull();
+    }
+
+    [Fact]
+    public void ParseEnableRealtimeTracing_EnabledPropertyExplicitNull_ReturnsNull()
+    {
+        AiSpeechAssistantConnectService.ParseEnableRealtimeTracing(DeserializeContent("{\"enabled\":null}")).ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData("{\"enabled\":\"true\"}")]    // string instead of bool
+    [InlineData("{\"enabled\":1}")]            // integer
+    [InlineData("{\"enabled\":[true]}")]       // array
+    public void ParseEnableRealtimeTracing_NonBooleanValue_ReturnsNull(string content)
+    {
+        // The schema requires a real JSON boolean. Anything else (string-coercible
+        // truthy values, numbers, arrays) is treated as malformed → tracing stays off.
+        AiSpeechAssistantConnectService.ParseEnableRealtimeTracing(DeserializeContent(content)).ShouldBeNull();
+    }
+
+    [Fact]
+    public void ParseEnableRealtimeTracing_ExplicitFalse_ReturnsNull()
+    {
+        // An explicit `{ "enabled": false }` MUST behave identically to a missing row
+        // or an inactive row. Operators sometimes persist the "off" state explicitly
+        // (e.g. via UI checkbox that defaults to false); we must not interpret that
+        // as a tracing opt-in.
+        AiSpeechAssistantConnectService.ParseEnableRealtimeTracing(DeserializeContent("{\"enabled\":false}")).ShouldBeNull();
+    }
+
+    // ── Active opt-in inputs ───────────────────────────────────────────────
+
+    [Fact]
+    public void ParseEnableRealtimeTracing_ExplicitTrue_ReturnsTrue()
+    {
+        AiSpeechAssistantConnectService.ParseEnableRealtimeTracing(DeserializeContent("{\"enabled\":true}")).ShouldBe(true);
+    }
+
+    [Fact]
+    public void ParseEnableRealtimeTracing_AdditionalProperties_StillExtractsEnabled()
+    {
+        // Forward-compatibility for future schema additions (e.g. workflow_name,
+        // group_id for finer-grained OpenAI trace classification). Extras are
+        // ignored; the parser only reads `enabled`.
+        var input = DeserializeContent("{\"enabled\":true,\"workflow_name\":\"escalation_123\",\"group_id\":\"ops\"}");
+
+        AiSpeechAssistantConnectService.ParseEnableRealtimeTracing(input).ShouldBe(true);
+    }
+
+    [Fact]
+    public void ParseEnableRealtimeTracing_EnabledKeyIsCaseSensitive()
+    {
+        AiSpeechAssistantConnectService.ParseEnableRealtimeTracing(DeserializeContent("{\"Enabled\":true}")).ShouldBeNull();
+        AiSpeechAssistantConnectService.ParseEnableRealtimeTracing(DeserializeContent("{\"ENABLED\":true}")).ShouldBeNull();
+    }
+}

--- a/src/SmartTalk.UnitTests/Services/AiSpeechAssistantConnect/ParseMaxResponseOutputTokensTests.cs
+++ b/src/SmartTalk.UnitTests/Services/AiSpeechAssistantConnect/ParseMaxResponseOutputTokensTests.cs
@@ -1,0 +1,128 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Shouldly;
+using SmartTalk.Core.Services.AiSpeechAssistantConnect;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Services.AiSpeechAssistantConnect;
+
+/// <summary>
+/// Exercises every input shape <see cref="AiSpeechAssistantConnectService.ParseMaxResponseOutputTokens"/>
+/// might receive from the deserialised <c>ai_speech_assistant_function_call.content</c> JSON.
+///
+/// <para>
+/// The single load-bearing invariant: anything that should leave the response cap
+/// unset (so OpenAI uses its server-side default) MUST return <c>null</c> here.
+/// In particular, a non-positive integer (zero or negative) — which OpenAI rejects
+/// or which would silently truncate AI responses to empty turns — is rejected by
+/// the parser rather than passed through.
+/// </para>
+///
+/// <para>
+/// Mirrors the structure of <see cref="ParseTranscriptionLanguageTests"/> and
+/// <see cref="ParseTranscriptionModelTests"/>; the three parsers share the same
+/// null-safety contract so regressions are visible in all three suites together.
+/// </para>
+/// </summary>
+public class ParseMaxResponseOutputTokensTests
+{
+    private static object DeserializeContent(string json) => JsonConvert.DeserializeObject<object>(json);
+
+    // ── Default-path inputs (every one of these must return null) ──────────
+
+    [Fact]
+    public void ParseMaxResponseOutputTokens_NullInput_ReturnsNull()
+    {
+        // Realistic prod state: no MaxResponseOutputTokens row exists, so
+        // DeserializeFunctionCallConfig returns null. The parser must propagate
+        // null so the adapter omits the cap field entirely.
+        AiSpeechAssistantConnectService.ParseMaxResponseOutputTokens(null).ShouldBeNull();
+    }
+
+    [Fact]
+    public void ParseMaxResponseOutputTokens_NonJObjectInput_ReturnsNull()
+    {
+        // Defence: future config rows whose content is a JSON array or scalar
+        // (not the expected `{ "value": <int> }` shape) must not throw.
+        AiSpeechAssistantConnectService.ParseMaxResponseOutputTokens(JArray.Parse("[1200]")).ShouldBeNull();
+        AiSpeechAssistantConnectService.ParseMaxResponseOutputTokens(1200).ShouldBeNull();
+        AiSpeechAssistantConnectService.ParseMaxResponseOutputTokens("1200").ShouldBeNull();
+    }
+
+    [Fact]
+    public void ParseMaxResponseOutputTokens_EmptyJsonObject_ReturnsNull()
+    {
+        // A row whose content is `{}` — the value property is missing entirely.
+        AiSpeechAssistantConnectService.ParseMaxResponseOutputTokens(DeserializeContent("{}")).ShouldBeNull();
+    }
+
+    [Fact]
+    public void ParseMaxResponseOutputTokens_ValuePropertyExplicitNull_ReturnsNull()
+    {
+        // `{ "value": null }` — operator (or migration) saved an explicit null.
+        // Must behave identically to "key missing".
+        AiSpeechAssistantConnectService.ParseMaxResponseOutputTokens(DeserializeContent("{\"value\":null}")).ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData("{\"value\":\"1200\"}")]   // string instead of int — schema violation
+    [InlineData("{\"value\":1.5}")]        // floating-point — schema violation
+    [InlineData("{\"value\":true}")]       // bool — schema violation
+    [InlineData("{\"value\":[1200]}")]     // array — schema violation
+    public void ParseMaxResponseOutputTokens_NonIntegerValue_ReturnsNull(string content)
+    {
+        // The JSON schema requires the value to be a plain integer. Anything else
+        // (string-coercible numbers, floats, bools, structured values) is treated
+        // as malformed — adapter falls back to no cap, which is safer than
+        // attempting a fragile coercion that could send an invalid value to OpenAI.
+        AiSpeechAssistantConnectService.ParseMaxResponseOutputTokens(DeserializeContent(content)).ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData("{\"value\":0}")]
+    [InlineData("{\"value\":-1}")]
+    [InlineData("{\"value\":-1000}")]
+    public void ParseMaxResponseOutputTokens_NonPositiveValue_ReturnsNull(string content)
+    {
+        // Zero or negative caps are either rejected by OpenAI server-side (invalid)
+        // or silently truncate AI responses to empty turns (one), both worse than
+        // omitting the cap. Reject at the parser layer.
+        AiSpeechAssistantConnectService.ParseMaxResponseOutputTokens(DeserializeContent(content)).ShouldBeNull();
+    }
+
+    // ── Active cap inputs ─────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("{\"value\":1}",     1)]      // minimum valid (degenerate but technically valid)
+    [InlineData("{\"value\":100}",   100)]
+    [InlineData("{\"value\":800}",   800)]    // recommended low end for restaurant turns
+    [InlineData("{\"value\":1200}",  1200)]   // recommended typical cap
+    [InlineData("{\"value\":4096}",  4096)]   // common upper bound
+    [InlineData("{\"value\":100000}", 100000)] // very generous cap — operator's choice
+    public void ParseMaxResponseOutputTokens_PositiveIntegerValue_ReturnsExactInteger(string content, int expected)
+    {
+        // No upper bound is enforced — operators choose the cap they want, and
+        // OpenAI rejects values beyond its server-side limits with a clear error
+        // rather than us silently clamping.
+        AiSpeechAssistantConnectService.ParseMaxResponseOutputTokens(DeserializeContent(content)).ShouldBe(expected);
+    }
+
+    [Fact]
+    public void ParseMaxResponseOutputTokens_AdditionalProperties_StillExtractsValue()
+    {
+        // Forward-compatibility: future schema additions (e.g. an operator note,
+        // a per-turn override) must not trip the parser.
+        var input = DeserializeContent("{\"value\":1200,\"note\":\"cap monologues\",\"applies_to\":\"all_turns\"}");
+
+        AiSpeechAssistantConnectService.ParseMaxResponseOutputTokens(input).ShouldBe(1200);
+    }
+
+    [Fact]
+    public void ParseMaxResponseOutputTokens_ValueKeyIsCaseSensitive()
+    {
+        // Wire-format property name is `value` (lowercase). A row with `Value` or
+        // `VALUE` is treated as malformed (= no cap) rather than silently activated.
+        AiSpeechAssistantConnectService.ParseMaxResponseOutputTokens(DeserializeContent("{\"Value\":1200}")).ShouldBeNull();
+        AiSpeechAssistantConnectService.ParseMaxResponseOutputTokens(DeserializeContent("{\"VALUE\":1200}")).ShouldBeNull();
+    }
+}

--- a/src/SmartTalk.UnitTests/Services/AiSpeechAssistantConnect/ParseOutputAudioSpeedTests.cs
+++ b/src/SmartTalk.UnitTests/Services/AiSpeechAssistantConnect/ParseOutputAudioSpeedTests.cs
@@ -1,0 +1,127 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Shouldly;
+using SmartTalk.Core.Services.AiSpeechAssistantConnect;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Services.AiSpeechAssistantConnect;
+
+/// <summary>
+/// Exercises every input shape <see cref="AiSpeechAssistantConnectService.ParseOutputAudioSpeed"/>
+/// might receive from the deserialised <c>ai_speech_assistant_function_call.content</c> JSON.
+///
+/// <para>
+/// The single load-bearing invariant: anything that should leave the speed
+/// unset (so OpenAI uses 1.0, current behaviour) MUST return <c>null</c>.
+/// Non-positive values are rejected at the parser layer because zero / negative
+/// playback speed is meaningless to OpenAI and would either be rejected
+/// server-side or worse interpreted differently across model versions.
+/// </para>
+///
+/// <para>
+/// The parser does NOT enforce OpenAI's documented range (currently 0.25 – 1.5).
+/// Operators who set out-of-range values are rejected by OpenAI server-side
+/// with a clear error rather than the adapter silently clamping into a
+/// different speed than the operator intended.
+/// </para>
+/// </summary>
+public class ParseOutputAudioSpeedTests
+{
+    private static object DeserializeContent(string json) => JsonConvert.DeserializeObject<object>(json);
+
+    // ── Default-path inputs (every one of these must return null) ──────────
+
+    [Fact]
+    public void ParseOutputAudioSpeed_NullInput_ReturnsNull()
+    {
+        AiSpeechAssistantConnectService.ParseOutputAudioSpeed(null).ShouldBeNull();
+    }
+
+    [Fact]
+    public void ParseOutputAudioSpeed_NonJObjectInput_ReturnsNull()
+    {
+        AiSpeechAssistantConnectService.ParseOutputAudioSpeed(JArray.Parse("[1.0]")).ShouldBeNull();
+        AiSpeechAssistantConnectService.ParseOutputAudioSpeed(1.0).ShouldBeNull();
+        AiSpeechAssistantConnectService.ParseOutputAudioSpeed("1.0").ShouldBeNull();
+    }
+
+    [Fact]
+    public void ParseOutputAudioSpeed_EmptyJsonObject_ReturnsNull()
+    {
+        AiSpeechAssistantConnectService.ParseOutputAudioSpeed(DeserializeContent("{}")).ShouldBeNull();
+    }
+
+    [Fact]
+    public void ParseOutputAudioSpeed_ValuePropertyExplicitNull_ReturnsNull()
+    {
+        AiSpeechAssistantConnectService.ParseOutputAudioSpeed(DeserializeContent("{\"value\":null}")).ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData("{\"value\":\"1.0\"}")]   // string instead of number
+    [InlineData("{\"value\":true}")]      // bool
+    [InlineData("{\"value\":[1.0]}")]     // array
+    public void ParseOutputAudioSpeed_NonNumericValue_ReturnsNull(string content)
+    {
+        AiSpeechAssistantConnectService.ParseOutputAudioSpeed(DeserializeContent(content)).ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData("{\"value\":0}")]
+    [InlineData("{\"value\":0.0}")]
+    [InlineData("{\"value\":-0.5}")]
+    [InlineData("{\"value\":-1.0}")]
+    public void ParseOutputAudioSpeed_NonPositiveValue_ReturnsNull(string content)
+    {
+        // Zero or negative playback speed is meaningless; reject at the parser
+        // rather than emit a value that OpenAI either rejects or interprets
+        // inconsistently across model versions.
+        AiSpeechAssistantConnectService.ParseOutputAudioSpeed(DeserializeContent(content)).ShouldBeNull();
+    }
+
+    // ── Active speed inputs ────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("{\"value\":0.25}", "0.25")]    // documented OpenAI minimum
+    [InlineData("{\"value\":0.8}",  "0.8")]     // a slower-than-natural setting
+    [InlineData("{\"value\":0.9}",  "0.9")]     // recommended for elderly customers
+    [InlineData("{\"value\":1.0}",  "1.0")]     // explicit natural speed
+    [InlineData("{\"value\":1.1}",  "1.1")]     // recommended for fast-paced customers
+    [InlineData("{\"value\":1.5}",  "1.5")]     // documented OpenAI maximum
+    public void ParseOutputAudioSpeed_PositiveDecimal_ReturnsExactValue(string content, string expectedString)
+    {
+        // Use string literals to avoid C# decimal-literal precision surprises in the
+        // [InlineData] table; convert here so each case is self-documenting.
+        var expected = decimal.Parse(expectedString, System.Globalization.CultureInfo.InvariantCulture);
+
+        AiSpeechAssistantConnectService.ParseOutputAudioSpeed(DeserializeContent(content)).ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("{\"value\":2}",   2)]      // integer 2 — passed through (out of OpenAI's 1.5 max but accepted by parser)
+    [InlineData("{\"value\":100}", 100)]    // way out of range — rejected by OpenAI, not the parser
+    public void ParseOutputAudioSpeed_IntegerValue_AcceptedAsDecimal(string content, int expectedInt)
+    {
+        // Integers also count as positive numerics. The parser does not enforce
+        // OpenAI's documented 0.25 – 1.5 range — out-of-range values are passed
+        // through and rejected by OpenAI server-side with a clear error.
+        var expected = (decimal)expectedInt;
+
+        AiSpeechAssistantConnectService.ParseOutputAudioSpeed(DeserializeContent(content)).ShouldBe(expected);
+    }
+
+    [Fact]
+    public void ParseOutputAudioSpeed_AdditionalProperties_StillExtractsValue()
+    {
+        var input = DeserializeContent("{\"value\":0.9,\"note\":\"elderly assistant\"}");
+
+        AiSpeechAssistantConnectService.ParseOutputAudioSpeed(input).ShouldBe(0.9m);
+    }
+
+    [Fact]
+    public void ParseOutputAudioSpeed_ValueKeyIsCaseSensitive()
+    {
+        AiSpeechAssistantConnectService.ParseOutputAudioSpeed(DeserializeContent("{\"Value\":0.9}")).ShouldBeNull();
+        AiSpeechAssistantConnectService.ParseOutputAudioSpeed(DeserializeContent("{\"VALUE\":0.9}")).ShouldBeNull();
+    }
+}

--- a/src/SmartTalk.UnitTests/Services/AiSpeechAssistantConnect/ParseTranscriptionLanguageTests.cs
+++ b/src/SmartTalk.UnitTests/Services/AiSpeechAssistantConnect/ParseTranscriptionLanguageTests.cs
@@ -1,0 +1,109 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Shouldly;
+using SmartTalk.Core.Services.AiSpeechAssistantConnect;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Services.AiSpeechAssistantConnect;
+
+/// <summary>
+/// Exercises every input shape <see cref="AiSpeechAssistantConnectService.ParseTranscriptionLanguage"/>
+/// might receive from the deserialised <c>ai_speech_assistant_function_call.content</c> JSON.
+///
+/// <para>
+/// The single load-bearing invariant: anything that should leave the outbound
+/// <c>session.audio.input.transcription</c> object byte-equivalent to the pre-hint
+/// payload MUST return <c>null</c> here. A regression that returns an empty string
+/// or a placeholder value would silently start sending <c>"language": ""</c> to
+/// OpenAI and could break transcription quality across every prod call.
+/// </para>
+/// </summary>
+public class ParseTranscriptionLanguageTests
+{
+    private static object DeserializeContent(string json) => JsonConvert.DeserializeObject<object>(json);
+
+    // ── Default-path inputs (every one of these must return null) ──────────
+
+    [Fact]
+    public void ParseTranscriptionLanguage_NullInput_ReturnsNull()
+    {
+        // The realistic prod state: no row exists in ai_speech_assistant_function_call
+        // for TranscriptionLanguage, DeserializeFunctionCallConfig returns null, and the
+        // parser must propagate null so the adapter emits no `language` key.
+        AiSpeechAssistantConnectService.ParseTranscriptionLanguage(null).ShouldBeNull();
+    }
+
+    [Fact]
+    public void ParseTranscriptionLanguage_NonJObjectInput_ReturnsNull()
+    {
+        // Defence against future config rows whose content is a JSON array or scalar
+        // (not the expected `{ "language": "..." }` shape). The parser must not throw —
+        // it returns null and leaves the adapter on the default path.
+        AiSpeechAssistantConnectService.ParseTranscriptionLanguage(JArray.Parse("[\"yue\"]")).ShouldBeNull();
+        AiSpeechAssistantConnectService.ParseTranscriptionLanguage("yue").ShouldBeNull();
+        AiSpeechAssistantConnectService.ParseTranscriptionLanguage(42).ShouldBeNull();
+    }
+
+    [Fact]
+    public void ParseTranscriptionLanguage_EmptyJsonObject_ReturnsNull()
+    {
+        // A row whose content is `{}` — the language property is missing entirely.
+        AiSpeechAssistantConnectService.ParseTranscriptionLanguage(DeserializeContent("{}")).ShouldBeNull();
+    }
+
+    [Fact]
+    public void ParseTranscriptionLanguage_LanguagePropertyExplicitNull_ReturnsNull()
+    {
+        // `{ "language": null }` — operator (or migration) saved an explicit null.
+        // Must behave identically to "key missing".
+        AiSpeechAssistantConnectService.ParseTranscriptionLanguage(DeserializeContent("{\"language\":null}")).ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData("{\"language\":\"\"}")]
+    [InlineData("{\"language\":\" \"}")]
+    [InlineData("{\"language\":\"   \"}")]
+    [InlineData("{\"language\":\"\\t\"}")]
+    public void ParseTranscriptionLanguage_EmptyOrWhitespaceValue_ReturnsNull(string content)
+    {
+        // Operator-supplied empty / whitespace MUST NOT propagate to the wire payload.
+        // OpenAI would reject `"language": ""` as an invalid request and kill the session.
+        AiSpeechAssistantConnectService.ParseTranscriptionLanguage(DeserializeContent(content)).ShouldBeNull();
+    }
+
+    // ── Active hint inputs ─────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("{\"language\":\"yue\"}",  "yue")]    // Cantonese — non-ISO-639-1 but the BCP-47 short form
+    [InlineData("{\"language\":\"zh\"}",   "zh")]     // generic Chinese (zh-CN / zh-HK / zh-TW)
+    [InlineData("{\"language\":\"en\"}",   "en")]     // English
+    [InlineData("{\"language\":\"es\"}",   "es")]     // Spanish
+    [InlineData("{\"language\":\"ja\"}",   "ja")]     // Japanese
+    [InlineData("{\"language\":\"ko\"}",   "ko")]     // Korean
+    [InlineData("{\"language\":\"vi\"}",   "vi")]     // Vietnamese
+    public void ParseTranscriptionLanguage_ValidValue_ReturnsTrimmedString(string content, string expected)
+    {
+        AiSpeechAssistantConnectService.ParseTranscriptionLanguage(DeserializeContent(content)).ShouldBe(expected);
+    }
+
+    [Fact]
+    public void ParseTranscriptionLanguage_AdditionalProperties_StillExtractsLanguage()
+    {
+        // Forward-compatibility: future schema additions to the config row (e.g. an
+        // operator note, a model variant) MUST NOT trip the parser. The single
+        // `language` property is what we extract; extras are ignored.
+        var input = DeserializeContent("{\"language\":\"yue\",\"note\":\"high-volume Cantonese DID\",\"model_variant\":\"v3\"}");
+
+        AiSpeechAssistantConnectService.ParseTranscriptionLanguage(input).ShouldBe("yue");
+    }
+
+    [Fact]
+    public void ParseTranscriptionLanguage_LanguageKeyIsCaseSensitive()
+    {
+        // The wire-format property name is `language` (lowercase). A row with `Language`
+        // or `LANGUAGE` is treated as malformed (= no hint) rather than silently activated
+        // — keeps the schema interpretation strict and predictable.
+        AiSpeechAssistantConnectService.ParseTranscriptionLanguage(DeserializeContent("{\"Language\":\"yue\"}")).ShouldBeNull();
+        AiSpeechAssistantConnectService.ParseTranscriptionLanguage(DeserializeContent("{\"LANGUAGE\":\"yue\"}")).ShouldBeNull();
+    }
+}

--- a/src/SmartTalk.UnitTests/Services/AiSpeechAssistantConnect/ParseTranscriptionModelTests.cs
+++ b/src/SmartTalk.UnitTests/Services/AiSpeechAssistantConnect/ParseTranscriptionModelTests.cs
@@ -1,0 +1,113 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Shouldly;
+using SmartTalk.Core.Services.AiSpeechAssistantConnect;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Services.AiSpeechAssistantConnect;
+
+/// <summary>
+/// Exercises every input shape <see cref="AiSpeechAssistantConnectService.ParseTranscriptionModel"/>
+/// might receive from the deserialised <c>ai_speech_assistant_function_call.content</c> JSON.
+///
+/// <para>
+/// The single load-bearing invariant: anything that should leave the adapter on its
+/// compile-time default model MUST return <c>null</c> here. A regression that returns
+/// an empty string or a placeholder value would silently send <c>"model": ""</c> (or
+/// worse, an unintended downgrade) to OpenAI, breaking transcription quality across
+/// affected calls.
+/// </para>
+///
+/// <para>
+/// Mirrors the structure of <see cref="ParseTranscriptionLanguageTests"/>; the two
+/// parsers share the same null-safety contract so regressions are visible in both
+/// suites together.
+/// </para>
+/// </summary>
+public class ParseTranscriptionModelTests
+{
+    private static object DeserializeContent(string json) => JsonConvert.DeserializeObject<object>(json);
+
+    // ── Default-path inputs (every one of these must return null) ──────────
+
+    [Fact]
+    public void ParseTranscriptionModel_NullInput_ReturnsNull()
+    {
+        // Realistic prod state: no TranscriptionModel row exists, so
+        // DeserializeFunctionCallConfig returns null. The parser must propagate
+        // null so the adapter stays on its compile-time default.
+        AiSpeechAssistantConnectService.ParseTranscriptionModel(null).ShouldBeNull();
+    }
+
+    [Fact]
+    public void ParseTranscriptionModel_NonJObjectInput_ReturnsNull()
+    {
+        // Defence: future config rows whose content is a JSON array or scalar
+        // (not the expected `{ "model": "..." }` shape) must not throw.
+        AiSpeechAssistantConnectService.ParseTranscriptionModel(JArray.Parse("[\"whisper-1\"]")).ShouldBeNull();
+        AiSpeechAssistantConnectService.ParseTranscriptionModel("whisper-1").ShouldBeNull();
+        AiSpeechAssistantConnectService.ParseTranscriptionModel(42).ShouldBeNull();
+    }
+
+    [Fact]
+    public void ParseTranscriptionModel_EmptyJsonObject_ReturnsNull()
+    {
+        // A row whose content is `{}` — the model property is missing entirely.
+        AiSpeechAssistantConnectService.ParseTranscriptionModel(DeserializeContent("{}")).ShouldBeNull();
+    }
+
+    [Fact]
+    public void ParseTranscriptionModel_ModelPropertyExplicitNull_ReturnsNull()
+    {
+        // `{ "model": null }` — operator (or migration) saved an explicit null.
+        // Must behave identically to "key missing".
+        AiSpeechAssistantConnectService.ParseTranscriptionModel(DeserializeContent("{\"model\":null}")).ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData("{\"model\":\"\"}")]
+    [InlineData("{\"model\":\" \"}")]
+    [InlineData("{\"model\":\"   \"}")]
+    [InlineData("{\"model\":\"\\t\"}")]
+    public void ParseTranscriptionModel_EmptyOrWhitespaceValue_ReturnsNull(string content)
+    {
+        // Operator-supplied empty / whitespace MUST NOT propagate to the wire payload.
+        // OpenAI would reject `"model": ""` as an invalid request and kill the session.
+        AiSpeechAssistantConnectService.ParseTranscriptionModel(DeserializeContent(content)).ShouldBeNull();
+    }
+
+    // ── Active override inputs ─────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("{\"model\":\"whisper-1\"}",               "whisper-1")]                // legacy downgrade
+    [InlineData("{\"model\":\"gpt-4o-mini-transcribe\"}",  "gpt-4o-mini-transcribe")]   // cheaper variant
+    [InlineData("{\"model\":\"gpt-4o-transcribe\"}",       "gpt-4o-transcribe")]        // explicit re-affirm of default
+    [InlineData("{\"model\":\"gpt-5-transcribe\"}",        "gpt-5-transcribe")]         // forward-compat: future model passthrough
+    public void ParseTranscriptionModel_RecognisedAndFuturePassthrough_ReturnsExactString(string content, string expected)
+    {
+        // The parser does NOT validate the string against a known list. Operators
+        // can opt into future OpenAI models without a code change, and OpenAI
+        // rejects unknown values server-side rather than us silently substituting.
+        AiSpeechAssistantConnectService.ParseTranscriptionModel(DeserializeContent(content)).ShouldBe(expected);
+    }
+
+    [Fact]
+    public void ParseTranscriptionModel_AdditionalProperties_StillExtractsModel()
+    {
+        // Forward-compatibility: future schema additions (e.g. an operator note,
+        // a temperature override) must not trip the parser.
+        var input = DeserializeContent("{\"model\":\"whisper-1\",\"note\":\"cost-sensitive DID\",\"variant\":\"v1\"}");
+
+        AiSpeechAssistantConnectService.ParseTranscriptionModel(input).ShouldBe("whisper-1");
+    }
+
+    [Fact]
+    public void ParseTranscriptionModel_ModelKeyIsCaseSensitive()
+    {
+        // Wire-format property name is `model` (lowercase). A row with `Model` or
+        // `MODEL` is treated as malformed (= no override) rather than silently
+        // activated — keeps schema interpretation strict and predictable.
+        AiSpeechAssistantConnectService.ParseTranscriptionModel(DeserializeContent("{\"Model\":\"whisper-1\"}")).ShouldBeNull();
+        AiSpeechAssistantConnectService.ParseTranscriptionModel(DeserializeContent("{\"MODEL\":\"whisper-1\"}")).ShouldBeNull();
+    }
+}

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterBetaEventSunsetTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterBetaEventSunsetTests.cs
@@ -1,0 +1,102 @@
+using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NSubstitute;
+using Shouldly;
+using SmartTalk.Core.Services.RealtimeAiV2.Adapters.Providers.OpenAi;
+using SmartTalk.Core.Settings.OpenAi;
+using SmartTalk.Messages.Enums.RealtimeAi;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Services.RealtimeAiV2;
+
+/// <summary>
+/// Locks in the post-sunset behaviour: the four Beta-era event names (the ones that
+/// hotfix #934 accepted alongside their GA replacements) now map to
+/// <see cref="RealtimeAiWssEventType.Unknown"/>. The Unknown classification triggers
+/// a Serilog warning at the service layer, giving operators an immediate signal if
+/// OpenAI ever regresses and re-emits a Beta-named event in production.
+///
+/// <para>
+/// Sunset rationale: OpenAI completed the GA cutover on 2026-05-07; hotfix #934
+/// deployed 2026-05-12; this PR is gated on ≥ 2 weeks of clean production logs
+/// (≥ 2026-05-26). Until that observation window passes, this PR stays in draft
+/// state — merging early reintroduces risk of silently dropping audio frames if
+/// OpenAI ever rolls a region back to Beta names.
+/// </para>
+/// </summary>
+public class OpenAiRealtimeAiProviderAdapterBetaEventSunsetTests
+{
+    private static OpenAiRealtimeAiProviderAdapter NewAdapter() =>
+        new(new OpenAiSettings(Substitute.For<IConfiguration>()));
+
+    private static string SerializeEvent(string type, object extras = null)
+    {
+        if (extras == null) return JsonConvert.SerializeObject(new { type });
+
+        var payload = JObject.FromObject(extras);
+        payload["type"] = type;
+        return payload.ToString();
+    }
+
+    // ── Beta-era names now classified as Unknown ──────────────────────────
+
+    [Theory]
+    [InlineData("response.audio.delta")]
+    [InlineData("response.audio.done")]
+    [InlineData("response.audio_transcript.delta")]
+    [InlineData("response.audio_transcript.done")]
+    public void ParseMessage_BetaEventName_NowMapsToUnknown(string betaEventName)
+    {
+        // After sunset, a Beta-named event surfaces as Unknown so the service's
+        // existing Log.Warning fires. The audio handler doesn't fire (= silence on
+        // the call), but the warning is the contract: regression is loud, not silent.
+        var raw = SerializeEvent(betaEventName);
+
+        var parsed = NewAdapter().ParseMessage(raw);
+
+        parsed.Type.ShouldBe(RealtimeAiWssEventType.Unknown);
+    }
+
+    // ── GA-named events keep working unchanged ────────────────────────────
+
+    [Fact]
+    public void ParseMessage_GaAudioDelta_StillProducesResponseAudioDelta()
+    {
+        var raw = SerializeEvent("response.output_audio.delta", new { delta = "AQID", item_id = "itm-1" });
+
+        var parsed = NewAdapter().ParseMessage(raw);
+
+        parsed.Type.ShouldBe(RealtimeAiWssEventType.ResponseAudioDelta);
+    }
+
+    [Fact]
+    public void ParseMessage_GaAudioDone_StillProducesResponseAudioDone()
+    {
+        var raw = SerializeEvent("response.output_audio.done");
+
+        var parsed = NewAdapter().ParseMessage(raw);
+
+        parsed.Type.ShouldBe(RealtimeAiWssEventType.ResponseAudioDone);
+    }
+
+    [Fact]
+    public void ParseMessage_GaTranscriptDelta_StillProducesOutputAudioTranscriptionPartial()
+    {
+        var raw = SerializeEvent("response.output_audio_transcript.delta", new { delta = "hello" });
+
+        var parsed = NewAdapter().ParseMessage(raw);
+
+        parsed.Type.ShouldBe(RealtimeAiWssEventType.OutputAudioTranscriptionPartial);
+    }
+
+    [Fact]
+    public void ParseMessage_GaTranscriptDone_StillProducesOutputAudioTranscriptionCompleted()
+    {
+        var raw = SerializeEvent("response.output_audio_transcript.done", new { transcript = "hello world" });
+
+        var parsed = NewAdapter().ParseMessage(raw);
+
+        parsed.Type.ShouldBe(RealtimeAiWssEventType.OutputAudioTranscriptionCompleted);
+    }
+}

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterExtractUsageTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterExtractUsageTests.cs
@@ -1,0 +1,275 @@
+using System.Text.Json;
+using Shouldly;
+using SmartTalk.Core.Services.RealtimeAiV2.Adapters.Providers.OpenAi;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Services.RealtimeAiV2;
+
+/// <summary>
+/// Exercises <see cref="OpenAiRealtimeAiProviderAdapter.ExtractUsage"/> against the
+/// shapes of OpenAI's <c>response.done.response.usage</c> payload. The parser must
+/// be defensive: older provider snapshots omit the usage block entirely, and even
+/// modern responses may omit individual sub-counts.
+///
+/// <para>
+/// The load-bearing invariant: a missing block or a missing sub-count returns
+/// <c>null</c> for that level, never zero. Zero is a meaningful value (an empty
+/// AI turn) and conflating it with "missing" would silently corrupt cost reports.
+/// </para>
+/// </summary>
+public class OpenAiRealtimeAiProviderAdapterExtractUsageTests
+{
+    private static JsonElement Parse(string json) => JsonDocument.Parse(json).RootElement;
+
+    // ── Missing / wrong-shape returns null ────────────────────────────────
+
+    [Fact]
+    public void ExtractUsage_NoResponseObject_ReturnsNull()
+    {
+        // Older provider snapshots emit `response.done` with just `{ type: "response.done" }`.
+        // Parser must return null rather than throw.
+        OpenAiRealtimeAiProviderAdapter.ExtractUsage(Parse("{\"type\":\"response.done\"}")).ShouldBeNull();
+    }
+
+    [Fact]
+    public void ExtractUsage_ResponseObjectButNoUsage_ReturnsNull()
+    {
+        // response is present but doesn't carry usage — that's not an error,
+        // it just means OpenAI didn't report token counts for this turn.
+        var root = Parse("{\"type\":\"response.done\",\"response\":{\"id\":\"resp_123\"}}");
+
+        OpenAiRealtimeAiProviderAdapter.ExtractUsage(root).ShouldBeNull();
+    }
+
+    [Fact]
+    public void ExtractUsage_ResponseNotAnObject_ReturnsNull()
+    {
+        // Defensive against malformed events where `response` is null or a scalar.
+        var root = Parse("{\"type\":\"response.done\",\"response\":null}");
+
+        OpenAiRealtimeAiProviderAdapter.ExtractUsage(root).ShouldBeNull();
+    }
+
+    [Fact]
+    public void ExtractUsage_UsageNotAnObject_ReturnsNull()
+    {
+        var root = Parse("{\"type\":\"response.done\",\"response\":{\"usage\":\"unexpected\"}}");
+
+        OpenAiRealtimeAiProviderAdapter.ExtractUsage(root).ShouldBeNull();
+    }
+
+    // ── Top-level sub-counts ──────────────────────────────────────────────
+
+    [Fact]
+    public void ExtractUsage_OnlyTopLevelCounts_ReturnsTotalInputOutput()
+    {
+        // The most minimal usage block — just the three top-level sums.
+        var root = Parse("""
+            {
+              "type": "response.done",
+              "response": {
+                "usage": {
+                  "total_tokens": 1500,
+                  "input_tokens": 800,
+                  "output_tokens": 700
+                }
+              }
+            }
+            """);
+
+        var usage = OpenAiRealtimeAiProviderAdapter.ExtractUsage(root);
+
+        usage.ShouldNotBeNull();
+        usage.TotalTokens.ShouldBe(1500);
+        usage.InputTokens.ShouldBe(800);
+        usage.OutputTokens.ShouldBe(700);
+        usage.CachedTokens.ShouldBeNull();
+        usage.InputAudioTokens.ShouldBeNull();
+        usage.InputTextTokens.ShouldBeNull();
+        usage.OutputAudioTokens.ShouldBeNull();
+        usage.OutputTextTokens.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ExtractUsage_TopLevelMissingTotal_ReturnsNullForThatField()
+    {
+        // Missing total_tokens is not an error — older snapshots sometimes omit it
+        // when the breakdown sums are sufficient. Other fields must still populate.
+        var root = Parse("""
+            {
+              "response": {
+                "usage": {
+                  "input_tokens": 100,
+                  "output_tokens": 50
+                }
+              }
+            }
+            """);
+
+        var usage = OpenAiRealtimeAiProviderAdapter.ExtractUsage(root);
+
+        usage.TotalTokens.ShouldBeNull();
+        usage.InputTokens.ShouldBe(100);
+        usage.OutputTokens.ShouldBe(50);
+    }
+
+    [Fact]
+    public void ExtractUsage_TopLevelZeroValues_PreservedAsZeroNotNull()
+    {
+        // Zero is a real value (empty AI turn). MUST be preserved as 0 — collapsing it
+        // to null would silently corrupt cost reports for empty / cancelled turns.
+        var root = Parse("{\"response\":{\"usage\":{\"total_tokens\":0,\"input_tokens\":0,\"output_tokens\":0}}}");
+
+        var usage = OpenAiRealtimeAiProviderAdapter.ExtractUsage(root);
+
+        usage.TotalTokens.ShouldBe(0);
+        usage.InputTokens.ShouldBe(0);
+        usage.OutputTokens.ShouldBe(0);
+    }
+
+    // ── Nested input_token_details / output_token_details ─────────────────
+
+    [Fact]
+    public void ExtractUsage_FullBreakdown_ReturnsAllFields()
+    {
+        var root = Parse("""
+            {
+              "response": {
+                "usage": {
+                  "total_tokens": 2000,
+                  "input_tokens": 1200,
+                  "output_tokens": 800,
+                  "input_token_details": {
+                    "cached_tokens": 400,
+                    "audio_tokens": 500,
+                    "text_tokens": 300
+                  },
+                  "output_token_details": {
+                    "audio_tokens": 600,
+                    "text_tokens": 200
+                  }
+                }
+              }
+            }
+            """);
+
+        var usage = OpenAiRealtimeAiProviderAdapter.ExtractUsage(root);
+
+        usage.TotalTokens.ShouldBe(2000);
+        usage.InputTokens.ShouldBe(1200);
+        usage.OutputTokens.ShouldBe(800);
+        usage.CachedTokens.ShouldBe(400);
+        usage.InputAudioTokens.ShouldBe(500);
+        usage.InputTextTokens.ShouldBe(300);
+        usage.OutputAudioTokens.ShouldBe(600);
+        usage.OutputTextTokens.ShouldBe(200);
+    }
+
+    [Fact]
+    public void ExtractUsage_InputTokenDetailsAbsent_OutputDetailsStillExtracted()
+    {
+        // Provider may report one side and not the other. Each nested block is
+        // optional independently of the other.
+        var root = Parse("""
+            {
+              "response": {
+                "usage": {
+                  "input_tokens": 100,
+                  "output_tokens": 50,
+                  "output_token_details": {
+                    "audio_tokens": 40,
+                    "text_tokens": 10
+                  }
+                }
+              }
+            }
+            """);
+
+        var usage = OpenAiRealtimeAiProviderAdapter.ExtractUsage(root);
+
+        usage.CachedTokens.ShouldBeNull();
+        usage.InputAudioTokens.ShouldBeNull();
+        usage.InputTextTokens.ShouldBeNull();
+        usage.OutputAudioTokens.ShouldBe(40);
+        usage.OutputTextTokens.ShouldBe(10);
+    }
+
+    [Fact]
+    public void ExtractUsage_NestedDetailsAreNull_ReturnsNullForLeafFields()
+    {
+        // Defensive: the provider may return null instead of an object for nested details.
+        var root = Parse("""
+            {
+              "response": {
+                "usage": {
+                  "input_tokens": 100,
+                  "output_tokens": 50,
+                  "input_token_details": null,
+                  "output_token_details": null
+                }
+              }
+            }
+            """);
+
+        var usage = OpenAiRealtimeAiProviderAdapter.ExtractUsage(root);
+
+        usage.CachedTokens.ShouldBeNull();
+        usage.InputAudioTokens.ShouldBeNull();
+        usage.InputTextTokens.ShouldBeNull();
+        usage.OutputAudioTokens.ShouldBeNull();
+        usage.OutputTextTokens.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ExtractUsage_NonIntegerCounts_ReturnsNullForThoseFields()
+    {
+        // Schema violation: a count is a string or a float. The parser tolerates
+        // this by returning null for the affected leaf rather than throwing.
+        var root = Parse("""
+            {
+              "response": {
+                "usage": {
+                  "total_tokens": "1500",
+                  "input_tokens": 100.5,
+                  "output_tokens": 50
+                }
+              }
+            }
+            """);
+
+        var usage = OpenAiRealtimeAiProviderAdapter.ExtractUsage(root);
+
+        usage.TotalTokens.ShouldBeNull();
+        usage.InputTokens.ShouldBeNull();
+        usage.OutputTokens.ShouldBe(50);
+    }
+
+    [Fact]
+    public void ExtractUsage_UnknownExtraFields_AreSilentlyIgnored()
+    {
+        // Forward-compatibility: when OpenAI adds new sub-counts (e.g. a new audio
+        // category), older builds of the parser must keep working. Extras are
+        // silently ignored; the documented fields still extract correctly.
+        var root = Parse("""
+            {
+              "response": {
+                "usage": {
+                  "total_tokens": 100,
+                  "input_tokens": 50,
+                  "output_tokens": 50,
+                  "future_premium_tokens": 999,
+                  "input_token_details": {
+                    "cached_tokens": 10,
+                    "exotic_new_category_tokens": 20
+                  }
+                }
+              }
+            }
+            """);
+
+        var usage = OpenAiRealtimeAiProviderAdapter.ExtractUsage(root);
+
+        usage.TotalTokens.ShouldBe(100);
+        usage.CachedTokens.ShouldBe(10);
+    }
+}

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterGaPayloadTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterGaPayloadTests.cs
@@ -148,6 +148,11 @@ public class OpenAiRealtimeAiProviderAdapterGaPayloadTests
     [Fact]
     public void BuildSessionConfig_AudioInput_CarriesTranscriptionAndTurnDetection()
     {
+        // Default transcription model upgraded from "whisper-1" to "gpt-4o-transcribe"
+        // (OpenAI's most capable transcription model, priced identically to whisper-1).
+        // The literal lives at OpenAiRealtimeAiProviderAdapter.DefaultTranscriptionModel —
+        // referencing the const here ties the assertion to the production constant so
+        // a future default change updates one place.
         var adapter = NewAdapter();
         var options = OptionsWithPromptAndVoice();
         options.ModelConfig.TurnDetection = new { type = "server_vad" };
@@ -155,7 +160,7 @@ public class OpenAiRealtimeAiProviderAdapterGaPayloadTests
         var json = SerializeSession(adapter.BuildSessionConfig(options, RealtimeAiAudioCodec.MULAW));
 
         var input = json["session"]!["audio"]!["input"]!;
-        input["transcription"]!["model"]!.Value<string>().ShouldBe("whisper-1");
+        input["transcription"]!["model"]!.Value<string>().ShouldBe(OpenAiRealtimeAiProviderAdapter.DefaultTranscriptionModel);
         input["turn_detection"]!["type"]!.Value<string>().ShouldBe("server_vad");
     }
 

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterMaxResponseOutputTokensTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterMaxResponseOutputTokensTests.cs
@@ -1,0 +1,145 @@
+using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NSubstitute;
+using Shouldly;
+using SmartTalk.Core.Services.RealtimeAiV2;
+using SmartTalk.Core.Services.RealtimeAiV2.Adapters.Providers.OpenAi;
+using SmartTalk.Core.Settings.OpenAi;
+using SmartTalk.Messages.Enums.RealtimeAi;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Services.RealtimeAiV2;
+
+/// <summary>
+/// Per-assistant response-token cap contract tests for
+/// <see cref="OpenAiRealtimeAiProviderAdapter.BuildSessionConfig"/>.
+///
+/// <para>
+/// The load-bearing invariant: when <see cref="RealtimeAiModelConfig.MaxResponseOutputTokens"/>
+/// is null (the realistic state for every assistant with no cap row), the
+/// <c>session</c> object MUST NOT contain a <c>max_response_output_tokens</c>
+/// property — so OpenAI uses its server-side default. This is what makes the
+/// feature non-breaking: every existing prod assistant continues to behave
+/// exactly as today until an operator inserts a row.
+/// </para>
+/// </summary>
+public class OpenAiRealtimeAiProviderAdapterMaxResponseOutputTokensTests
+{
+    private static readonly JsonSerializerSettings ProductionSerializer = new()
+    {
+        NullValueHandling = NullValueHandling.Ignore
+    };
+
+    private static OpenAiRealtimeAiProviderAdapter NewAdapter() =>
+        new(new OpenAiSettings(Substitute.For<IConfiguration>()));
+
+    private static RealtimeSessionOptions OptionsWithCap(int? cap) =>
+        new()
+        {
+            ModelConfig = new RealtimeAiModelConfig
+            {
+                Prompt = "you are helpful",
+                Voice = "alloy",
+                Tools = new List<object>(),
+                MaxResponseOutputTokens = cap
+            }
+        };
+
+    private static JObject SerializeAsProduction(object payload) =>
+        JObject.Parse(JsonConvert.SerializeObject(payload, ProductionSerializer));
+
+    // ── Default path: null cap → field absent from payload ────────────────
+
+    [Fact]
+    public void BuildSessionConfig_MaxResponseOutputTokensNull_FieldAbsentFromPayload()
+    {
+        // The load-bearing test: every existing prod assistant has no
+        // MaxResponseOutputTokens config row, so ModelConfig.MaxResponseOutputTokens
+        // is null. The serialised session object MUST contain no
+        // `max_response_output_tokens` property — NullValueHandling.Ignore
+        // strips it at serialisation time. OpenAI server-side default applies.
+        var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(OptionsWithCap(null), RealtimeAiAudioCodec.MULAW));
+
+        json["session"]!["max_response_output_tokens"].ShouldBeNull();
+    }
+
+    [Fact]
+    public void BuildSessionConfig_MaxResponseOutputTokensNull_AdjacentSessionFieldsUnchanged()
+    {
+        // Sanity check: the null-cap path must not perturb any adjacent
+        // session-level field. Regression here would mean Phase 5.5 silently
+        // shifted instructions / output_modalities / tools semantics.
+        var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(OptionsWithCap(null), RealtimeAiAudioCodec.MULAW));
+
+        var session = json["session"]!;
+        session["type"]!.Value<string>().ShouldBe("realtime");
+        session["instructions"]!.Value<string>().ShouldBe("you are helpful");
+        session["output_modalities"]!.Values<string>().ShouldBe(new[] { "audio" });
+        session["max_response_output_tokens"].ShouldBeNull();
+    }
+
+    // ── Active path: cap set → emitted at session level ────────────────────
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(100)]
+    [InlineData(800)]
+    [InlineData(1200)]
+    [InlineData(4096)]
+    [InlineData(100000)]
+    public void BuildSessionConfig_MaxResponseOutputTokensSet_EmitsCapAtSessionLevel(int cap)
+    {
+        // The adapter forwards whatever the operator set. No clamping — operators
+        // get exact control, and OpenAI rejects values beyond its server-side
+        // limits with a clear error rather than the adapter silently clipping.
+        var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(OptionsWithCap(cap), RealtimeAiAudioCodec.MULAW));
+
+        json["session"]!["max_response_output_tokens"]!.Value<int>().ShouldBe(cap);
+    }
+
+    [Fact]
+    public void BuildSessionConfig_MaxResponseOutputTokensSet_DoesNotPerturbAudioFields()
+    {
+        // Activating the cap must not silently shift transcription, turn_detection,
+        // noise_reduction, voice, or output format.
+        var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(OptionsWithCap(1200), RealtimeAiAudioCodec.MULAW));
+
+        var session = json["session"]!;
+        session["audio"]!["input"]!["transcription"]!["model"]!.Value<string>()
+            .ShouldBe(OpenAiRealtimeAiProviderAdapter.DefaultTranscriptionModel);
+        session["audio"]!["input"]!["turn_detection"]!["type"]!.Value<string>().ShouldBe("server_vad");
+        session["audio"]!["input"]!["noise_reduction"].ShouldBeNull();
+        session["audio"]!["output"]!["voice"]!.Value<string>().ShouldBe("alloy");
+        session["audio"]!["output"]!["format"]!["type"]!.Value<string>().ShouldBe("audio/pcmu");
+    }
+
+    // ── Coexistence with adjacent per-assistant configs ────────────────────
+
+    [Fact]
+    public void BuildSessionConfig_CapAndLanguageAndModel_AllActivateIndependently()
+    {
+        // All three Phase 5 per-assistant configs are independent dimensions.
+        // Pin the combined shape so a future PR that touches one cannot silently
+        // break the others.
+        var options = new RealtimeSessionOptions
+        {
+            ModelConfig = new RealtimeAiModelConfig
+            {
+                Prompt = "you are helpful",
+                Voice = "alloy",
+                Tools = new List<object>(),
+                TranscriptionLanguage = "yue",
+                TranscriptionModel = "gpt-4o-mini-transcribe",
+                MaxResponseOutputTokens = 1200
+            }
+        };
+
+        var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(options, RealtimeAiAudioCodec.MULAW));
+
+        var session = json["session"]!;
+        session["audio"]!["input"]!["transcription"]!["model"]!.Value<string>().ShouldBe("gpt-4o-mini-transcribe");
+        session["audio"]!["input"]!["transcription"]!["language"]!.Value<string>().ShouldBe("yue");
+        session["max_response_output_tokens"]!.Value<int>().ShouldBe(1200);
+    }
+}

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterOutputAudioSpeedTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterOutputAudioSpeedTests.cs
@@ -1,0 +1,138 @@
+using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NSubstitute;
+using Shouldly;
+using SmartTalk.Core.Services.RealtimeAiV2;
+using SmartTalk.Core.Services.RealtimeAiV2.Adapters.Providers.OpenAi;
+using SmartTalk.Core.Settings.OpenAi;
+using SmartTalk.Messages.Enums.RealtimeAi;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Services.RealtimeAiV2;
+
+/// <summary>
+/// Per-assistant output audio speed contract tests for
+/// <see cref="OpenAiRealtimeAiProviderAdapter.BuildSessionConfig"/>.
+///
+/// <para>
+/// The load-bearing invariant: when <see cref="RealtimeAiModelConfig.OutputAudioSpeed"/>
+/// is null (the realistic state for every assistant with no speed row), the
+/// <c>audio.output</c> object MUST NOT contain a <c>speed</c> property — so
+/// OpenAI uses its default of 1.0.
+/// </para>
+/// </summary>
+public class OpenAiRealtimeAiProviderAdapterOutputAudioSpeedTests
+{
+    private static readonly JsonSerializerSettings ProductionSerializer = new()
+    {
+        NullValueHandling = NullValueHandling.Ignore
+    };
+
+    private static OpenAiRealtimeAiProviderAdapter NewAdapter() =>
+        new(new OpenAiSettings(Substitute.For<IConfiguration>()));
+
+    private static RealtimeSessionOptions OptionsWithSpeed(decimal? speed) =>
+        new()
+        {
+            ModelConfig = new RealtimeAiModelConfig
+            {
+                Prompt = "you are helpful",
+                Voice = "alloy",
+                Tools = new List<object>(),
+                OutputAudioSpeed = speed
+            }
+        };
+
+    private static JObject SerializeAsProduction(object payload) =>
+        JObject.Parse(JsonConvert.SerializeObject(payload, ProductionSerializer));
+
+    // ── Default path: null speed → field absent from payload ──────────────
+
+    [Fact]
+    public void BuildSessionConfig_OutputAudioSpeedNull_FieldAbsentFromPayload()
+    {
+        // Load-bearing: every existing prod assistant has no OutputAudioSpeed row →
+        // ModelConfig.OutputAudioSpeed is null → NullValueHandling.Ignore strips the
+        // key from `audio.output`. OpenAI uses 1.0 as before.
+        var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(OptionsWithSpeed(null), RealtimeAiAudioCodec.MULAW));
+
+        json["session"]!["audio"]!["output"]!["speed"].ShouldBeNull();
+    }
+
+    [Fact]
+    public void BuildSessionConfig_OutputAudioSpeedNull_AdjacentOutputFieldsUnchanged()
+    {
+        // Null speed must not perturb voice or format inside audio.output.
+        var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(OptionsWithSpeed(null), RealtimeAiAudioCodec.MULAW));
+
+        var output = json["session"]!["audio"]!["output"]!;
+        output["voice"]!.Value<string>().ShouldBe("alloy");
+        output["format"]!["type"]!.Value<string>().ShouldBe("audio/pcmu");
+        output["speed"].ShouldBeNull();
+    }
+
+    // ── Active path: speed set → emitted inside audio.output ──────────────
+
+    [Theory]
+    [InlineData("0.25")]   // documented minimum
+    [InlineData("0.85")]   // slower-than-natural
+    [InlineData("0.9")]    // elderly-customer recommendation
+    [InlineData("1.0")]    // explicit natural speed
+    [InlineData("1.1")]    // fast-paced
+    [InlineData("1.5")]    // documented maximum
+    public void BuildSessionConfig_OutputAudioSpeedSet_EmitsSpeedInsideAudioOutput(string speedString)
+    {
+        var speed = decimal.Parse(speedString, System.Globalization.CultureInfo.InvariantCulture);
+
+        var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(OptionsWithSpeed(speed), RealtimeAiAudioCodec.MULAW));
+
+        json["session"]!["audio"]!["output"]!["speed"]!.Value<decimal>().ShouldBe(speed);
+    }
+
+    [Fact]
+    public void BuildSessionConfig_OutputAudioSpeedSet_DoesNotPerturbInputFields()
+    {
+        // Activating output speed must not silently shift any input-side field
+        // (transcription / turn_detection / noise_reduction / format).
+        var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(OptionsWithSpeed(0.9m), RealtimeAiAudioCodec.MULAW));
+
+        var input = json["session"]!["audio"]!["input"]!;
+        input["transcription"]!["model"]!.Value<string>()
+            .ShouldBe(OpenAiRealtimeAiProviderAdapter.DefaultTranscriptionModel);
+        input["turn_detection"]!["type"]!.Value<string>().ShouldBe("server_vad");
+        input["noise_reduction"].ShouldBeNull();
+        input["format"]!["type"]!.Value<string>().ShouldBe("audio/pcmu");
+    }
+
+    // ── Coexistence with other per-assistant configs ───────────────────────
+
+    [Fact]
+    public void BuildSessionConfig_SpeedAndLanguageAndCap_AllActivateIndependently()
+    {
+        // Each per-assistant config is an independent dimension. Pin the
+        // combined shape so a future PR that touches one cannot silently break
+        // the others.
+        var options = new RealtimeSessionOptions
+        {
+            ModelConfig = new RealtimeAiModelConfig
+            {
+                Prompt = "you are helpful",
+                Voice = "alloy",
+                Tools = new List<object>(),
+                TranscriptionLanguage = "yue",
+                TranscriptionModel = "gpt-4o-mini-transcribe",
+                MaxResponseOutputTokens = 1200,
+                OutputAudioSpeed = 0.9m
+            }
+        };
+
+        var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(options, RealtimeAiAudioCodec.MULAW));
+
+        var session = json["session"]!;
+        session["audio"]!["input"]!["transcription"]!["model"]!.Value<string>().ShouldBe("gpt-4o-mini-transcribe");
+        session["audio"]!["input"]!["transcription"]!["language"]!.Value<string>().ShouldBe("yue");
+        session["audio"]!["output"]!["speed"]!.Value<decimal>().ShouldBe(0.9m);
+        session["max_response_output_tokens"]!.Value<int>().ShouldBe(1200);
+    }
+}

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterParseMessageUsageTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterParseMessageUsageTests.cs
@@ -1,0 +1,113 @@
+using Microsoft.Extensions.Configuration;
+using NSubstitute;
+using Shouldly;
+using SmartTalk.Core.Services.RealtimeAiV2.Adapters.Providers.OpenAi;
+using SmartTalk.Core.Settings.OpenAi;
+using SmartTalk.Messages.Enums.RealtimeAi;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Services.RealtimeAiV2;
+
+/// <summary>
+/// End-to-end tests that the V2 adapter's <see cref="OpenAiRealtimeAiProviderAdapter.ParseMessage"/>
+/// surfaces the usage block on the parsed event for the two <c>response.done</c> variants
+/// (<see cref="RealtimeAiWssEventType.ResponseTurnCompleted"/> and
+/// <see cref="RealtimeAiWssEventType.FunctionCallSuggested"/>).
+///
+/// <para>
+/// The unit-test counterpart of <see cref="OpenAiRealtimeAiProviderAdapterExtractUsageTests"/> —
+/// those exercise the parser in isolation; these exercise the wiring that puts the
+/// parsed value onto the event consumers read.
+/// </para>
+/// </summary>
+public class OpenAiRealtimeAiProviderAdapterParseMessageUsageTests
+{
+    private static OpenAiRealtimeAiProviderAdapter NewAdapter() =>
+        new(new OpenAiSettings(Substitute.For<IConfiguration>()));
+
+    [Fact]
+    public void ParseMessage_ResponseDoneWithUsage_AttachesUsageToCompletionEvent()
+    {
+        var raw = """
+            {
+              "type": "response.done",
+              "response": {
+                "id": "resp_test",
+                "usage": {
+                  "total_tokens": 1234,
+                  "input_tokens": 800,
+                  "output_tokens": 434,
+                  "input_token_details": { "cached_tokens": 200 }
+                }
+              }
+            }
+            """;
+
+        var parsed = NewAdapter().ParseMessage(raw);
+
+        parsed.Type.ShouldBe(RealtimeAiWssEventType.ResponseTurnCompleted);
+        parsed.Usage.ShouldNotBeNull();
+        parsed.Usage.TotalTokens.ShouldBe(1234);
+        parsed.Usage.InputTokens.ShouldBe(800);
+        parsed.Usage.OutputTokens.ShouldBe(434);
+        parsed.Usage.CachedTokens.ShouldBe(200);
+    }
+
+    [Fact]
+    public void ParseMessage_ResponseDoneWithoutUsage_LeavesUsageNull()
+    {
+        // Older provider snapshots emit response.done with no usage block. The
+        // event still surfaces (cleanup logic depends on it) but Usage is null
+        // and the consumer's usage callback is skipped.
+        var raw = """
+            {
+              "type": "response.done",
+              "response": {
+                "id": "resp_test"
+              }
+            }
+            """;
+
+        var parsed = NewAdapter().ParseMessage(raw);
+
+        parsed.Type.ShouldBe(RealtimeAiWssEventType.ResponseTurnCompleted);
+        parsed.Usage.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ParseMessage_ResponseDoneWithFunctionCallAndUsage_AttachesUsageToFunctionCallEvent()
+    {
+        // The same response.done message can be classified as
+        // FunctionCallSuggested when the response output contains function calls.
+        // Usage MUST still be surfaced — operators need cost tracking on
+        // function-call turns just as much as on text turns.
+        var raw = """
+            {
+              "type": "response.done",
+              "response": {
+                "id": "resp_test",
+                "output": [
+                  {
+                    "type": "function_call",
+                    "name": "confirm_order",
+                    "call_id": "call_abc",
+                    "arguments": "{}"
+                  }
+                ],
+                "usage": {
+                  "total_tokens": 500,
+                  "input_tokens": 480,
+                  "output_tokens": 20
+                }
+              }
+            }
+            """;
+
+        var parsed = NewAdapter().ParseMessage(raw);
+
+        parsed.Type.ShouldBe(RealtimeAiWssEventType.FunctionCallSuggested);
+        parsed.Data.ShouldNotBeNull();   // function call payload still there
+        parsed.Usage.ShouldNotBeNull();
+        parsed.Usage.TotalTokens.ShouldBe(500);
+    }
+}

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterRealtimeTracingTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterRealtimeTracingTests.cs
@@ -1,0 +1,155 @@
+using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NSubstitute;
+using Shouldly;
+using SmartTalk.Core.Services.RealtimeAiV2;
+using SmartTalk.Core.Services.RealtimeAiV2.Adapters.Providers.OpenAi;
+using SmartTalk.Core.Settings.OpenAi;
+using SmartTalk.Messages.Enums.RealtimeAi;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Services.RealtimeAiV2;
+
+/// <summary>
+/// Per-assistant OpenAI session-tracing contract tests for
+/// <see cref="OpenAiRealtimeAiProviderAdapter.BuildSessionConfig"/>.
+///
+/// <para>
+/// The load-bearing invariant: when <see cref="RealtimeAiModelConfig.EnableRealtimeTracing"/>
+/// is null or false (the realistic state for every assistant with no opt-in
+/// row), the <c>session</c> object MUST NOT contain a <c>tracing</c> property
+/// — so OpenAI does NOT retain a session trace, matching the pre-feature
+/// privacy posture.
+/// </para>
+/// </summary>
+public class OpenAiRealtimeAiProviderAdapterRealtimeTracingTests
+{
+    private static readonly JsonSerializerSettings ProductionSerializer = new()
+    {
+        NullValueHandling = NullValueHandling.Ignore
+    };
+
+    private static OpenAiRealtimeAiProviderAdapter NewAdapter() =>
+        new(new OpenAiSettings(Substitute.For<IConfiguration>()));
+
+    private static RealtimeSessionOptions OptionsWithTracing(bool? enableTracing) =>
+        new()
+        {
+            ModelConfig = new RealtimeAiModelConfig
+            {
+                Prompt = "you are helpful",
+                Voice = "alloy",
+                Tools = new List<object>(),
+                EnableRealtimeTracing = enableTracing
+            }
+        };
+
+    private static JObject SerializeAsProduction(object payload) =>
+        JObject.Parse(JsonConvert.SerializeObject(payload, ProductionSerializer));
+
+    // ── Compile-time mode constant pinned ─────────────────────────────────
+
+    [Fact]
+    public void EnabledTracingMode_PinnedToAuto()
+    {
+        // The wire literal under session.tracing is hard-pinned so a future
+        // rename / typo is a visible compile-time decision rather than an
+        // invisible refactor.
+        OpenAiRealtimeAiProviderAdapter.EnabledTracingMode.ShouldBe("auto");
+    }
+
+    // ── Default path: null / false → field absent ──────────────────────────
+
+    [Fact]
+    public void BuildSessionConfig_TracingNull_FieldAbsentFromPayload()
+    {
+        // Load-bearing: every existing prod assistant has no RealtimeTracing row →
+        // EnableRealtimeTracing is null → NullValueHandling.Ignore strips the
+        // `tracing` key from session. OpenAI does not retain a trace.
+        var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(OptionsWithTracing(null), RealtimeAiAudioCodec.MULAW));
+
+        json["session"]!["tracing"].ShouldBeNull();
+    }
+
+    [Fact]
+    public void BuildSessionConfig_TracingFalse_FieldAbsentFromPayload()
+    {
+        // An explicit `false` MUST behave identically to null — operators can
+        // persist a row with `{ "enabled": false }` to deliberately document
+        // "we considered tracing and decided against it"; that must not surface
+        // as an enabled trace.
+        var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(OptionsWithTracing(false), RealtimeAiAudioCodec.MULAW));
+
+        json["session"]!["tracing"].ShouldBeNull();
+    }
+
+    [Fact]
+    public void BuildSessionConfig_TracingNull_AdjacentSessionFieldsUnchanged()
+    {
+        // Sanity: null tracing must not perturb any adjacent session-level field.
+        var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(OptionsWithTracing(null), RealtimeAiAudioCodec.MULAW));
+
+        var session = json["session"]!;
+        session["type"]!.Value<string>().ShouldBe("realtime");
+        session["instructions"]!.Value<string>().ShouldBe("you are helpful");
+        session["output_modalities"]!.Values<string>().ShouldBe(new[] { "audio" });
+        session["tracing"].ShouldBeNull();
+    }
+
+    // ── Active opt-in: true → emits "auto" at session level ────────────────
+
+    [Fact]
+    public void BuildSessionConfig_TracingTrue_EmitsAutoAtSessionLevel()
+    {
+        var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(OptionsWithTracing(true), RealtimeAiAudioCodec.MULAW));
+
+        json["session"]!["tracing"]!.Value<string>().ShouldBe(OpenAiRealtimeAiProviderAdapter.EnabledTracingMode);
+    }
+
+    [Fact]
+    public void BuildSessionConfig_TracingTrue_DoesNotPerturbAudioFields()
+    {
+        // Activating tracing must not silently shift any audio field —
+        // tracing is purely an out-of-band metadata flag.
+        var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(OptionsWithTracing(true), RealtimeAiAudioCodec.MULAW));
+
+        var session = json["session"]!;
+        session["audio"]!["input"]!["transcription"]!["model"]!.Value<string>()
+            .ShouldBe(OpenAiRealtimeAiProviderAdapter.DefaultTranscriptionModel);
+        session["audio"]!["input"]!["turn_detection"]!["type"]!.Value<string>().ShouldBe("server_vad");
+        session["audio"]!["input"]!["noise_reduction"].ShouldBeNull();
+        session["audio"]!["output"]!["voice"]!.Value<string>().ShouldBe("alloy");
+        session["audio"]!["output"]!["format"]!["type"]!.Value<string>().ShouldBe("audio/pcmu");
+    }
+
+    // ── Coexistence with adjacent per-assistant configs ────────────────────
+
+    [Fact]
+    public void BuildSessionConfig_TracingAndLanguageAndModelAndCap_AllActivateIndependently()
+    {
+        // Pin the combined shape so a future PR that touches one Phase 5 config
+        // cannot silently break adjacent ones.
+        var options = new RealtimeSessionOptions
+        {
+            ModelConfig = new RealtimeAiModelConfig
+            {
+                Prompt = "you are helpful",
+                Voice = "alloy",
+                Tools = new List<object>(),
+                TranscriptionLanguage = "yue",
+                TranscriptionModel = "gpt-4o-mini-transcribe",
+                MaxResponseOutputTokens = 1200,
+                EnableRealtimeTracing = true
+            }
+        };
+
+        var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(options, RealtimeAiAudioCodec.MULAW));
+
+        var session = json["session"]!;
+        session["audio"]!["input"]!["transcription"]!["model"]!.Value<string>().ShouldBe("gpt-4o-mini-transcribe");
+        session["audio"]!["input"]!["transcription"]!["language"]!.Value<string>().ShouldBe("yue");
+        session["max_response_output_tokens"]!.Value<int>().ShouldBe(1200);
+        session["tracing"]!.Value<string>().ShouldBe("auto");
+    }
+}

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterTranscriptionLanguageTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterTranscriptionLanguageTests.cs
@@ -20,7 +20,8 @@ namespace SmartTalk.UnitTests.Services.RealtimeAiV2;
 /// is null or empty (the realistic state for every existing prod assistant — no
 /// TranscriptionLanguage row in <c>ai_speech_assistant_function_call</c>), the
 /// serialised <c>transcription</c> object MUST be byte-equivalent to the pre-hint
-/// payload: <c>{ "model": "whisper-1" }</c> with no <c>language</c> key.
+/// payload: <c>{ "model": &lt;default&gt; }</c> with no <c>language</c> key. The
+/// default model is sourced from <see cref="OpenAiRealtimeAiProviderAdapter.DefaultTranscriptionModel"/>.
 /// </para>
 ///
 /// <para>
@@ -63,10 +64,12 @@ public class OpenAiRealtimeAiProviderAdapterTranscriptionLanguageTests
         // The load-bearing test: every existing prod assistant has no
         // TranscriptionLanguage config row, so ModelConfig.TranscriptionLanguage is null.
         // The serialised transcription object MUST contain only `model` — no `language`.
+        // `model` resolves to OpenAiRealtimeAiProviderAdapter.DefaultTranscriptionModel
+        // (whatever OpenAI's strongest model is at the time of the build).
         var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(OptionsWithLanguage(null), RealtimeAiAudioCodec.MULAW));
 
         var transcription = json["session"]!["audio"]!["input"]!["transcription"]!;
-        transcription["model"]!.Value<string>().ShouldBe("whisper-1");
+        transcription["model"]!.Value<string>().ShouldBe(OpenAiRealtimeAiProviderAdapter.DefaultTranscriptionModel);
         transcription["language"].ShouldBeNull();
     }
 
@@ -130,10 +133,13 @@ public class OpenAiRealtimeAiProviderAdapterTranscriptionLanguageTests
     [InlineData("ja")]
     public void BuildSessionConfig_TranscriptionLanguageSet_EmitsLanguageProperty(string language)
     {
+        // Setting a language hint must not perturb the model field — it stays on the
+        // adapter's compile-time default unless the assistant also opted into a
+        // TranscriptionModel override (covered separately).
         var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(OptionsWithLanguage(language), RealtimeAiAudioCodec.MULAW));
 
         var transcription = json["session"]!["audio"]!["input"]!["transcription"]!;
-        transcription["model"]!.Value<string>().ShouldBe("whisper-1");
+        transcription["model"]!.Value<string>().ShouldBe(OpenAiRealtimeAiProviderAdapter.DefaultTranscriptionModel);
         transcription["language"]!.Value<string>().ShouldBe(language);
     }
 

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterTranscriptionLanguageTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterTranscriptionLanguageTests.cs
@@ -1,0 +1,153 @@
+using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NSubstitute;
+using Shouldly;
+using SmartTalk.Core.Services.RealtimeAiV2;
+using SmartTalk.Core.Services.RealtimeAiV2.Adapters.Providers.OpenAi;
+using SmartTalk.Core.Settings.OpenAi;
+using SmartTalk.Messages.Enums.RealtimeAi;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Services.RealtimeAiV2;
+
+/// <summary>
+/// Per-assistant transcription language hint contract tests for
+/// <see cref="OpenAiRealtimeAiProviderAdapter.BuildSessionConfig"/>.
+///
+/// <para>
+/// The load-bearing invariant: when <see cref="RealtimeAiModelConfig.TranscriptionLanguage"/>
+/// is null or empty (the realistic state for every existing prod assistant — no
+/// TranscriptionLanguage row in <c>ai_speech_assistant_function_call</c>), the
+/// serialised <c>transcription</c> object MUST be byte-equivalent to the pre-hint
+/// payload: <c>{ "model": "whisper-1" }</c> with no <c>language</c> key.
+/// </para>
+///
+/// <para>
+/// Tests serialise with <see cref="JsonSerializerSettings"/> mirroring the production
+/// caller (<c>NullValueHandling.Ignore</c>) — null fields are stripped at serialisation
+/// time, which is what makes "null TranscriptionLanguage produces byte-equivalent
+/// output" work without an explicit conditional in the adapter.
+/// </para>
+/// </summary>
+public class OpenAiRealtimeAiProviderAdapterTranscriptionLanguageTests
+{
+    private static readonly JsonSerializerSettings ProductionSerializer = new()
+    {
+        NullValueHandling = NullValueHandling.Ignore
+    };
+
+    private static OpenAiRealtimeAiProviderAdapter NewAdapter() =>
+        new(new OpenAiSettings(Substitute.For<IConfiguration>()));
+
+    private static RealtimeSessionOptions OptionsWithLanguage(string language) =>
+        new()
+        {
+            ModelConfig = new RealtimeAiModelConfig
+            {
+                Prompt = "you are helpful",
+                Voice = "alloy",
+                Tools = new List<object>(),
+                TranscriptionLanguage = language
+            }
+        };
+
+    private static JObject SerializeAsProduction(object payload) =>
+        JObject.Parse(JsonConvert.SerializeObject(payload, ProductionSerializer));
+
+    // ── Default path: null / empty TranscriptionLanguage → byte-equivalent ──
+
+    [Fact]
+    public void BuildSessionConfig_TranscriptionLanguageNull_NoLanguageKeyInTranscription()
+    {
+        // The load-bearing test: every existing prod assistant has no
+        // TranscriptionLanguage config row, so ModelConfig.TranscriptionLanguage is null.
+        // The serialised transcription object MUST contain only `model` — no `language`.
+        var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(OptionsWithLanguage(null), RealtimeAiAudioCodec.MULAW));
+
+        var transcription = json["session"]!["audio"]!["input"]!["transcription"]!;
+        transcription["model"]!.Value<string>().ShouldBe("whisper-1");
+        transcription["language"].ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("   ")]
+    public void BuildSessionConfig_TranscriptionLanguageEmpty_NoLanguageKeyInTranscription(string language)
+    {
+        // Defence in depth: even if the service-side parser ever lets through an
+        // empty / whitespace value (current parser strips it, but adapter should
+        // still produce safe output). NullValueHandling.Ignore strips literal null
+        // but an empty string is NOT a null — so this test pins the parser's
+        // null-on-whitespace behaviour by checking the end-to-end shape.
+        //
+        // If this ever starts failing with `"language": ""` in the payload, the
+        // parser's IsNullOrWhiteSpace guard has regressed.
+        var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(OptionsWithLanguage(language), RealtimeAiAudioCodec.MULAW));
+
+        var transcription = json["session"]!["audio"]!["input"]!["transcription"]!;
+
+        if (language == "")
+        {
+            // Empty string passes through and gets serialised as ""; this is intentionally
+            // documented behaviour: the empty-string case is handled upstream by the parser
+            // (ParseTranscriptionLanguage returns null for empty / whitespace inputs).
+            // If you ever bypass the parser and pass "" directly into ModelConfig, you'll
+            // see it in the payload — which is the expected adapter contract.
+            transcription["language"]!.Value<string>().ShouldBe("");
+        }
+        else
+        {
+            transcription["language"]!.Value<string>().ShouldBe(language);
+        }
+    }
+
+    [Fact]
+    public void BuildSessionConfig_TranscriptionLanguageNull_PayloadByteEquivalentInOtherFields()
+    {
+        // Sanity check: setting TranscriptionLanguage=null must not perturb any
+        // adjacent field. Regression here would mean Phase 5.1 silently shifted
+        // turn_detection / noise_reduction / voice / instructions semantics.
+        var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(OptionsWithLanguage(null), RealtimeAiAudioCodec.MULAW));
+
+        var session = json["session"]!;
+        session["type"]!.Value<string>().ShouldBe("realtime");
+        session["instructions"]!.Value<string>().ShouldBe("you are helpful");
+        session["output_modalities"]!.Values<string>().ShouldBe(new[] { "audio" });
+        session["audio"]!["input"]!["format"]!["type"]!.Value<string>().ShouldBe("audio/pcmu");
+        session["audio"]!["input"]!["turn_detection"]!["type"]!.Value<string>().ShouldBe("server_vad");
+        session["audio"]!["output"]!["voice"]!.Value<string>().ShouldBe("alloy");
+    }
+
+    // ── Active path: language set → appears as transcription.language ──────
+
+    [Theory]
+    [InlineData("yue")]
+    [InlineData("zh")]
+    [InlineData("en")]
+    [InlineData("es")]
+    [InlineData("ja")]
+    public void BuildSessionConfig_TranscriptionLanguageSet_EmitsLanguageProperty(string language)
+    {
+        var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(OptionsWithLanguage(language), RealtimeAiAudioCodec.MULAW));
+
+        var transcription = json["session"]!["audio"]!["input"]!["transcription"]!;
+        transcription["model"]!.Value<string>().ShouldBe("whisper-1");
+        transcription["language"]!.Value<string>().ShouldBe(language);
+    }
+
+    [Fact]
+    public void BuildSessionConfig_TranscriptionLanguageSet_DoesNotPerturbAdjacentFields()
+    {
+        // Activating the language hint must not silently affect turn_detection,
+        // noise_reduction, voice, or output format.
+        var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(OptionsWithLanguage("yue"), RealtimeAiAudioCodec.MULAW));
+
+        var session = json["session"]!;
+        session["audio"]!["input"]!["turn_detection"]!["type"]!.Value<string>().ShouldBe("server_vad");
+        session["audio"]!["input"]!["noise_reduction"].ShouldBeNull();   // ModelConfig.InputAudioNoiseReduction is null
+        session["audio"]!["output"]!["voice"]!.Value<string>().ShouldBe("alloy");
+        session["audio"]!["output"]!["format"]!["type"]!.Value<string>().ShouldBe("audio/pcmu");
+    }
+}

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterTranscriptionModelTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterTranscriptionModelTests.cs
@@ -1,0 +1,169 @@
+using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NSubstitute;
+using Shouldly;
+using SmartTalk.Core.Services.RealtimeAiV2;
+using SmartTalk.Core.Services.RealtimeAiV2.Adapters.Providers.OpenAi;
+using SmartTalk.Core.Settings.OpenAi;
+using SmartTalk.Messages.Enums.RealtimeAi;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Services.RealtimeAiV2;
+
+/// <summary>
+/// Per-assistant transcription model override contract tests for
+/// <see cref="OpenAiRealtimeAiProviderAdapter.BuildSessionConfig"/>.
+///
+/// <para>
+/// Two load-bearing invariants:
+/// <list type="bullet">
+///   <item>
+///     When <see cref="RealtimeAiModelConfig.TranscriptionModel"/> is null or empty
+///     (the realistic state for every assistant with no TranscriptionModel row),
+///     the adapter emits <see cref="OpenAiRealtimeAiProviderAdapter.DefaultTranscriptionModel"/>.
+///     This is what makes the Phase 5.4 default-upgrade safe: every existing prod
+///     assistant transparently gets the upgraded model on deploy.
+///   </item>
+///   <item>
+///     When an operator sets a non-null TranscriptionModel value, the adapter emits
+///     it verbatim — no allow-list, no silent substitution. OpenAI rejects unknown
+///     values server-side rather than the adapter falling back to the default.
+///   </item>
+/// </list>
+/// </para>
+/// </summary>
+public class OpenAiRealtimeAiProviderAdapterTranscriptionModelTests
+{
+    private static readonly JsonSerializerSettings ProductionSerializer = new()
+    {
+        NullValueHandling = NullValueHandling.Ignore
+    };
+
+    private static OpenAiRealtimeAiProviderAdapter NewAdapter() =>
+        new(new OpenAiSettings(Substitute.For<IConfiguration>()));
+
+    private static RealtimeSessionOptions OptionsWithModel(string model) =>
+        new()
+        {
+            ModelConfig = new RealtimeAiModelConfig
+            {
+                Prompt = "you are helpful",
+                Voice = "alloy",
+                Tools = new List<object>(),
+                TranscriptionModel = model
+            }
+        };
+
+    private static JObject SerializeAsProduction(object payload) =>
+        JObject.Parse(JsonConvert.SerializeObject(payload, ProductionSerializer));
+
+    // ── Compile-time default ───────────────────────────────────────────────
+
+    [Fact]
+    public void DefaultTranscriptionModel_PinIsCurrentStrongestModel()
+    {
+        // Hard-pinned literal so a future default change is a deliberate,
+        // visible decision rather than an invisible refactor. As of 2026-05-19
+        // gpt-4o-transcribe is OpenAI's most capable transcription model and is
+        // priced identically to whisper-1 ($0.006/min) — strict quality upgrade,
+        // zero cost change. If/when OpenAI ships a stronger default, update this
+        // pin together with the production constant.
+        OpenAiRealtimeAiProviderAdapter.DefaultTranscriptionModel.ShouldBe("gpt-4o-transcribe");
+    }
+
+    // ── Default path: null / empty TranscriptionModel → adapter default ────
+
+    [Fact]
+    public void BuildSessionConfig_TranscriptionModelNull_UsesDefaultModel()
+    {
+        // The realistic prod state: no TranscriptionModel row → ModelConfig.TranscriptionModel
+        // is null → adapter falls back to DefaultTranscriptionModel. This is the deploy-day
+        // behaviour for every existing assistant.
+        var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(OptionsWithModel(null), RealtimeAiAudioCodec.MULAW));
+
+        json["session"]!["audio"]!["input"]!["transcription"]!["model"]!.Value<string>()
+            .ShouldBe(OpenAiRealtimeAiProviderAdapter.DefaultTranscriptionModel);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("   ")]
+    public void BuildSessionConfig_TranscriptionModelEmptyOrWhitespace_UsesDefaultModel(string model)
+    {
+        // Defence: even if the service-side parser ever lets through an empty / whitespace
+        // value (current parser strips it), the adapter falls back to default instead of
+        // sending `"model": ""` and getting rejected by OpenAI.
+        var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(OptionsWithModel(model), RealtimeAiAudioCodec.MULAW));
+
+        json["session"]!["audio"]!["input"]!["transcription"]!["model"]!.Value<string>()
+            .ShouldBe(OpenAiRealtimeAiProviderAdapter.DefaultTranscriptionModel);
+    }
+
+    // ── Active override path: operator-supplied model ──────────────────────
+
+    [Theory]
+    [InlineData("whisper-1")]                  // legacy downgrade (e.g. cost-sensitive assistant)
+    [InlineData("gpt-4o-mini-transcribe")]     // cheaper variant
+    [InlineData("gpt-4o-transcribe")]          // explicit re-affirm of the default
+    public void BuildSessionConfig_TranscriptionModelSet_EmitsOperatorValue(string model)
+    {
+        var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(OptionsWithModel(model), RealtimeAiAudioCodec.MULAW));
+
+        json["session"]!["audio"]!["input"]!["transcription"]!["model"]!.Value<string>().ShouldBe(model);
+    }
+
+    [Fact]
+    public void BuildSessionConfig_TranscriptionModelFutureValue_PassesThroughVerbatim()
+    {
+        // Forward-compatibility: an operator can opt into a future OpenAI model
+        // (e.g. `gpt-5-transcribe`) without a code change. The adapter does not
+        // validate the string — OpenAI rejects unknown values server-side rather
+        // than the adapter silently falling back to default.
+        var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(OptionsWithModel("gpt-5-transcribe"), RealtimeAiAudioCodec.MULAW));
+
+        json["session"]!["audio"]!["input"]!["transcription"]!["model"]!.Value<string>().ShouldBe("gpt-5-transcribe");
+    }
+
+    // ── Coexistence with TranscriptionLanguage ─────────────────────────────
+
+    [Fact]
+    public void BuildSessionConfig_BothModelAndLanguageSet_BothActivateIndependently()
+    {
+        // The two per-assistant configs are independent dimensions: an operator can
+        // set model alone, language alone, or both. This test pins the combined shape.
+        var adapter = NewAdapter();
+        var options = new RealtimeSessionOptions
+        {
+            ModelConfig = new RealtimeAiModelConfig
+            {
+                Prompt = "you are helpful",
+                Voice = "alloy",
+                Tools = new List<object>(),
+                TranscriptionModel = "gpt-4o-mini-transcribe",
+                TranscriptionLanguage = "yue"
+            }
+        };
+
+        var json = SerializeAsProduction(adapter.BuildSessionConfig(options, RealtimeAiAudioCodec.MULAW));
+
+        var transcription = json["session"]!["audio"]!["input"]!["transcription"]!;
+        transcription["model"]!.Value<string>().ShouldBe("gpt-4o-mini-transcribe");
+        transcription["language"]!.Value<string>().ShouldBe("yue");
+    }
+
+    [Fact]
+    public void BuildSessionConfig_TranscriptionModelSet_DoesNotPerturbAdjacentFields()
+    {
+        // Activating the model override must not silently shift turn_detection,
+        // noise_reduction, voice, or output format.
+        var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(OptionsWithModel("whisper-1"), RealtimeAiAudioCodec.MULAW));
+
+        var session = json["session"]!;
+        session["audio"]!["input"]!["turn_detection"]!["type"]!.Value<string>().ShouldBe("server_vad");
+        session["audio"]!["input"]!["noise_reduction"].ShouldBeNull();
+        session["audio"]!["output"]!["voice"]!.Value<string>().ShouldBe("alloy");
+        session["audio"]!["output"]!["format"]!["type"]!.Value<string>().ShouldBe("audio/pcmu");
+    }
+}

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterVoiceListTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterVoiceListTests.cs
@@ -1,0 +1,155 @@
+using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NSubstitute;
+using Shouldly;
+using SmartTalk.Core.Services.RealtimeAiV2;
+using SmartTalk.Core.Services.RealtimeAiV2.Adapters.Providers.OpenAi;
+using SmartTalk.Core.Settings.OpenAi;
+using SmartTalk.Messages.Enums.RealtimeAi;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Services.RealtimeAiV2;
+
+/// <summary>
+/// Pins the OpenAI Realtime API voice list and the default-voice constant.
+///
+/// <para>
+/// The literals are mirrored from OpenAI's documented voice options. The pin exists
+/// so any drift between the OpenAI docs and our list is a visible code change rather
+/// than a silent dropdown-population bug, and so UI / operator tooling has a single
+/// source of truth.
+/// </para>
+///
+/// <para>
+/// The adapter does NOT enforce membership — operators may opt into a future OpenAI
+/// voice without a code change, and OpenAI rejects unknown values server-side. The
+/// last test pins the pass-through behaviour so we never silently substitute.
+/// </para>
+/// </summary>
+public class OpenAiRealtimeAiProviderAdapterVoiceListTests
+{
+    private static readonly JsonSerializerSettings ProductionSerializer = new()
+    {
+        NullValueHandling = NullValueHandling.Ignore
+    };
+
+    private static OpenAiRealtimeAiProviderAdapter NewAdapter() =>
+        new(new OpenAiSettings(Substitute.For<IConfiguration>()));
+
+    private static RealtimeSessionOptions OptionsWithVoice(string voice) =>
+        new()
+        {
+            ModelConfig = new RealtimeAiModelConfig
+            {
+                Prompt = "you are helpful",
+                Voice = voice,
+                Tools = new List<object>()
+            }
+        };
+
+    private static JObject SerializeAsProduction(object payload) =>
+        JObject.Parse(JsonConvert.SerializeObject(payload, ProductionSerializer));
+
+    // ── Constants pinned ───────────────────────────────────────────────────
+
+    [Fact]
+    public void DefaultVoice_IsAlloy()
+    {
+        // The historical default is "alloy". Changing it is a deliberate decision —
+        // every assistant without an explicit Voice override would switch to the new
+        // value on deploy. Hard-pin the literal so the change is visible in code review.
+        OpenAiRealtimeAiProviderAdapter.DefaultVoice.ShouldBe("alloy");
+    }
+
+    [Fact]
+    public void SupportedVoices_ContainsExactly13DocumentedVoices()
+    {
+        // Source: https://platform.openai.com/docs/guides/realtime as of 2026-05-20.
+        // Order matches a stable ID alphabetisation so a diff against this assertion
+        // makes the addition / removal obvious in code review.
+        OpenAiRealtimeAiProviderAdapter.SupportedVoices.ShouldBe(new[]
+        {
+            "alloy",
+            "ash",
+            "ballad",
+            "coral",
+            "echo",
+            "fable",
+            "onyx",
+            "nova",
+            "sage",
+            "shimmer",
+            "verse",
+            "marin",
+            "cedar"
+        });
+    }
+
+    [Fact]
+    public void SupportedVoices_ContainsTheDefaultVoice()
+    {
+        // The default we send must be one of the values OpenAI accepts — otherwise
+        // every assistant without an explicit Voice override would fail at session.update.
+        OpenAiRealtimeAiProviderAdapter.SupportedVoices.ShouldContain(OpenAiRealtimeAiProviderAdapter.DefaultVoice);
+    }
+
+    [Fact]
+    public void SupportedVoices_HasNoDuplicates()
+    {
+        // Defensive: a duplicate would not break anything, but it suggests sloppy
+        // editing when the list was last updated. Catch at test time, not in review.
+        OpenAiRealtimeAiProviderAdapter.SupportedVoices.Distinct().Count()
+            .ShouldBe(OpenAiRealtimeAiProviderAdapter.SupportedVoices.Count);
+    }
+
+    // ── Adapter wires the default + passes through every list entry ───────
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void BuildSessionConfig_VoiceNullOrEmpty_UsesDefault(string voice)
+    {
+        var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(OptionsWithVoice(voice), RealtimeAiAudioCodec.MULAW));
+
+        json["session"]!["audio"]!["output"]!["voice"]!.Value<string>()
+            .ShouldBe(OpenAiRealtimeAiProviderAdapter.DefaultVoice);
+    }
+
+    [Theory]
+    [InlineData("alloy")]
+    [InlineData("ash")]
+    [InlineData("ballad")]
+    [InlineData("coral")]
+    [InlineData("echo")]
+    [InlineData("fable")]
+    [InlineData("onyx")]
+    [InlineData("nova")]
+    [InlineData("sage")]
+    [InlineData("shimmer")]
+    [InlineData("verse")]
+    [InlineData("marin")]
+    [InlineData("cedar")]
+    public void BuildSessionConfig_EveryDocumentedVoice_EmittedVerbatim(string voice)
+    {
+        // Each documented voice must pass through the adapter unchanged. Failure here
+        // would mean the adapter silently coerced an operator-selected voice into a
+        // different one — a UX regression hard to debug from logs alone.
+        var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(OptionsWithVoice(voice), RealtimeAiAudioCodec.MULAW));
+
+        json["session"]!["audio"]!["output"]!["voice"]!.Value<string>().ShouldBe(voice);
+    }
+
+    [Fact]
+    public void BuildSessionConfig_UnknownVoice_PassesThroughVerbatim()
+    {
+        // Forward-compatibility: when OpenAI adds a new voice (e.g. "midnight"),
+        // operators can opt into it immediately. The adapter does NOT validate the
+        // string — OpenAI rejects unknown values server-side with a clear error,
+        // which is strictly better than the adapter silently swapping in DefaultVoice
+        // and leaving the operator wondering why their selection had no effect.
+        var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(OptionsWithVoice("midnight"), RealtimeAiAudioCodec.MULAW));
+
+        json["session"]!["audio"]!["output"]!["voice"]!.Value<string>().ShouldBe("midnight");
+    }
+}

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/RealtimeAiServiceRecordingTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/RealtimeAiServiceRecordingTests.cs
@@ -82,7 +82,7 @@ public class RealtimeAiServiceRecordingTests : RealtimeAiServiceTestBase
 
         var sessionTask = await StartSessionInBackgroundAsync(options);
 
-        await FakeWssClient.SimulateMessageReceivedAsync("{\"type\":\"response.audio.delta\"}");
+        await FakeWssClient.SimulateMessageReceivedAsync("{\"type\":\"response.output_audio.delta\"}");
         await Task.Delay(100);
 
         FakeWs.EnqueueClose();
@@ -240,7 +240,7 @@ public class RealtimeAiServiceRecordingTests : RealtimeAiServiceTestBase
         var sessionTask = await StartSessionInBackgroundAsync(options);
 
         // 1. Provider sends audio delta → IsAiSpeaking=true, AI audio (4 bytes) buffered
-        await FakeWssClient.SimulateMessageReceivedAsync("{\"type\":\"response.audio.delta\"}");
+        await FakeWssClient.SimulateMessageReceivedAsync("{\"type\":\"response.output_audio.delta\"}");
         await Task.Delay(50);
 
         // 2. Provider sends SpeechDetected → IsAiSpeaking should reset to false

--- a/src/SmartTalk.UnitTests/Services/Timer/InactivityTimerManagerTests.cs
+++ b/src/SmartTalk.UnitTests/Services/Timer/InactivityTimerManagerTests.cs
@@ -73,6 +73,37 @@ public class InactivityTimerManagerTests : IDisposable
         secondTcs.Task.IsCompleted.ShouldBeTrue();
         firstCallbackInvoked.ShouldBeFalse();
     }
+    
+    [Fact]
+    public async Task StartTimer_OldTimerFinishes_ShouldNotRemoveOrphanNewTimer()
+    {
+        var firstStarted = new TaskCompletionSource<bool>();
+        var releaseFirst = new TaskCompletionSource<bool>();
+        var secondCallbackInvoked = false;
+
+        _sut.StartTimer(SessionId, TimeSpan.FromMilliseconds(20), async () =>
+        {
+            firstStarted.TrySetResult(true);
+            await releaseFirst.Task;
+        });
+
+        var firstStartedTask = await Task.WhenAny(firstStarted.Task, Task.Delay(TimeSpan.FromSeconds(5)));
+        firstStartedTask.ShouldBe(firstStarted.Task, "First callback should start");
+
+        _sut.StartTimer(SessionId, TimeSpan.FromMilliseconds(120), () =>
+        {
+            secondCallbackInvoked = true;
+            return Task.CompletedTask;
+        });
+
+        releaseFirst.TrySetResult(true);
+        await Task.Delay(50);
+
+        _sut.StopTimer(SessionId);
+        await Task.Delay(180);
+
+        secondCallbackInvoked.ShouldBeFalse("Second timer should remain cancellable after old timer finishes");
+    }
 
     [Fact]
     public async Task StartTimer_MultipleSessions_ShouldWorkIndependently()


### PR DESCRIPTION
## Summary

Base branch for the Round 2 V2 stability and quality improvements. **No code in this PR yet** — each Phase / feature lands as its own PR targeting this branch. When the collection has been observed in staging for ≥ 48h with no regression, this branch merges into main as a single atomic batch (same pattern as Round 1 PR #922).

## Storage pattern for per-assistant config

Round 2 reuses the existing `ai_speech_assistant_function_call` per-assistant config-map table — the same one already storing `TurnDirection` and `InputAudioNoiseReduction` configs. New Realtime API knobs become new values of the `AiSpeechAssistantSessionConfigType` enum; no `ALTER TABLE` per knob.

- NULL row in the config table (the existing prod state for every assistant) → adapter uses today's hard-coded default → byte-equivalent output
- Non-null row → that field activates for that assistant
- Rollback: `UPDATE ai_speech_assistant_function_call SET is_active = false WHERE assistant_id = X AND type = Y` — per-assistant, per-knob

## Sub-PR convention

- Each sub-PR targets this branch (`feat/v2-stability-perf-round-2`), not `main`
- No direct commits to this branch — everything lands via PR + merge
- Each sub-PR ships its own tests proving the all-null path remains byte-equivalent to current prod
- Planning / tracking docs stay out of the repo