### PR TITLE
Upgrade default transcription model to gpt-4o-transcribe + add per-assistant override

### DIFF
--- a/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectService.Build.Session.cs
+++ b/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectService.Build.Session.cs
@@ -34,7 +34,8 @@ public partial class AiSpeechAssistantConnectService
                     .ToList(),
                 TurnDetection = DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.TurnDirection),
                 InputAudioNoiseReduction = DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.InputAudioNoiseReduction),
-                TranscriptionLanguage = ParseTranscriptionLanguage(DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.TranscriptionLanguage))
+                TranscriptionLanguage = ParseTranscriptionLanguage(DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.TranscriptionLanguage)),
+                TranscriptionModel = ParseTranscriptionModel(DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.TranscriptionModel))
             },
             ConnectionProfile = new RealtimeAiConnectionProfile
             {
@@ -98,5 +99,25 @@ public partial class AiSpeechAssistantConnectService
         var language = obj["language"]?.Value<string>();
 
         return string.IsNullOrWhiteSpace(language) ? null : language;
+    }
+
+    /// <summary>
+    /// Extracts the <c>model</c> string from a deserialised
+    /// <see cref="AiSpeechAssistantSessionConfigType.TranscriptionModel"/> config object.
+    /// Returns <c>null</c> for every shape that should leave the adapter on its
+    /// compile-time default: null input, non-JObject input, missing <c>model</c>
+    /// property, or empty / whitespace value. The string itself is NOT validated
+    /// against a known list — operators may opt into future OpenAI models without
+    /// a code change, and OpenAI rejects unknown values server-side rather than us
+    /// silently falling back.
+    /// Public static so the schema-interpretation rules can be exhaustively unit tested.
+    /// </summary>
+    public static string ParseTranscriptionModel(object deserialisedConfig)
+    {
+        if (deserialisedConfig is not JObject obj) return null;
+
+        var model = obj["model"]?.Value<string>();
+
+        return string.IsNullOrWhiteSpace(model) ? null : model;
     }
 }

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Providers/OpenAi/OpenAiRealtimeAiProviderAdapter.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Providers/OpenAi/OpenAiRealtimeAiProviderAdapter.cs
@@ -12,6 +12,22 @@ namespace SmartTalk.Core.Services.RealtimeAiV2.Adapters.Providers.OpenAi;
 
 public class OpenAiRealtimeAiProviderAdapter : IRealtimeAiProviderAdapter
 {
+    /// <summary>
+    /// Compile-time default for the OpenAI transcription model. As of 2026-05-19
+    /// <c>gpt-4o-transcribe</c> is OpenAI's most capable transcription model and is
+    /// priced identically to the legacy <c>whisper-1</c> ($0.006/min), so this is a
+    /// strict quality upgrade with no operating-cost change.
+    /// <para>
+    /// This is the ONE place to change when OpenAI ships a stronger default. Per-
+    /// assistant override goes through <see cref="RealtimeAiModelConfig.TranscriptionModel"/>
+    /// — operators who need to pin a specific assistant to <c>whisper-1</c> or to
+    /// <c>gpt-4o-mini-transcribe</c> (cheaper) do so by inserting a
+    /// <see cref="SmartTalk.Messages.Enums.AiSpeechAssistant.AiSpeechAssistantSessionConfigType.TranscriptionModel"/>
+    /// row in <c>ai_speech_assistant_function_call</c>.
+    /// </para>
+    /// </summary>
+    public const string DefaultTranscriptionModel = "gpt-4o-transcribe";
+
     private readonly OpenAiSettings _openAiSettings;
 
     public OpenAiRealtimeAiProviderAdapter(OpenAiSettings openAiSettings)
@@ -56,12 +72,22 @@ public class OpenAiRealtimeAiProviderAdapter : IRealtimeAiProviderAdapter
                     input = new
                     {
                         format = ConvertCodecToGaFormat(clientCodec),
-                        // `language` is null for every assistant with no TranscriptionLanguage
-                        // row in ai_speech_assistant_function_call; the caller's
-                        // NullValueHandling.Ignore (RealtimeAiService.Connect.cs:23) strips
-                        // the key entirely, so the transcription object stays byte-equivalent
-                        // to `{ model: "whisper-1" }` for every existing prod row.
-                        transcription = new { model = "whisper-1", language = modelConfig.TranscriptionLanguage },
+                        // model defaults to DefaultTranscriptionModel (currently gpt-4o-transcribe);
+                        // operators downgrade specific assistants to whisper-1 or gpt-4o-mini-transcribe
+                        // by populating a TranscriptionModel row in ai_speech_assistant_function_call.
+                        //
+                        // language is null when no TranscriptionLanguage row exists for the assistant;
+                        // the caller's NullValueHandling.Ignore (RealtimeAiService.Connect.cs:23) strips
+                        // the key entirely, keeping the transcription object byte-equivalent to
+                        // `{ model: <default> }` for every assistant without the language hint.
+                        transcription = new
+                        {
+                            // IsNullOrWhiteSpace (not IsNullOrEmpty) so an accidental " " or "\t"
+                            // in the config row also falls back to the adapter default rather than
+                            // being forwarded as an invalid model literal and rejected by OpenAI.
+                            model = string.IsNullOrWhiteSpace(modelConfig.TranscriptionModel) ? DefaultTranscriptionModel : modelConfig.TranscriptionModel,
+                            language = modelConfig.TranscriptionLanguage
+                        },
                         turn_detection = modelConfig.TurnDetection ?? new { type = "server_vad" },
                         noise_reduction = modelConfig.InputAudioNoiseReduction
                     },

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/RealtimeSessionOptions.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/RealtimeSessionOptions.cs
@@ -72,6 +72,17 @@ public class RealtimeAiModelConfig
     /// <c>RealtimeAiService.Connect</c>) to strip the property when the value is null.
     /// </summary>
     public string TranscriptionLanguage { get; set; }
+
+    /// <summary>
+    /// Optional override of the OpenAI transcription model string sent under
+    /// <c>session.audio.input.transcription.model</c>. <c>null</c> or empty →
+    /// adapter uses its compile-time default (currently <c>gpt-4o-transcribe</c>).
+    /// Recognised operator values: <c>"whisper-1"</c>, <c>"gpt-4o-mini-transcribe"</c>,
+    /// <c>"gpt-4o-transcribe"</c>. Unrecognised values are passed through verbatim
+    /// (operator's responsibility) — OpenAI will reject them server-side rather
+    /// than the adapter silently falling back.
+    /// </summary>
+    public string TranscriptionModel { get; set; }
 }
 
 /// <summary>

--- a/src/SmartTalk.Messages/Enums/AiSpeechAssistant/AiSpeechAssistantSessionConfigType.cs
+++ b/src/SmartTalk.Messages/Enums/AiSpeechAssistant/AiSpeechAssistantSessionConfigType.cs
@@ -13,5 +13,17 @@ public enum AiSpeechAssistantSessionConfigType
     /// <c>{ "language": "yue" }</c>.
     /// Absent / inactive row → no hint sent (current default behaviour).
     /// </summary>
-    TranscriptionLanguage
+    TranscriptionLanguage,
+
+    /// <summary>
+    /// Optional per-assistant override of the OpenAI transcription model. Row
+    /// content is a JSON object with a single <c>model</c> property. Example:
+    /// <c>{ "model": "whisper-1" }</c> (downgrade) or
+    /// <c>{ "model": "gpt-4o-mini-transcribe" }</c> (cheaper variant).
+    /// Absent / inactive row → adapter falls back to its compile-time default
+    /// (<c>gpt-4o-transcribe</c>, OpenAI's most capable transcription model).
+    /// Unrecognised values are passed through verbatim — OpenAI will reject
+    /// them server-side rather than the adapter silently substituting.
+    /// </summary>
+    TranscriptionModel
 }

--- a/src/SmartTalk.UnitTests/Services/AiSpeechAssistantConnect/ParseTranscriptionModelTests.cs
+++ b/src/SmartTalk.UnitTests/Services/AiSpeechAssistantConnect/ParseTranscriptionModelTests.cs
@@ -1,0 +1,113 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Shouldly;
+using SmartTalk.Core.Services.AiSpeechAssistantConnect;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Services.AiSpeechAssistantConnect;
+
+/// <summary>
+/// Exercises every input shape <see cref="AiSpeechAssistantConnectService.ParseTranscriptionModel"/>
+/// might receive from the deserialised <c>ai_speech_assistant_function_call.content</c> JSON.
+///
+/// <para>
+/// The single load-bearing invariant: anything that should leave the adapter on its
+/// compile-time default model MUST return <c>null</c> here. A regression that returns
+/// an empty string or a placeholder value would silently send <c>"model": ""</c> (or
+/// worse, an unintended downgrade) to OpenAI, breaking transcription quality across
+/// affected calls.
+/// </para>
+///
+/// <para>
+/// Mirrors the structure of <see cref="ParseTranscriptionLanguageTests"/>; the two
+/// parsers share the same null-safety contract so regressions are visible in both
+/// suites together.
+/// </para>
+/// </summary>
+public class ParseTranscriptionModelTests
+{
+    private static object DeserializeContent(string json) => JsonConvert.DeserializeObject<object>(json);
+
+    // ── Default-path inputs (every one of these must return null) ──────────
+
+    [Fact]
+    public void ParseTranscriptionModel_NullInput_ReturnsNull()
+    {
+        // Realistic prod state: no TranscriptionModel row exists, so
+        // DeserializeFunctionCallConfig returns null. The parser must propagate
+        // null so the adapter stays on its compile-time default.
+        AiSpeechAssistantConnectService.ParseTranscriptionModel(null).ShouldBeNull();
+    }
+
+    [Fact]
+    public void ParseTranscriptionModel_NonJObjectInput_ReturnsNull()
+    {
+        // Defence: future config rows whose content is a JSON array or scalar
+        // (not the expected `{ "model": "..." }` shape) must not throw.
+        AiSpeechAssistantConnectService.ParseTranscriptionModel(JArray.Parse("[\"whisper-1\"]")).ShouldBeNull();
+        AiSpeechAssistantConnectService.ParseTranscriptionModel("whisper-1").ShouldBeNull();
+        AiSpeechAssistantConnectService.ParseTranscriptionModel(42).ShouldBeNull();
+    }
+
+    [Fact]
+    public void ParseTranscriptionModel_EmptyJsonObject_ReturnsNull()
+    {
+        // A row whose content is `{}` — the model property is missing entirely.
+        AiSpeechAssistantConnectService.ParseTranscriptionModel(DeserializeContent("{}")).ShouldBeNull();
+    }
+
+    [Fact]
+    public void ParseTranscriptionModel_ModelPropertyExplicitNull_ReturnsNull()
+    {
+        // `{ "model": null }` — operator (or migration) saved an explicit null.
+        // Must behave identically to "key missing".
+        AiSpeechAssistantConnectService.ParseTranscriptionModel(DeserializeContent("{\"model\":null}")).ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData("{\"model\":\"\"}")]
+    [InlineData("{\"model\":\" \"}")]
+    [InlineData("{\"model\":\"   \"}")]
+    [InlineData("{\"model\":\"\\t\"}")]
+    public void ParseTranscriptionModel_EmptyOrWhitespaceValue_ReturnsNull(string content)
+    {
+        // Operator-supplied empty / whitespace MUST NOT propagate to the wire payload.
+        // OpenAI would reject `"model": ""` as an invalid request and kill the session.
+        AiSpeechAssistantConnectService.ParseTranscriptionModel(DeserializeContent(content)).ShouldBeNull();
+    }
+
+    // ── Active override inputs ─────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("{\"model\":\"whisper-1\"}",               "whisper-1")]                // legacy downgrade
+    [InlineData("{\"model\":\"gpt-4o-mini-transcribe\"}",  "gpt-4o-mini-transcribe")]   // cheaper variant
+    [InlineData("{\"model\":\"gpt-4o-transcribe\"}",       "gpt-4o-transcribe")]        // explicit re-affirm of default
+    [InlineData("{\"model\":\"gpt-5-transcribe\"}",        "gpt-5-transcribe")]         // forward-compat: future model passthrough
+    public void ParseTranscriptionModel_RecognisedAndFuturePassthrough_ReturnsExactString(string content, string expected)
+    {
+        // The parser does NOT validate the string against a known list. Operators
+        // can opt into future OpenAI models without a code change, and OpenAI
+        // rejects unknown values server-side rather than us silently substituting.
+        AiSpeechAssistantConnectService.ParseTranscriptionModel(DeserializeContent(content)).ShouldBe(expected);
+    }
+
+    [Fact]
+    public void ParseTranscriptionModel_AdditionalProperties_StillExtractsModel()
+    {
+        // Forward-compatibility: future schema additions (e.g. an operator note,
+        // a temperature override) must not trip the parser.
+        var input = DeserializeContent("{\"model\":\"whisper-1\",\"note\":\"cost-sensitive DID\",\"variant\":\"v1\"}");
+
+        AiSpeechAssistantConnectService.ParseTranscriptionModel(input).ShouldBe("whisper-1");
+    }
+
+    [Fact]
+    public void ParseTranscriptionModel_ModelKeyIsCaseSensitive()
+    {
+        // Wire-format property name is `model` (lowercase). A row with `Model` or
+        // `MODEL` is treated as malformed (= no override) rather than silently
+        // activated — keeps schema interpretation strict and predictable.
+        AiSpeechAssistantConnectService.ParseTranscriptionModel(DeserializeContent("{\"Model\":\"whisper-1\"}")).ShouldBeNull();
+        AiSpeechAssistantConnectService.ParseTranscriptionModel(DeserializeContent("{\"MODEL\":\"whisper-1\"}")).ShouldBeNull();
+    }
+}

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterGaPayloadTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterGaPayloadTests.cs
@@ -148,6 +148,11 @@ public class OpenAiRealtimeAiProviderAdapterGaPayloadTests
     [Fact]
     public void BuildSessionConfig_AudioInput_CarriesTranscriptionAndTurnDetection()
     {
+        // Default transcription model upgraded from "whisper-1" to "gpt-4o-transcribe"
+        // (OpenAI's most capable transcription model, priced identically to whisper-1).
+        // The literal lives at OpenAiRealtimeAiProviderAdapter.DefaultTranscriptionModel —
+        // referencing the const here ties the assertion to the production constant so
+        // a future default change updates one place.
         var adapter = NewAdapter();
         var options = OptionsWithPromptAndVoice();
         options.ModelConfig.TurnDetection = new { type = "server_vad" };
@@ -155,7 +160,7 @@ public class OpenAiRealtimeAiProviderAdapterGaPayloadTests
         var json = SerializeSession(adapter.BuildSessionConfig(options, RealtimeAiAudioCodec.MULAW));
 
         var input = json["session"]!["audio"]!["input"]!;
-        input["transcription"]!["model"]!.Value<string>().ShouldBe("whisper-1");
+        input["transcription"]!["model"]!.Value<string>().ShouldBe(OpenAiRealtimeAiProviderAdapter.DefaultTranscriptionModel);
         input["turn_detection"]!["type"]!.Value<string>().ShouldBe("server_vad");
     }
 

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterTranscriptionLanguageTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterTranscriptionLanguageTests.cs
@@ -20,7 +20,8 @@ namespace SmartTalk.UnitTests.Services.RealtimeAiV2;
 /// is null or empty (the realistic state for every existing prod assistant — no
 /// TranscriptionLanguage row in <c>ai_speech_assistant_function_call</c>), the
 /// serialised <c>transcription</c> object MUST be byte-equivalent to the pre-hint
-/// payload: <c>{ "model": "whisper-1" }</c> with no <c>language</c> key.
+/// payload: <c>{ "model": &lt;default&gt; }</c> with no <c>language</c> key. The
+/// default model is sourced from <see cref="OpenAiRealtimeAiProviderAdapter.DefaultTranscriptionModel"/>.
 /// </para>
 ///
 /// <para>
@@ -63,10 +64,12 @@ public class OpenAiRealtimeAiProviderAdapterTranscriptionLanguageTests
         // The load-bearing test: every existing prod assistant has no
         // TranscriptionLanguage config row, so ModelConfig.TranscriptionLanguage is null.
         // The serialised transcription object MUST contain only `model` — no `language`.
+        // `model` resolves to OpenAiRealtimeAiProviderAdapter.DefaultTranscriptionModel
+        // (whatever OpenAI's strongest model is at the time of the build).
         var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(OptionsWithLanguage(null), RealtimeAiAudioCodec.MULAW));
 
         var transcription = json["session"]!["audio"]!["input"]!["transcription"]!;
-        transcription["model"]!.Value<string>().ShouldBe("whisper-1");
+        transcription["model"]!.Value<string>().ShouldBe(OpenAiRealtimeAiProviderAdapter.DefaultTranscriptionModel);
         transcription["language"].ShouldBeNull();
     }
 
@@ -130,10 +133,13 @@ public class OpenAiRealtimeAiProviderAdapterTranscriptionLanguageTests
     [InlineData("ja")]
     public void BuildSessionConfig_TranscriptionLanguageSet_EmitsLanguageProperty(string language)
     {
+        // Setting a language hint must not perturb the model field — it stays on the
+        // adapter's compile-time default unless the assistant also opted into a
+        // TranscriptionModel override (covered separately).
         var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(OptionsWithLanguage(language), RealtimeAiAudioCodec.MULAW));
 
         var transcription = json["session"]!["audio"]!["input"]!["transcription"]!;
-        transcription["model"]!.Value<string>().ShouldBe("whisper-1");
+        transcription["model"]!.Value<string>().ShouldBe(OpenAiRealtimeAiProviderAdapter.DefaultTranscriptionModel);
         transcription["language"]!.Value<string>().ShouldBe(language);
     }
 

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterTranscriptionModelTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterTranscriptionModelTests.cs
@@ -1,0 +1,169 @@
+using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NSubstitute;
+using Shouldly;
+using SmartTalk.Core.Services.RealtimeAiV2;
+using SmartTalk.Core.Services.RealtimeAiV2.Adapters.Providers.OpenAi;
+using SmartTalk.Core.Settings.OpenAi;
+using SmartTalk.Messages.Enums.RealtimeAi;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Services.RealtimeAiV2;
+
+/// <summary>
+/// Per-assistant transcription model override contract tests for
+/// <see cref="OpenAiRealtimeAiProviderAdapter.BuildSessionConfig"/>.
+///
+/// <para>
+/// Two load-bearing invariants:
+/// <list type="bullet">
+///   <item>
+///     When <see cref="RealtimeAiModelConfig.TranscriptionModel"/> is null or empty
+///     (the realistic state for every assistant with no TranscriptionModel row),
+///     the adapter emits <see cref="OpenAiRealtimeAiProviderAdapter.DefaultTranscriptionModel"/>.
+///     This is what makes the Phase 5.4 default-upgrade safe: every existing prod
+///     assistant transparently gets the upgraded model on deploy.
+///   </item>
+///   <item>
+///     When an operator sets a non-null TranscriptionModel value, the adapter emits
+///     it verbatim — no allow-list, no silent substitution. OpenAI rejects unknown
+///     values server-side rather than the adapter falling back to the default.
+///   </item>
+/// </list>
+/// </para>
+/// </summary>
+public class OpenAiRealtimeAiProviderAdapterTranscriptionModelTests
+{
+    private static readonly JsonSerializerSettings ProductionSerializer = new()
+    {
+        NullValueHandling = NullValueHandling.Ignore
+    };
+
+    private static OpenAiRealtimeAiProviderAdapter NewAdapter() =>
+        new(new OpenAiSettings(Substitute.For<IConfiguration>()));
+
+    private static RealtimeSessionOptions OptionsWithModel(string model) =>
+        new()
+        {
+            ModelConfig = new RealtimeAiModelConfig
+            {
+                Prompt = "you are helpful",
+                Voice = "alloy",
+                Tools = new List<object>(),
+                TranscriptionModel = model
+            }
+        };
+
+    private static JObject SerializeAsProduction(object payload) =>
+        JObject.Parse(JsonConvert.SerializeObject(payload, ProductionSerializer));
+
+    // ── Compile-time default ───────────────────────────────────────────────
+
+    [Fact]
+    public void DefaultTranscriptionModel_PinIsCurrentStrongestModel()
+    {
+        // Hard-pinned literal so a future default change is a deliberate,
+        // visible decision rather than an invisible refactor. As of 2026-05-19
+        // gpt-4o-transcribe is OpenAI's most capable transcription model and is
+        // priced identically to whisper-1 ($0.006/min) — strict quality upgrade,
+        // zero cost change. If/when OpenAI ships a stronger default, update this
+        // pin together with the production constant.
+        OpenAiRealtimeAiProviderAdapter.DefaultTranscriptionModel.ShouldBe("gpt-4o-transcribe");
+    }
+
+    // ── Default path: null / empty TranscriptionModel → adapter default ────
+
+    [Fact]
+    public void BuildSessionConfig_TranscriptionModelNull_UsesDefaultModel()
+    {
+        // The realistic prod state: no TranscriptionModel row → ModelConfig.TranscriptionModel
+        // is null → adapter falls back to DefaultTranscriptionModel. This is the deploy-day
+        // behaviour for every existing assistant.
+        var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(OptionsWithModel(null), RealtimeAiAudioCodec.MULAW));
+
+        json["session"]!["audio"]!["input"]!["transcription"]!["model"]!.Value<string>()
+            .ShouldBe(OpenAiRealtimeAiProviderAdapter.DefaultTranscriptionModel);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("   ")]
+    public void BuildSessionConfig_TranscriptionModelEmptyOrWhitespace_UsesDefaultModel(string model)
+    {
+        // Defence: even if the service-side parser ever lets through an empty / whitespace
+        // value (current parser strips it), the adapter falls back to default instead of
+        // sending `"model": ""` and getting rejected by OpenAI.
+        var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(OptionsWithModel(model), RealtimeAiAudioCodec.MULAW));
+
+        json["session"]!["audio"]!["input"]!["transcription"]!["model"]!.Value<string>()
+            .ShouldBe(OpenAiRealtimeAiProviderAdapter.DefaultTranscriptionModel);
+    }
+
+    // ── Active override path: operator-supplied model ──────────────────────
+
+    [Theory]
+    [InlineData("whisper-1")]                  // legacy downgrade (e.g. cost-sensitive assistant)
+    [InlineData("gpt-4o-mini-transcribe")]     // cheaper variant
+    [InlineData("gpt-4o-transcribe")]          // explicit re-affirm of the default
+    public void BuildSessionConfig_TranscriptionModelSet_EmitsOperatorValue(string model)
+    {
+        var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(OptionsWithModel(model), RealtimeAiAudioCodec.MULAW));
+
+        json["session"]!["audio"]!["input"]!["transcription"]!["model"]!.Value<string>().ShouldBe(model);
+    }
+
+    [Fact]
+    public void BuildSessionConfig_TranscriptionModelFutureValue_PassesThroughVerbatim()
+    {
+        // Forward-compatibility: an operator can opt into a future OpenAI model
+        // (e.g. `gpt-5-transcribe`) without a code change. The adapter does not
+        // validate the string — OpenAI rejects unknown values server-side rather
+        // than the adapter silently falling back to default.
+        var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(OptionsWithModel("gpt-5-transcribe"), RealtimeAiAudioCodec.MULAW));
+
+        json["session"]!["audio"]!["input"]!["transcription"]!["model"]!.Value<string>().ShouldBe("gpt-5-transcribe");
+    }
+
+    // ── Coexistence with TranscriptionLanguage ─────────────────────────────
+
+    [Fact]
+    public void BuildSessionConfig_BothModelAndLanguageSet_BothActivateIndependently()
+    {
+        // The two per-assistant configs are independent dimensions: an operator can
+        // set model alone, language alone, or both. This test pins the combined shape.
+        var adapter = NewAdapter();
+        var options = new RealtimeSessionOptions
+        {
+            ModelConfig = new RealtimeAiModelConfig
+            {
+                Prompt = "you are helpful",
+                Voice = "alloy",
+                Tools = new List<object>(),
+                TranscriptionModel = "gpt-4o-mini-transcribe",
+                TranscriptionLanguage = "yue"
+            }
+        };
+
+        var json = SerializeAsProduction(adapter.BuildSessionConfig(options, RealtimeAiAudioCodec.MULAW));
+
+        var transcription = json["session"]!["audio"]!["input"]!["transcription"]!;
+        transcription["model"]!.Value<string>().ShouldBe("gpt-4o-mini-transcribe");
+        transcription["language"]!.Value<string>().ShouldBe("yue");
+    }
+
+    [Fact]
+    public void BuildSessionConfig_TranscriptionModelSet_DoesNotPerturbAdjacentFields()
+    {
+        // Activating the model override must not silently shift turn_detection,
+        // noise_reduction, voice, or output format.
+        var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(OptionsWithModel("whisper-1"), RealtimeAiAudioCodec.MULAW));
+
+        var session = json["session"]!;
+        session["audio"]!["input"]!["turn_detection"]!["type"]!.Value<string>().ShouldBe("server_vad");
+        session["audio"]!["input"]!["noise_reduction"].ShouldBeNull();
+        session["audio"]!["output"]!["voice"]!.Value<string>().ShouldBe("alloy");
+        session["audio"]!["output"]!["format"]!["type"]!.Value<string>().ShouldBe("audio/pcmu");
+    }
+}


### PR DESCRIPTION
## Summary

Two changes in one PR:

1. **Default transcription model upgrade**: hard-coded `"whisper-1"` is replaced by a `DefaultTranscriptionModel` constant set to `"gpt-4o-transcribe"` — OpenAI's most capable transcription model as of 2026-05-19, priced identically to whisper-1 (`$0.006/min`). Strict quality upgrade, zero operating-cost change.

2. **Per-assistant override**: new `TranscriptionModel` enum value lets operators pin specific assistants to `whisper-1` (legacy compat), `gpt-4o-mini-transcribe` (cheaper variant), or any future OpenAI model via the existing `ai_speech_assistant_function_call` config-map.

## ⚠️ Intentional behaviour change

Unlike PR #951 (pure opt-in), **this PR changes the wire payload for every existing prod assistant on deploy**. The `session.audio.input.transcription.model` field switches from `whisper-1` to `gpt-4o-transcribe` system-wide. Per-assistant override is provided for any assistant that needs to stay on whisper-1.

## Quality motivation

Restaurant phone orders mix Cantonese, Mandarin, and English mid-utterance. `gpt-4o-transcribe` outperforms `whisper-1` on every multilingual benchmark OpenAI has published, and recognises mixed-in English tokens after a Chinese-family language switch noticeably more reliably. Combined with PR #951's language hint, every existing prod assistant gets a transcription-quality lift on deploy with no per-assistant configuration needed.

## Risk + rollback

| Risk | Mitigation |
|---|---|
| Quality regression on a specific assistant | Per-assistant override → SQL `INSERT` to pin that assistant to `whisper-1`, no service restart |
| System-wide regression discovered after deploy | `git revert` this PR + redeploy → back to `whisper-1` default |
| Future OpenAI model name change / typo | Adapter does not validate strings; unknown values are rejected by OpenAI server-side with `invalid_value`, not silently substituted |

## Changes

| File | Change |
|---|---|
| `AiSpeechAssistantSessionConfigType.cs` | New enum value `TranscriptionModel` (value 4, appended) |
| `RealtimeSessionOptions.cs` (V2 `RealtimeAiModelConfig`) | New nullable `string TranscriptionModel` |
| `AiSpeechAssistantConnectService.Build.Session.cs` | New public-static helper `ParseTranscriptionModel(object)`; `BuildSessionOptions` wires it |
| `OpenAiRealtimeAiProviderAdapter.cs` | New `public const string DefaultTranscriptionModel = "gpt-4o-transcribe"`; `BuildSessionConfig`'s transcription object uses it with `IsNullOrWhiteSpace` fallback |
| Existing tests | `OpenAiRealtimeAiProviderAdapterGaPayloadTests` + `…TranscriptionLanguageTests` assertions on `"whisper-1"` literal now reference `OpenAiRealtimeAiProviderAdapter.DefaultTranscriptionModel` |

## Test plan

- [x] Build: 0 errors
- [x] **`ParseTranscriptionModelTests`** — 14 cases: null input, non-JObject input, empty object, explicit null property, empty/whitespace value (4 variants), recognised models (`whisper-1`, `gpt-4o-mini-transcribe`, `gpt-4o-transcribe`), forward-compat future model passthrough, additional properties, case-sensitivity guard
- [x] **`OpenAiRealtimeAiProviderAdapterTranscriptionModelTests`** — 11 cases:
  - `DefaultTranscriptionModel` constant value hard-pinned (`"gpt-4o-transcribe"`)
  - null / 3 empty-variant → adapter default
  - 3 recognised models activate verbatim
  - Forward-compat: `gpt-5-transcribe` passthrough
  - Coexistence with `TranscriptionLanguage` hint
  - Adjacent fields not perturbed
- [x] **Existing GA pinning + TranscriptionLanguage tests** updated to reference the const, all pass
- [x] **Full unit suite**: 384/384 pass (was 359 baseline + 25 new)
- [ ] **Staging**: deploy with all assistants on default; record 100 mixed-language calls; compare transcription accuracy vs. whisper-1 baseline (human-rated sample of ~200 utterances)
- [ ] **Prod canary**: deploy + observe 24h — watch `invalid_value` errors (should be 0), Twilio `CallStatus.completed` rate (should be ≥ baseline), user complaints (none model-related)
- [ ] If quality regression on any specific assistant: per-assistant SQL override → `whisper-1`

## Operator naming convention for the `name` column

The `name` column in `ai_speech_assistant_function_call` is a human-readable label only — the runtime looks up rows by `type`. Use the snake_case of the enum value (`transcription_model`, `transcription_language`, `turn_direction`, etc.) so DB queries and dashboards are self-documenting. (PR #951 examples showed `transcription_language_hint`; the cleaner convention going forward is the plain enum name `transcription_language`.)

## Operator commands

**Pin one assistant to `whisper-1`** (cost-sensitive / quality-stable):
```sql
INSERT INTO ai_speech_assistant_function_call
    (assistant_id, name, content, type, model_provider, is_active, created_date)
VALUES
    (<id>, 'transcription_model', '{"model":"whisper-1"}',
     4, <provider>, true, NOW());
```

**Pin one assistant to `gpt-4o-mini-transcribe`** (50% cheaper, still better than whisper-1):
```sql
INSERT INTO ai_speech_assistant_function_call
    (assistant_id, name, content, type, model_provider, is_active, created_date)
VALUES
    (<id>, 'transcription_model', '{"model":"gpt-4o-mini-transcribe"}',
     4, <provider>, true, NOW());
```

**Per-assistant rollback** (back to default `gpt-4o-transcribe`):
```sql
UPDATE ai_speech_assistant_function_call
SET is_active = false
WHERE assistant_id = <id> AND type = 4;
```

**Global rollback to `whisper-1`**: `git revert <this-sha>` + redeploy.

## Refs

- https://platform.openai.com/docs/models#gpt-4o-transcribe
- https://platform.openai.com/docs/api-reference/realtime-sessions
- Base: PR #950 (Round 2 base branch). Sits on top of PR #951 (transcription language hint).