### PR TITLE
Add per-assistant max_response_output_tokens cap via config-map row

### DIFF
--- a/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectService.Build.Session.cs
+++ b/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectService.Build.Session.cs
@@ -35,7 +35,8 @@ public partial class AiSpeechAssistantConnectService
                 TurnDetection = DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.TurnDirection),
                 InputAudioNoiseReduction = DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.InputAudioNoiseReduction),
                 TranscriptionLanguage = ParseTranscriptionLanguage(DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.TranscriptionLanguage)),
-                TranscriptionModel = ParseTranscriptionModel(DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.TranscriptionModel))
+                TranscriptionModel = ParseTranscriptionModel(DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.TranscriptionModel)),
+                MaxResponseOutputTokens = ParseMaxResponseOutputTokens(DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.MaxResponseOutputTokens))
             },
             ConnectionProfile = new RealtimeAiConnectionProfile
             {
@@ -119,5 +120,30 @@ public partial class AiSpeechAssistantConnectService
         var model = obj["model"]?.Value<string>();
 
         return string.IsNullOrWhiteSpace(model) ? null : model;
+    }
+
+    /// <summary>
+    /// Extracts the <c>value</c> integer from a deserialised
+    /// <see cref="AiSpeechAssistantSessionConfigType.MaxResponseOutputTokens"/> config object.
+    /// Returns <c>null</c> for every shape that should leave the response cap unset
+    /// (so OpenAI uses its server-side default): null input, non-JObject input,
+    /// missing <c>value</c> property, non-integer value, or non-positive integer.
+    /// Non-positive caps are rejected here rather than passed through because they
+    /// would either be rejected by OpenAI server-side anyway (zero / negative) or
+    /// silently truncate AI responses to an empty turn (one), which is worse than
+    /// the default.
+    /// Public static so the schema-interpretation rules can be exhaustively unit tested.
+    /// </summary>
+    public static int? ParseMaxResponseOutputTokens(object deserialisedConfig)
+    {
+        if (deserialisedConfig is not JObject obj) return null;
+
+        var token = obj["value"];
+
+        if (token == null || token.Type != JTokenType.Integer) return null;
+
+        var value = token.Value<int>();
+
+        return value > 0 ? value : null;
     }
 }

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Providers/OpenAi/OpenAiRealtimeAiProviderAdapter.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Providers/OpenAi/OpenAiRealtimeAiProviderAdapter.cs
@@ -67,6 +67,11 @@ public class OpenAiRealtimeAiProviderAdapter : IRealtimeAiProviderAdapter
                 type = "realtime",
                 instructions = modelConfig.Prompt,
                 output_modalities = new[] { "audio" },
+                // null for every assistant without a MaxResponseOutputTokens row; the
+                // caller's NullValueHandling.Ignore (RealtimeAiService.Connect.cs:23)
+                // strips the key entirely, so OpenAI uses its server-side default
+                // (effectively unlimited within the session budget).
+                max_response_output_tokens = modelConfig.MaxResponseOutputTokens,
                 audio = new
                 {
                     input = new

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/RealtimeSessionOptions.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/RealtimeSessionOptions.cs
@@ -83,6 +83,15 @@ public class RealtimeAiModelConfig
     /// than the adapter silently falling back.
     /// </summary>
     public string TranscriptionModel { get; set; }
+
+    /// <summary>
+    /// Optional cap on the response output tokens for a single AI turn, sent under
+    /// <c>session.max_response_output_tokens</c>. <c>null</c> → the field is omitted
+    /// from the payload (the caller's <see cref="Newtonsoft.Json.NullValueHandling.Ignore"/>
+    /// strips it), so OpenAI uses its server-side default. Positive integer → caps a
+    /// runaway monologue; OpenAI rejects non-positive integers server-side.
+    /// </summary>
+    public int? MaxResponseOutputTokens { get; set; }
 }
 
 /// <summary>

--- a/src/SmartTalk.Messages/Enums/AiSpeechAssistant/AiSpeechAssistantSessionConfigType.cs
+++ b/src/SmartTalk.Messages/Enums/AiSpeechAssistant/AiSpeechAssistantSessionConfigType.cs
@@ -25,5 +25,16 @@ public enum AiSpeechAssistantSessionConfigType
     /// Unrecognised values are passed through verbatim — OpenAI will reject
     /// them server-side rather than the adapter silently substituting.
     /// </summary>
-    TranscriptionModel
+    TranscriptionModel,
+
+    /// <summary>
+    /// Optional per-assistant cap on the response output token count. Row
+    /// content is a JSON object with a single <c>value</c> property holding a
+    /// positive integer. Example: <c>{ "value": 1200 }</c>. Absent / inactive
+    /// row → no <c>max_response_output_tokens</c> field is sent, so OpenAI
+    /// uses its server-side default (effectively unlimited within the session
+    /// budget). Caps a single AI turn — useful when an assistant occasionally
+    /// monologues and delays the user's next prompt.
+    /// </summary>
+    MaxResponseOutputTokens
 }

--- a/src/SmartTalk.UnitTests/Services/AiSpeechAssistantConnect/ParseMaxResponseOutputTokensTests.cs
+++ b/src/SmartTalk.UnitTests/Services/AiSpeechAssistantConnect/ParseMaxResponseOutputTokensTests.cs
@@ -1,0 +1,128 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Shouldly;
+using SmartTalk.Core.Services.AiSpeechAssistantConnect;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Services.AiSpeechAssistantConnect;
+
+/// <summary>
+/// Exercises every input shape <see cref="AiSpeechAssistantConnectService.ParseMaxResponseOutputTokens"/>
+/// might receive from the deserialised <c>ai_speech_assistant_function_call.content</c> JSON.
+///
+/// <para>
+/// The single load-bearing invariant: anything that should leave the response cap
+/// unset (so OpenAI uses its server-side default) MUST return <c>null</c> here.
+/// In particular, a non-positive integer (zero or negative) — which OpenAI rejects
+/// or which would silently truncate AI responses to empty turns — is rejected by
+/// the parser rather than passed through.
+/// </para>
+///
+/// <para>
+/// Mirrors the structure of <see cref="ParseTranscriptionLanguageTests"/> and
+/// <see cref="ParseTranscriptionModelTests"/>; the three parsers share the same
+/// null-safety contract so regressions are visible in all three suites together.
+/// </para>
+/// </summary>
+public class ParseMaxResponseOutputTokensTests
+{
+    private static object DeserializeContent(string json) => JsonConvert.DeserializeObject<object>(json);
+
+    // ── Default-path inputs (every one of these must return null) ──────────
+
+    [Fact]
+    public void ParseMaxResponseOutputTokens_NullInput_ReturnsNull()
+    {
+        // Realistic prod state: no MaxResponseOutputTokens row exists, so
+        // DeserializeFunctionCallConfig returns null. The parser must propagate
+        // null so the adapter omits the cap field entirely.
+        AiSpeechAssistantConnectService.ParseMaxResponseOutputTokens(null).ShouldBeNull();
+    }
+
+    [Fact]
+    public void ParseMaxResponseOutputTokens_NonJObjectInput_ReturnsNull()
+    {
+        // Defence: future config rows whose content is a JSON array or scalar
+        // (not the expected `{ "value": <int> }` shape) must not throw.
+        AiSpeechAssistantConnectService.ParseMaxResponseOutputTokens(JArray.Parse("[1200]")).ShouldBeNull();
+        AiSpeechAssistantConnectService.ParseMaxResponseOutputTokens(1200).ShouldBeNull();
+        AiSpeechAssistantConnectService.ParseMaxResponseOutputTokens("1200").ShouldBeNull();
+    }
+
+    [Fact]
+    public void ParseMaxResponseOutputTokens_EmptyJsonObject_ReturnsNull()
+    {
+        // A row whose content is `{}` — the value property is missing entirely.
+        AiSpeechAssistantConnectService.ParseMaxResponseOutputTokens(DeserializeContent("{}")).ShouldBeNull();
+    }
+
+    [Fact]
+    public void ParseMaxResponseOutputTokens_ValuePropertyExplicitNull_ReturnsNull()
+    {
+        // `{ "value": null }` — operator (or migration) saved an explicit null.
+        // Must behave identically to "key missing".
+        AiSpeechAssistantConnectService.ParseMaxResponseOutputTokens(DeserializeContent("{\"value\":null}")).ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData("{\"value\":\"1200\"}")]   // string instead of int — schema violation
+    [InlineData("{\"value\":1.5}")]        // floating-point — schema violation
+    [InlineData("{\"value\":true}")]       // bool — schema violation
+    [InlineData("{\"value\":[1200]}")]     // array — schema violation
+    public void ParseMaxResponseOutputTokens_NonIntegerValue_ReturnsNull(string content)
+    {
+        // The JSON schema requires the value to be a plain integer. Anything else
+        // (string-coercible numbers, floats, bools, structured values) is treated
+        // as malformed — adapter falls back to no cap, which is safer than
+        // attempting a fragile coercion that could send an invalid value to OpenAI.
+        AiSpeechAssistantConnectService.ParseMaxResponseOutputTokens(DeserializeContent(content)).ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData("{\"value\":0}")]
+    [InlineData("{\"value\":-1}")]
+    [InlineData("{\"value\":-1000}")]
+    public void ParseMaxResponseOutputTokens_NonPositiveValue_ReturnsNull(string content)
+    {
+        // Zero or negative caps are either rejected by OpenAI server-side (invalid)
+        // or silently truncate AI responses to empty turns (one), both worse than
+        // omitting the cap. Reject at the parser layer.
+        AiSpeechAssistantConnectService.ParseMaxResponseOutputTokens(DeserializeContent(content)).ShouldBeNull();
+    }
+
+    // ── Active cap inputs ─────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("{\"value\":1}",     1)]      // minimum valid (degenerate but technically valid)
+    [InlineData("{\"value\":100}",   100)]
+    [InlineData("{\"value\":800}",   800)]    // recommended low end for restaurant turns
+    [InlineData("{\"value\":1200}",  1200)]   // recommended typical cap
+    [InlineData("{\"value\":4096}",  4096)]   // common upper bound
+    [InlineData("{\"value\":100000}", 100000)] // very generous cap — operator's choice
+    public void ParseMaxResponseOutputTokens_PositiveIntegerValue_ReturnsExactInteger(string content, int expected)
+    {
+        // No upper bound is enforced — operators choose the cap they want, and
+        // OpenAI rejects values beyond its server-side limits with a clear error
+        // rather than us silently clamping.
+        AiSpeechAssistantConnectService.ParseMaxResponseOutputTokens(DeserializeContent(content)).ShouldBe(expected);
+    }
+
+    [Fact]
+    public void ParseMaxResponseOutputTokens_AdditionalProperties_StillExtractsValue()
+    {
+        // Forward-compatibility: future schema additions (e.g. an operator note,
+        // a per-turn override) must not trip the parser.
+        var input = DeserializeContent("{\"value\":1200,\"note\":\"cap monologues\",\"applies_to\":\"all_turns\"}");
+
+        AiSpeechAssistantConnectService.ParseMaxResponseOutputTokens(input).ShouldBe(1200);
+    }
+
+    [Fact]
+    public void ParseMaxResponseOutputTokens_ValueKeyIsCaseSensitive()
+    {
+        // Wire-format property name is `value` (lowercase). A row with `Value` or
+        // `VALUE` is treated as malformed (= no cap) rather than silently activated.
+        AiSpeechAssistantConnectService.ParseMaxResponseOutputTokens(DeserializeContent("{\"Value\":1200}")).ShouldBeNull();
+        AiSpeechAssistantConnectService.ParseMaxResponseOutputTokens(DeserializeContent("{\"VALUE\":1200}")).ShouldBeNull();
+    }
+}

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterMaxResponseOutputTokensTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterMaxResponseOutputTokensTests.cs
@@ -1,0 +1,145 @@
+using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NSubstitute;
+using Shouldly;
+using SmartTalk.Core.Services.RealtimeAiV2;
+using SmartTalk.Core.Services.RealtimeAiV2.Adapters.Providers.OpenAi;
+using SmartTalk.Core.Settings.OpenAi;
+using SmartTalk.Messages.Enums.RealtimeAi;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Services.RealtimeAiV2;
+
+/// <summary>
+/// Per-assistant response-token cap contract tests for
+/// <see cref="OpenAiRealtimeAiProviderAdapter.BuildSessionConfig"/>.
+///
+/// <para>
+/// The load-bearing invariant: when <see cref="RealtimeAiModelConfig.MaxResponseOutputTokens"/>
+/// is null (the realistic state for every assistant with no cap row), the
+/// <c>session</c> object MUST NOT contain a <c>max_response_output_tokens</c>
+/// property — so OpenAI uses its server-side default. This is what makes the
+/// feature non-breaking: every existing prod assistant continues to behave
+/// exactly as today until an operator inserts a row.
+/// </para>
+/// </summary>
+public class OpenAiRealtimeAiProviderAdapterMaxResponseOutputTokensTests
+{
+    private static readonly JsonSerializerSettings ProductionSerializer = new()
+    {
+        NullValueHandling = NullValueHandling.Ignore
+    };
+
+    private static OpenAiRealtimeAiProviderAdapter NewAdapter() =>
+        new(new OpenAiSettings(Substitute.For<IConfiguration>()));
+
+    private static RealtimeSessionOptions OptionsWithCap(int? cap) =>
+        new()
+        {
+            ModelConfig = new RealtimeAiModelConfig
+            {
+                Prompt = "you are helpful",
+                Voice = "alloy",
+                Tools = new List<object>(),
+                MaxResponseOutputTokens = cap
+            }
+        };
+
+    private static JObject SerializeAsProduction(object payload) =>
+        JObject.Parse(JsonConvert.SerializeObject(payload, ProductionSerializer));
+
+    // ── Default path: null cap → field absent from payload ────────────────
+
+    [Fact]
+    public void BuildSessionConfig_MaxResponseOutputTokensNull_FieldAbsentFromPayload()
+    {
+        // The load-bearing test: every existing prod assistant has no
+        // MaxResponseOutputTokens config row, so ModelConfig.MaxResponseOutputTokens
+        // is null. The serialised session object MUST contain no
+        // `max_response_output_tokens` property — NullValueHandling.Ignore
+        // strips it at serialisation time. OpenAI server-side default applies.
+        var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(OptionsWithCap(null), RealtimeAiAudioCodec.MULAW));
+
+        json["session"]!["max_response_output_tokens"].ShouldBeNull();
+    }
+
+    [Fact]
+    public void BuildSessionConfig_MaxResponseOutputTokensNull_AdjacentSessionFieldsUnchanged()
+    {
+        // Sanity check: the null-cap path must not perturb any adjacent
+        // session-level field. Regression here would mean Phase 5.5 silently
+        // shifted instructions / output_modalities / tools semantics.
+        var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(OptionsWithCap(null), RealtimeAiAudioCodec.MULAW));
+
+        var session = json["session"]!;
+        session["type"]!.Value<string>().ShouldBe("realtime");
+        session["instructions"]!.Value<string>().ShouldBe("you are helpful");
+        session["output_modalities"]!.Values<string>().ShouldBe(new[] { "audio" });
+        session["max_response_output_tokens"].ShouldBeNull();
+    }
+
+    // ── Active path: cap set → emitted at session level ────────────────────
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(100)]
+    [InlineData(800)]
+    [InlineData(1200)]
+    [InlineData(4096)]
+    [InlineData(100000)]
+    public void BuildSessionConfig_MaxResponseOutputTokensSet_EmitsCapAtSessionLevel(int cap)
+    {
+        // The adapter forwards whatever the operator set. No clamping — operators
+        // get exact control, and OpenAI rejects values beyond its server-side
+        // limits with a clear error rather than the adapter silently clipping.
+        var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(OptionsWithCap(cap), RealtimeAiAudioCodec.MULAW));
+
+        json["session"]!["max_response_output_tokens"]!.Value<int>().ShouldBe(cap);
+    }
+
+    [Fact]
+    public void BuildSessionConfig_MaxResponseOutputTokensSet_DoesNotPerturbAudioFields()
+    {
+        // Activating the cap must not silently shift transcription, turn_detection,
+        // noise_reduction, voice, or output format.
+        var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(OptionsWithCap(1200), RealtimeAiAudioCodec.MULAW));
+
+        var session = json["session"]!;
+        session["audio"]!["input"]!["transcription"]!["model"]!.Value<string>()
+            .ShouldBe(OpenAiRealtimeAiProviderAdapter.DefaultTranscriptionModel);
+        session["audio"]!["input"]!["turn_detection"]!["type"]!.Value<string>().ShouldBe("server_vad");
+        session["audio"]!["input"]!["noise_reduction"].ShouldBeNull();
+        session["audio"]!["output"]!["voice"]!.Value<string>().ShouldBe("alloy");
+        session["audio"]!["output"]!["format"]!["type"]!.Value<string>().ShouldBe("audio/pcmu");
+    }
+
+    // ── Coexistence with adjacent per-assistant configs ────────────────────
+
+    [Fact]
+    public void BuildSessionConfig_CapAndLanguageAndModel_AllActivateIndependently()
+    {
+        // All three Phase 5 per-assistant configs are independent dimensions.
+        // Pin the combined shape so a future PR that touches one cannot silently
+        // break the others.
+        var options = new RealtimeSessionOptions
+        {
+            ModelConfig = new RealtimeAiModelConfig
+            {
+                Prompt = "you are helpful",
+                Voice = "alloy",
+                Tools = new List<object>(),
+                TranscriptionLanguage = "yue",
+                TranscriptionModel = "gpt-4o-mini-transcribe",
+                MaxResponseOutputTokens = 1200
+            }
+        };
+
+        var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(options, RealtimeAiAudioCodec.MULAW));
+
+        var session = json["session"]!;
+        session["audio"]!["input"]!["transcription"]!["model"]!.Value<string>().ShouldBe("gpt-4o-mini-transcribe");
+        session["audio"]!["input"]!["transcription"]!["language"]!.Value<string>().ShouldBe("yue");
+        session["max_response_output_tokens"]!.Value<int>().ShouldBe(1200);
+    }
+}


### PR DESCRIPTION
## Summary

Adds an optional per-assistant cap on the OpenAI Realtime API's `session.max_response_output_tokens` field. Operators activate the cap by inserting a `MaxResponseOutputTokens` row in `ai_speech_assistant_function_call` with content `{"value": 1200}`. Absent / inactive row → no cap field is sent → OpenAI uses its server-side default (effectively unlimited within the session budget) — **byte-equivalent to today's payload**.

## Motivation

Restaurant assistants occasionally monologue (e.g. enumerating menu options at length) and delay the user's next prompt. A per-assistant cap shortens runaway turns without changing default behaviour: every existing assistant continues with no cap until an operator opts a specific assistant in.

## Default behaviour guarantee

Every existing prod assistant has no `MaxResponseOutputTokens` row →
- `ParseMaxResponseOutputTokens` returns `null`
- `ModelConfig.MaxResponseOutputTokens` is `null`
- Adapter emits `max_response_output_tokens = null`
- Caller's `NullValueHandling.Ignore` (`RealtimeAiService.Connect.cs:23`) strips the property
- Wire payload is identical to today

Existing 12 GA pinning tests all pass — regression boundary preserved.

## Changes

| File | Change |
|---|---|
| `AiSpeechAssistantSessionConfigType.cs` | New enum value `MaxResponseOutputTokens` (value = 5, appended) |
| `RealtimeSessionOptions.cs` (V2 `RealtimeAiModelConfig`) | New `int? MaxResponseOutputTokens` |
| `AiSpeechAssistantConnectService.Build.Session.cs` | New public-static `ParseMaxResponseOutputTokens(object)`; `BuildSessionOptions` wires it |
| `OpenAiRealtimeAiProviderAdapter.cs` | Emits `max_response_output_tokens` at session level (null stripped by serialiser) |

## Parser contract

Returns `null` (= no cap, default applies) for every shape that should leave the cap unset:
- null input
- non-JObject input
- empty object `{}`
- `{"value": null}` (explicit null)
- non-integer values (string, float, bool, array)
- non-positive integers (0, negative)

Positive integers pass through verbatim — no upper-bound clamping. Operators choose the cap they want; OpenAI rejects values beyond its server-side limits with a clear error rather than the adapter silently clipping.

## Test plan

- [x] Build: 0 errors
- [x] **`ParseMaxResponseOutputTokensTests`** — 21 cases: null, non-object, empty, explicit null, non-integer values (4 variants), non-positive (3 variants), positive integers (6 variants from 1 to 100k), additional properties, case sensitivity
- [x] **`OpenAiRealtimeAiProviderAdapterMaxResponseOutputTokensTests`** — 8 cases:
  - null cap → field absent from payload (load-bearing invariant)
  - null cap → adjacent session fields unchanged
  - 6 positive caps emit correctly (no clamping)
  - Coexistence with adjacent per-assistant configs (language + model)
  - Adjacent audio fields not perturbed
- [x] **Existing GA pinning suite** (12 cases) — all pass unchanged (regression boundary preserved)
- [x] **Full unit suite**: 413/413 pass (was 384 baseline + 29 new)
- [ ] Staging: pin one chatty assistant to `{"value": 800}`, verify AI turns shorten on long-explanation prompts without truncating mid-sentence

## Operator commands

**Cap one assistant at 1200 tokens** (typical):
```sql
INSERT INTO ai_speech_assistant_function_call
    (assistant_id, name, content, type, model_provider, is_active, created_date)
VALUES
    (<id>, 'max_response_output_tokens', '{"value":1200}',
     5, <provider>, true, NOW());
```

**Per-assistant rollback** (back to no cap):
```sql
UPDATE ai_speech_assistant_function_call
SET is_active = false
WHERE assistant_id = <id> AND type = 5;
```

Base: PR #950 (Round 2 base branch).

## Refs

- https://platform.openai.com/docs/api-reference/realtime-sessions/update