### PR TITLE
Add per-assistant audio output speed via config-map row

### DIFF
--- a/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectService.Build.Session.cs
+++ b/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectService.Build.Session.cs
@@ -36,7 +36,8 @@ public partial class AiSpeechAssistantConnectService
                 InputAudioNoiseReduction = DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.InputAudioNoiseReduction),
                 TranscriptionLanguage = ParseTranscriptionLanguage(DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.TranscriptionLanguage)),
                 TranscriptionModel = ParseTranscriptionModel(DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.TranscriptionModel)),
-                MaxResponseOutputTokens = ParseMaxResponseOutputTokens(DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.MaxResponseOutputTokens))
+                MaxResponseOutputTokens = ParseMaxResponseOutputTokens(DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.MaxResponseOutputTokens)),
+                OutputAudioSpeed = ParseOutputAudioSpeed(DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.OutputAudioSpeed))
             },
             ConnectionProfile = new RealtimeAiConnectionProfile
             {
@@ -143,6 +144,31 @@ public partial class AiSpeechAssistantConnectService
         if (token == null || token.Type != JTokenType.Integer) return null;
 
         var value = token.Value<int>();
+
+        return value > 0 ? value : null;
+    }
+
+    /// <summary>
+    /// Extracts the <c>value</c> decimal from a deserialised
+    /// <see cref="AiSpeechAssistantSessionConfigType.OutputAudioSpeed"/> config object.
+    /// Returns <c>null</c> for every shape that should leave the speed unset (so
+    /// OpenAI uses 1.0, current behaviour): null input, non-JObject input, missing
+    /// <c>value</c> property, non-numeric value, or non-positive value. The parser
+    /// does NOT enforce OpenAI's range (currently 0.25 – 1.5) — operators who set
+    /// out-of-range values are rejected by OpenAI server-side with a clear error,
+    /// rather than the adapter silently clamping into a different speed than the
+    /// operator intended.
+    /// Public static so the schema-interpretation rules can be exhaustively unit tested.
+    /// </summary>
+    public static decimal? ParseOutputAudioSpeed(object deserialisedConfig)
+    {
+        if (deserialisedConfig is not JObject obj) return null;
+
+        var token = obj["value"];
+
+        if (token == null || (token.Type != JTokenType.Float && token.Type != JTokenType.Integer)) return null;
+
+        var value = token.Value<decimal>();
 
         return value > 0 ? value : null;
     }

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Providers/OpenAi/OpenAiRealtimeAiProviderAdapter.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Providers/OpenAi/OpenAiRealtimeAiProviderAdapter.cs
@@ -99,7 +99,11 @@ public class OpenAiRealtimeAiProviderAdapter : IRealtimeAiProviderAdapter
                     output = new
                     {
                         format = ConvertCodecToGaFormat(clientCodec),
-                        voice = string.IsNullOrEmpty(modelConfig.Voice) ? "alloy" : modelConfig.Voice
+                        voice = string.IsNullOrEmpty(modelConfig.Voice) ? "alloy" : modelConfig.Voice,
+                        // null for every assistant without an OutputAudioSpeed row; the
+                        // caller's NullValueHandling.Ignore (RealtimeAiService.Connect.cs:23)
+                        // strips the key entirely, so OpenAI uses its default 1.0.
+                        speed = modelConfig.OutputAudioSpeed
                     }
                 },
                 tools = modelConfig.Tools.Any() ? modelConfig.Tools : null

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/RealtimeSessionOptions.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/RealtimeSessionOptions.cs
@@ -92,6 +92,15 @@ public class RealtimeAiModelConfig
     /// runaway monologue; OpenAI rejects non-positive integers server-side.
     /// </summary>
     public int? MaxResponseOutputTokens { get; set; }
+
+    /// <summary>
+    /// Optional playback-speed multiplier for the AI's audio output, sent under
+    /// <c>session.audio.output.speed</c>. <c>null</c> → the field is omitted (so
+    /// OpenAI uses 1.0, current behaviour). Range supported by OpenAI is 0.25 – 1.5
+    /// (1.0 = natural). Values outside the range are rejected by OpenAI server-side
+    /// rather than the adapter silently clamping.
+    /// </summary>
+    public decimal? OutputAudioSpeed { get; set; }
 }
 
 /// <summary>

--- a/src/SmartTalk.Messages/Enums/AiSpeechAssistant/AiSpeechAssistantSessionConfigType.cs
+++ b/src/SmartTalk.Messages/Enums/AiSpeechAssistant/AiSpeechAssistantSessionConfigType.cs
@@ -36,5 +36,16 @@ public enum AiSpeechAssistantSessionConfigType
     /// budget). Caps a single AI turn — useful when an assistant occasionally
     /// monologues and delays the user's next prompt.
     /// </summary>
-    MaxResponseOutputTokens
+    MaxResponseOutputTokens,
+
+    /// <summary>
+    /// Optional per-assistant playback-speed multiplier for the AI's audio
+    /// output. Row content is a JSON object with a single <c>value</c>
+    /// property holding a decimal in the range supported by OpenAI (currently
+    /// 0.25 – 1.5; 1.0 = natural). Example: <c>{ "value": 0.9 }</c> for
+    /// elderly customers, <c>{ "value": 1.1 }</c> for fast-paced ones.
+    /// Absent / inactive row → no <c>speed</c> field is sent, so OpenAI uses
+    /// 1.0 (current behaviour).
+    /// </summary>
+    OutputAudioSpeed
 }

--- a/src/SmartTalk.UnitTests/Services/AiSpeechAssistantConnect/ParseOutputAudioSpeedTests.cs
+++ b/src/SmartTalk.UnitTests/Services/AiSpeechAssistantConnect/ParseOutputAudioSpeedTests.cs
@@ -1,0 +1,127 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Shouldly;
+using SmartTalk.Core.Services.AiSpeechAssistantConnect;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Services.AiSpeechAssistantConnect;
+
+/// <summary>
+/// Exercises every input shape <see cref="AiSpeechAssistantConnectService.ParseOutputAudioSpeed"/>
+/// might receive from the deserialised <c>ai_speech_assistant_function_call.content</c> JSON.
+///
+/// <para>
+/// The single load-bearing invariant: anything that should leave the speed
+/// unset (so OpenAI uses 1.0, current behaviour) MUST return <c>null</c>.
+/// Non-positive values are rejected at the parser layer because zero / negative
+/// playback speed is meaningless to OpenAI and would either be rejected
+/// server-side or worse interpreted differently across model versions.
+/// </para>
+///
+/// <para>
+/// The parser does NOT enforce OpenAI's documented range (currently 0.25 – 1.5).
+/// Operators who set out-of-range values are rejected by OpenAI server-side
+/// with a clear error rather than the adapter silently clamping into a
+/// different speed than the operator intended.
+/// </para>
+/// </summary>
+public class ParseOutputAudioSpeedTests
+{
+    private static object DeserializeContent(string json) => JsonConvert.DeserializeObject<object>(json);
+
+    // ── Default-path inputs (every one of these must return null) ──────────
+
+    [Fact]
+    public void ParseOutputAudioSpeed_NullInput_ReturnsNull()
+    {
+        AiSpeechAssistantConnectService.ParseOutputAudioSpeed(null).ShouldBeNull();
+    }
+
+    [Fact]
+    public void ParseOutputAudioSpeed_NonJObjectInput_ReturnsNull()
+    {
+        AiSpeechAssistantConnectService.ParseOutputAudioSpeed(JArray.Parse("[1.0]")).ShouldBeNull();
+        AiSpeechAssistantConnectService.ParseOutputAudioSpeed(1.0).ShouldBeNull();
+        AiSpeechAssistantConnectService.ParseOutputAudioSpeed("1.0").ShouldBeNull();
+    }
+
+    [Fact]
+    public void ParseOutputAudioSpeed_EmptyJsonObject_ReturnsNull()
+    {
+        AiSpeechAssistantConnectService.ParseOutputAudioSpeed(DeserializeContent("{}")).ShouldBeNull();
+    }
+
+    [Fact]
+    public void ParseOutputAudioSpeed_ValuePropertyExplicitNull_ReturnsNull()
+    {
+        AiSpeechAssistantConnectService.ParseOutputAudioSpeed(DeserializeContent("{\"value\":null}")).ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData("{\"value\":\"1.0\"}")]   // string instead of number
+    [InlineData("{\"value\":true}")]      // bool
+    [InlineData("{\"value\":[1.0]}")]     // array
+    public void ParseOutputAudioSpeed_NonNumericValue_ReturnsNull(string content)
+    {
+        AiSpeechAssistantConnectService.ParseOutputAudioSpeed(DeserializeContent(content)).ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData("{\"value\":0}")]
+    [InlineData("{\"value\":0.0}")]
+    [InlineData("{\"value\":-0.5}")]
+    [InlineData("{\"value\":-1.0}")]
+    public void ParseOutputAudioSpeed_NonPositiveValue_ReturnsNull(string content)
+    {
+        // Zero or negative playback speed is meaningless; reject at the parser
+        // rather than emit a value that OpenAI either rejects or interprets
+        // inconsistently across model versions.
+        AiSpeechAssistantConnectService.ParseOutputAudioSpeed(DeserializeContent(content)).ShouldBeNull();
+    }
+
+    // ── Active speed inputs ────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("{\"value\":0.25}", "0.25")]    // documented OpenAI minimum
+    [InlineData("{\"value\":0.8}",  "0.8")]     // a slower-than-natural setting
+    [InlineData("{\"value\":0.9}",  "0.9")]     // recommended for elderly customers
+    [InlineData("{\"value\":1.0}",  "1.0")]     // explicit natural speed
+    [InlineData("{\"value\":1.1}",  "1.1")]     // recommended for fast-paced customers
+    [InlineData("{\"value\":1.5}",  "1.5")]     // documented OpenAI maximum
+    public void ParseOutputAudioSpeed_PositiveDecimal_ReturnsExactValue(string content, string expectedString)
+    {
+        // Use string literals to avoid C# decimal-literal precision surprises in the
+        // [InlineData] table; convert here so each case is self-documenting.
+        var expected = decimal.Parse(expectedString, System.Globalization.CultureInfo.InvariantCulture);
+
+        AiSpeechAssistantConnectService.ParseOutputAudioSpeed(DeserializeContent(content)).ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("{\"value\":2}",   2)]      // integer 2 — passed through (out of OpenAI's 1.5 max but accepted by parser)
+    [InlineData("{\"value\":100}", 100)]    // way out of range — rejected by OpenAI, not the parser
+    public void ParseOutputAudioSpeed_IntegerValue_AcceptedAsDecimal(string content, int expectedInt)
+    {
+        // Integers also count as positive numerics. The parser does not enforce
+        // OpenAI's documented 0.25 – 1.5 range — out-of-range values are passed
+        // through and rejected by OpenAI server-side with a clear error.
+        var expected = (decimal)expectedInt;
+
+        AiSpeechAssistantConnectService.ParseOutputAudioSpeed(DeserializeContent(content)).ShouldBe(expected);
+    }
+
+    [Fact]
+    public void ParseOutputAudioSpeed_AdditionalProperties_StillExtractsValue()
+    {
+        var input = DeserializeContent("{\"value\":0.9,\"note\":\"elderly assistant\"}");
+
+        AiSpeechAssistantConnectService.ParseOutputAudioSpeed(input).ShouldBe(0.9m);
+    }
+
+    [Fact]
+    public void ParseOutputAudioSpeed_ValueKeyIsCaseSensitive()
+    {
+        AiSpeechAssistantConnectService.ParseOutputAudioSpeed(DeserializeContent("{\"Value\":0.9}")).ShouldBeNull();
+        AiSpeechAssistantConnectService.ParseOutputAudioSpeed(DeserializeContent("{\"VALUE\":0.9}")).ShouldBeNull();
+    }
+}

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterOutputAudioSpeedTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterOutputAudioSpeedTests.cs
@@ -1,0 +1,138 @@
+using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NSubstitute;
+using Shouldly;
+using SmartTalk.Core.Services.RealtimeAiV2;
+using SmartTalk.Core.Services.RealtimeAiV2.Adapters.Providers.OpenAi;
+using SmartTalk.Core.Settings.OpenAi;
+using SmartTalk.Messages.Enums.RealtimeAi;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Services.RealtimeAiV2;
+
+/// <summary>
+/// Per-assistant output audio speed contract tests for
+/// <see cref="OpenAiRealtimeAiProviderAdapter.BuildSessionConfig"/>.
+///
+/// <para>
+/// The load-bearing invariant: when <see cref="RealtimeAiModelConfig.OutputAudioSpeed"/>
+/// is null (the realistic state for every assistant with no speed row), the
+/// <c>audio.output</c> object MUST NOT contain a <c>speed</c> property — so
+/// OpenAI uses its default of 1.0.
+/// </para>
+/// </summary>
+public class OpenAiRealtimeAiProviderAdapterOutputAudioSpeedTests
+{
+    private static readonly JsonSerializerSettings ProductionSerializer = new()
+    {
+        NullValueHandling = NullValueHandling.Ignore
+    };
+
+    private static OpenAiRealtimeAiProviderAdapter NewAdapter() =>
+        new(new OpenAiSettings(Substitute.For<IConfiguration>()));
+
+    private static RealtimeSessionOptions OptionsWithSpeed(decimal? speed) =>
+        new()
+        {
+            ModelConfig = new RealtimeAiModelConfig
+            {
+                Prompt = "you are helpful",
+                Voice = "alloy",
+                Tools = new List<object>(),
+                OutputAudioSpeed = speed
+            }
+        };
+
+    private static JObject SerializeAsProduction(object payload) =>
+        JObject.Parse(JsonConvert.SerializeObject(payload, ProductionSerializer));
+
+    // ── Default path: null speed → field absent from payload ──────────────
+
+    [Fact]
+    public void BuildSessionConfig_OutputAudioSpeedNull_FieldAbsentFromPayload()
+    {
+        // Load-bearing: every existing prod assistant has no OutputAudioSpeed row →
+        // ModelConfig.OutputAudioSpeed is null → NullValueHandling.Ignore strips the
+        // key from `audio.output`. OpenAI uses 1.0 as before.
+        var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(OptionsWithSpeed(null), RealtimeAiAudioCodec.MULAW));
+
+        json["session"]!["audio"]!["output"]!["speed"].ShouldBeNull();
+    }
+
+    [Fact]
+    public void BuildSessionConfig_OutputAudioSpeedNull_AdjacentOutputFieldsUnchanged()
+    {
+        // Null speed must not perturb voice or format inside audio.output.
+        var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(OptionsWithSpeed(null), RealtimeAiAudioCodec.MULAW));
+
+        var output = json["session"]!["audio"]!["output"]!;
+        output["voice"]!.Value<string>().ShouldBe("alloy");
+        output["format"]!["type"]!.Value<string>().ShouldBe("audio/pcmu");
+        output["speed"].ShouldBeNull();
+    }
+
+    // ── Active path: speed set → emitted inside audio.output ──────────────
+
+    [Theory]
+    [InlineData("0.25")]   // documented minimum
+    [InlineData("0.85")]   // slower-than-natural
+    [InlineData("0.9")]    // elderly-customer recommendation
+    [InlineData("1.0")]    // explicit natural speed
+    [InlineData("1.1")]    // fast-paced
+    [InlineData("1.5")]    // documented maximum
+    public void BuildSessionConfig_OutputAudioSpeedSet_EmitsSpeedInsideAudioOutput(string speedString)
+    {
+        var speed = decimal.Parse(speedString, System.Globalization.CultureInfo.InvariantCulture);
+
+        var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(OptionsWithSpeed(speed), RealtimeAiAudioCodec.MULAW));
+
+        json["session"]!["audio"]!["output"]!["speed"]!.Value<decimal>().ShouldBe(speed);
+    }
+
+    [Fact]
+    public void BuildSessionConfig_OutputAudioSpeedSet_DoesNotPerturbInputFields()
+    {
+        // Activating output speed must not silently shift any input-side field
+        // (transcription / turn_detection / noise_reduction / format).
+        var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(OptionsWithSpeed(0.9m), RealtimeAiAudioCodec.MULAW));
+
+        var input = json["session"]!["audio"]!["input"]!;
+        input["transcription"]!["model"]!.Value<string>()
+            .ShouldBe(OpenAiRealtimeAiProviderAdapter.DefaultTranscriptionModel);
+        input["turn_detection"]!["type"]!.Value<string>().ShouldBe("server_vad");
+        input["noise_reduction"].ShouldBeNull();
+        input["format"]!["type"]!.Value<string>().ShouldBe("audio/pcmu");
+    }
+
+    // ── Coexistence with other per-assistant configs ───────────────────────
+
+    [Fact]
+    public void BuildSessionConfig_SpeedAndLanguageAndCap_AllActivateIndependently()
+    {
+        // Each per-assistant config is an independent dimension. Pin the
+        // combined shape so a future PR that touches one cannot silently break
+        // the others.
+        var options = new RealtimeSessionOptions
+        {
+            ModelConfig = new RealtimeAiModelConfig
+            {
+                Prompt = "you are helpful",
+                Voice = "alloy",
+                Tools = new List<object>(),
+                TranscriptionLanguage = "yue",
+                TranscriptionModel = "gpt-4o-mini-transcribe",
+                MaxResponseOutputTokens = 1200,
+                OutputAudioSpeed = 0.9m
+            }
+        };
+
+        var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(options, RealtimeAiAudioCodec.MULAW));
+
+        var session = json["session"]!;
+        session["audio"]!["input"]!["transcription"]!["model"]!.Value<string>().ShouldBe("gpt-4o-mini-transcribe");
+        session["audio"]!["input"]!["transcription"]!["language"]!.Value<string>().ShouldBe("yue");
+        session["audio"]!["output"]!["speed"]!.Value<decimal>().ShouldBe(0.9m);
+        session["max_response_output_tokens"]!.Value<int>().ShouldBe(1200);
+    }
+}


### PR DESCRIPTION
## Summary

Adds an optional per-assistant playback-speed multiplier sent under `session.audio.output.speed`. Operators activate by inserting an `OutputAudioSpeed` row with content `{"value": 0.9}`. Absent / inactive row → no `speed` field is sent → OpenAI uses 1.0 (current behaviour).

## Motivation

Restaurant assistants serve mixed customer cohorts:
- Some elderly customers struggle with natural-speed AI output → operators can set `0.85` – `0.9`
- Some fast-paced customers find natural speed too slow → operators can set `1.10` – `1.15`

A per-assistant dial gives operators a small UX lever without affecting any other assistant.

## Default behaviour guarantee

Every existing prod assistant has no `OutputAudioSpeed` row →
- `ParseOutputAudioSpeed` returns `null`
- `ModelConfig.OutputAudioSpeed` is `null`
- Adapter emits `speed = null` inside `audio.output`
- Caller's `NullValueHandling.Ignore` strips the property
- Wire payload is identical to today

Existing 12 GA pinning tests all pass — regression boundary preserved.

## Changes

| File | Change |
|---|---|
| `AiSpeechAssistantSessionConfigType.cs` | New enum value `OutputAudioSpeed` (value = 6, appended) |
| `RealtimeSessionOptions.cs` (V2 `RealtimeAiModelConfig`) | New `decimal? OutputAudioSpeed` |
| `AiSpeechAssistantConnectService.Build.Session.cs` | New public-static `ParseOutputAudioSpeed(object)`; `BuildSessionOptions` wires it |
| `OpenAiRealtimeAiProviderAdapter.cs` | Emits `speed` inside `audio.output` (null stripped by serialiser) |

## Parser contract

Returns `null` (= no speed, default 1.0 applies) for every shape that should leave it unset:
- null input
- non-JObject input
- empty object `{}`
- `{"value": null}`
- non-numeric values (string, bool, array)
- non-positive values (0, 0.0, negative)

Positive numeric values pass through. **The parser does NOT enforce OpenAI's documented 0.25 – 1.5 range** — out-of-range values are rejected by OpenAI server-side with a clear error rather than the adapter silently clamping into a different speed than the operator intended.

## Test plan

- [x] Build: 0 errors
- [x] **`ParseOutputAudioSpeedTests`** — 23 cases: null, non-object, empty, explicit null, non-numeric (3 variants), non-positive (4 variants), positive decimals (6 from 0.25 to 1.5), integer passthrough, additional properties, case sensitivity
- [x] **`OpenAiRealtimeAiProviderAdapterOutputAudioSpeedTests`** — 8 cases: null → absent (load-bearing); 6 speeds emit verbatim; adjacent input/output fields unchanged; coexistence with language + model + cap configs
- [x] **Existing GA pinning suite** (12 cases) — all still pass unchanged
- [x] **Full unit suite**: 444/444 pass (was 413 baseline + 31 new)
- [ ] Staging canary: pin one elderly-heavy assistant to `{"value": 0.9}` and one fast-paced assistant to `{"value": 1.1}`, gather subjective feedback

## Operator commands

**Slower for elderly customers**:
```sql
INSERT INTO ai_speech_assistant_function_call
    (assistant_id, name, content, type, model_provider, is_active, created_date)
VALUES
    (<id>, 'output_audio_speed', '{"value":0.9}',
     6, <provider>, true, NOW());
```

**Faster for fast-paced customers**:
```sql
INSERT INTO ai_speech_assistant_function_call
    (assistant_id, name, content, type, model_provider, is_active, created_date)
VALUES
    (<id>, 'output_audio_speed', '{"value":1.1}',
     6, <provider>, true, NOW());
```

**Per-assistant rollback** (back to 1.0):
```sql
UPDATE ai_speech_assistant_function_call
SET is_active = false
WHERE assistant_id = <id> AND type = 6;
```

Base: PR #950 (Round 2 base branch).

## Refs

- https://platform.openai.com/docs/api-reference/realtime-sessions/update