### PR TITLE
Add per-assistant OpenAI realtime session tracing opt-in via config-map row

### DIFF
--- a/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectService.Build.Session.cs
+++ b/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectService.Build.Session.cs
@@ -37,7 +37,8 @@ public partial class AiSpeechAssistantConnectService
                 TranscriptionLanguage = ParseTranscriptionLanguage(DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.TranscriptionLanguage)),
                 TranscriptionModel = ParseTranscriptionModel(DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.TranscriptionModel)),
                 MaxResponseOutputTokens = ParseMaxResponseOutputTokens(DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.MaxResponseOutputTokens)),
-                OutputAudioSpeed = ParseOutputAudioSpeed(DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.OutputAudioSpeed))
+                OutputAudioSpeed = ParseOutputAudioSpeed(DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.OutputAudioSpeed)),
+                EnableRealtimeTracing = ParseEnableRealtimeTracing(DeserializeFunctionCallConfig(AiSpeechAssistantSessionConfigType.RealtimeTracing))
             },
             ConnectionProfile = new RealtimeAiConnectionProfile
             {
@@ -171,5 +172,26 @@ public partial class AiSpeechAssistantConnectService
         var value = token.Value<decimal>();
 
         return value > 0 ? value : null;
+    }
+
+    /// <summary>
+    /// Extracts the <c>enabled</c> boolean from a deserialised
+    /// <see cref="AiSpeechAssistantSessionConfigType.RealtimeTracing"/> config object.
+    /// Returns <c>null</c> for every shape that should leave tracing off (current
+    /// behaviour): null input, non-JObject input, missing <c>enabled</c> property,
+    /// non-boolean value, or explicit <c>false</c>. Only an explicit <c>true</c>
+    /// activates tracing; the parser distinguishes <c>false</c> from <c>null</c> so
+    /// an operator can persist an explicit "off" state alongside the inactive flag.
+    /// Public static so the schema-interpretation rules can be exhaustively unit tested.
+    /// </summary>
+    public static bool? ParseEnableRealtimeTracing(object deserialisedConfig)
+    {
+        if (deserialisedConfig is not JObject obj) return null;
+
+        var token = obj["enabled"];
+
+        if (token == null || token.Type != JTokenType.Boolean) return null;
+
+        return token.Value<bool>() ? true : null;
     }
 }

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Providers/OpenAi/OpenAiRealtimeAiProviderAdapter.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Providers/OpenAi/OpenAiRealtimeAiProviderAdapter.cs
@@ -28,6 +28,15 @@ public class OpenAiRealtimeAiProviderAdapter : IRealtimeAiProviderAdapter
     /// </summary>
     public const string DefaultTranscriptionModel = "gpt-4o-transcribe";
 
+    /// <summary>
+    /// Wire value emitted under <c>session.tracing</c> when an assistant opts into
+    /// OpenAI's official session tracing. As of 2026-05-20 OpenAI documents <c>"auto"</c>
+    /// as the no-config opt-in: OpenAI picks sensible defaults for workflow grouping
+    /// and retention. Operators see the captured sessions at
+    /// <c>https://platform.openai.com/traces</c>.
+    /// </summary>
+    public const string EnabledTracingMode = "auto";
+
     private readonly OpenAiSettings _openAiSettings;
 
     public OpenAiRealtimeAiProviderAdapter(OpenAiSettings openAiSettings)
@@ -72,6 +81,12 @@ public class OpenAiRealtimeAiProviderAdapter : IRealtimeAiProviderAdapter
                 // strips the key entirely, so OpenAI uses its server-side default
                 // (effectively unlimited within the session budget).
                 max_response_output_tokens = modelConfig.MaxResponseOutputTokens,
+                // null for every assistant without an opt-in RealtimeTracing row; the
+                // serializer strips the key, so OpenAI does not retain a trace
+                // (current behaviour). Setting EnableRealtimeTracing = true emits
+                // `tracing = "auto"` and the session shows up in the OpenAI
+                // traces dashboard for 30 days — escalation-debug tool.
+                tracing = modelConfig.EnableRealtimeTracing == true ? EnabledTracingMode : null,
                 audio = new
                 {
                     input = new

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/RealtimeSessionOptions.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/RealtimeSessionOptions.cs
@@ -101,6 +101,15 @@ public class RealtimeAiModelConfig
     /// rather than the adapter silently clamping.
     /// </summary>
     public decimal? OutputAudioSpeed { get; set; }
+
+    /// <summary>
+    /// Optional opt-in to OpenAI's official session tracing. <c>true</c> → adapter
+    /// emits <c>session.tracing = "auto"</c>, telling OpenAI to retain the session
+    /// in their trace dashboard for 30 days. <c>null</c> or <c>false</c> → the
+    /// <c>tracing</c> field is omitted (current behaviour). Use during customer
+    /// escalations to capture an intermittent reproduction; disable afterwards.
+    /// </summary>
+    public bool? EnableRealtimeTracing { get; set; }
 }
 
 /// <summary>

--- a/src/SmartTalk.Messages/Enums/AiSpeechAssistant/AiSpeechAssistantSessionConfigType.cs
+++ b/src/SmartTalk.Messages/Enums/AiSpeechAssistant/AiSpeechAssistantSessionConfigType.cs
@@ -47,5 +47,18 @@ public enum AiSpeechAssistantSessionConfigType
     /// Absent / inactive row → no <c>speed</c> field is sent, so OpenAI uses
     /// 1.0 (current behaviour).
     /// </summary>
-    OutputAudioSpeed
+    OutputAudioSpeed,
+
+    /// <summary>
+    /// Optional per-assistant opt-in to OpenAI's official session tracing.
+    /// Row content is a JSON object with a single boolean <c>enabled</c>
+    /// property. Example: <c>{ "enabled": true }</c>. Absent / inactive row
+    /// or <c>{ "enabled": false }</c> → no <c>tracing</c> field is sent, so
+    /// OpenAI does not retain a session trace (current behaviour). When
+    /// enabled the adapter sends <c>tracing = "auto"</c>, which makes OpenAI
+    /// retain the session in <c>platform.openai.com/traces</c> for 30 days —
+    /// essential for diagnosing intermittent calls during customer
+    /// escalations. Disable after capturing the reproduction.
+    /// </summary>
+    RealtimeTracing
 }

--- a/src/SmartTalk.UnitTests/Services/AiSpeechAssistantConnect/ParseEnableRealtimeTracingTests.cs
+++ b/src/SmartTalk.UnitTests/Services/AiSpeechAssistantConnect/ParseEnableRealtimeTracingTests.cs
@@ -1,0 +1,100 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Shouldly;
+using SmartTalk.Core.Services.AiSpeechAssistantConnect;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Services.AiSpeechAssistantConnect;
+
+/// <summary>
+/// Exercises every input shape <see cref="AiSpeechAssistantConnectService.ParseEnableRealtimeTracing"/>
+/// might receive from the deserialised <c>ai_speech_assistant_function_call.content</c> JSON.
+///
+/// <para>
+/// The single load-bearing invariant: anything that should leave tracing OFF
+/// (current behaviour — OpenAI does NOT retain a session trace) MUST return
+/// <c>null</c>. Only an explicit <c>{ "enabled": true }</c> activates tracing.
+/// An explicit <c>{ "enabled": false }</c> also returns null — operators can
+/// persist the row in the inactive state without accidentally enabling tracing,
+/// distinguishing "deliberately off" from "no row" semantically.
+/// </para>
+/// </summary>
+public class ParseEnableRealtimeTracingTests
+{
+    private static object DeserializeContent(string json) => JsonConvert.DeserializeObject<object>(json);
+
+    // ── Default-path inputs (every one of these must return null) ──────────
+
+    [Fact]
+    public void ParseEnableRealtimeTracing_NullInput_ReturnsNull()
+    {
+        AiSpeechAssistantConnectService.ParseEnableRealtimeTracing(null).ShouldBeNull();
+    }
+
+    [Fact]
+    public void ParseEnableRealtimeTracing_NonJObjectInput_ReturnsNull()
+    {
+        AiSpeechAssistantConnectService.ParseEnableRealtimeTracing(JArray.Parse("[true]")).ShouldBeNull();
+        AiSpeechAssistantConnectService.ParseEnableRealtimeTracing(true).ShouldBeNull();
+        AiSpeechAssistantConnectService.ParseEnableRealtimeTracing("true").ShouldBeNull();
+    }
+
+    [Fact]
+    public void ParseEnableRealtimeTracing_EmptyJsonObject_ReturnsNull()
+    {
+        AiSpeechAssistantConnectService.ParseEnableRealtimeTracing(DeserializeContent("{}")).ShouldBeNull();
+    }
+
+    [Fact]
+    public void ParseEnableRealtimeTracing_EnabledPropertyExplicitNull_ReturnsNull()
+    {
+        AiSpeechAssistantConnectService.ParseEnableRealtimeTracing(DeserializeContent("{\"enabled\":null}")).ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData("{\"enabled\":\"true\"}")]    // string instead of bool
+    [InlineData("{\"enabled\":1}")]            // integer
+    [InlineData("{\"enabled\":[true]}")]       // array
+    public void ParseEnableRealtimeTracing_NonBooleanValue_ReturnsNull(string content)
+    {
+        // The schema requires a real JSON boolean. Anything else (string-coercible
+        // truthy values, numbers, arrays) is treated as malformed → tracing stays off.
+        AiSpeechAssistantConnectService.ParseEnableRealtimeTracing(DeserializeContent(content)).ShouldBeNull();
+    }
+
+    [Fact]
+    public void ParseEnableRealtimeTracing_ExplicitFalse_ReturnsNull()
+    {
+        // An explicit `{ "enabled": false }` MUST behave identically to a missing row
+        // or an inactive row. Operators sometimes persist the "off" state explicitly
+        // (e.g. via UI checkbox that defaults to false); we must not interpret that
+        // as a tracing opt-in.
+        AiSpeechAssistantConnectService.ParseEnableRealtimeTracing(DeserializeContent("{\"enabled\":false}")).ShouldBeNull();
+    }
+
+    // ── Active opt-in inputs ───────────────────────────────────────────────
+
+    [Fact]
+    public void ParseEnableRealtimeTracing_ExplicitTrue_ReturnsTrue()
+    {
+        AiSpeechAssistantConnectService.ParseEnableRealtimeTracing(DeserializeContent("{\"enabled\":true}")).ShouldBe(true);
+    }
+
+    [Fact]
+    public void ParseEnableRealtimeTracing_AdditionalProperties_StillExtractsEnabled()
+    {
+        // Forward-compatibility for future schema additions (e.g. workflow_name,
+        // group_id for finer-grained OpenAI trace classification). Extras are
+        // ignored; the parser only reads `enabled`.
+        var input = DeserializeContent("{\"enabled\":true,\"workflow_name\":\"escalation_123\",\"group_id\":\"ops\"}");
+
+        AiSpeechAssistantConnectService.ParseEnableRealtimeTracing(input).ShouldBe(true);
+    }
+
+    [Fact]
+    public void ParseEnableRealtimeTracing_EnabledKeyIsCaseSensitive()
+    {
+        AiSpeechAssistantConnectService.ParseEnableRealtimeTracing(DeserializeContent("{\"Enabled\":true}")).ShouldBeNull();
+        AiSpeechAssistantConnectService.ParseEnableRealtimeTracing(DeserializeContent("{\"ENABLED\":true}")).ShouldBeNull();
+    }
+}

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterRealtimeTracingTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterRealtimeTracingTests.cs
@@ -1,0 +1,155 @@
+using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NSubstitute;
+using Shouldly;
+using SmartTalk.Core.Services.RealtimeAiV2;
+using SmartTalk.Core.Services.RealtimeAiV2.Adapters.Providers.OpenAi;
+using SmartTalk.Core.Settings.OpenAi;
+using SmartTalk.Messages.Enums.RealtimeAi;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Services.RealtimeAiV2;
+
+/// <summary>
+/// Per-assistant OpenAI session-tracing contract tests for
+/// <see cref="OpenAiRealtimeAiProviderAdapter.BuildSessionConfig"/>.
+///
+/// <para>
+/// The load-bearing invariant: when <see cref="RealtimeAiModelConfig.EnableRealtimeTracing"/>
+/// is null or false (the realistic state for every assistant with no opt-in
+/// row), the <c>session</c> object MUST NOT contain a <c>tracing</c> property
+/// — so OpenAI does NOT retain a session trace, matching the pre-feature
+/// privacy posture.
+/// </para>
+/// </summary>
+public class OpenAiRealtimeAiProviderAdapterRealtimeTracingTests
+{
+    private static readonly JsonSerializerSettings ProductionSerializer = new()
+    {
+        NullValueHandling = NullValueHandling.Ignore
+    };
+
+    private static OpenAiRealtimeAiProviderAdapter NewAdapter() =>
+        new(new OpenAiSettings(Substitute.For<IConfiguration>()));
+
+    private static RealtimeSessionOptions OptionsWithTracing(bool? enableTracing) =>
+        new()
+        {
+            ModelConfig = new RealtimeAiModelConfig
+            {
+                Prompt = "you are helpful",
+                Voice = "alloy",
+                Tools = new List<object>(),
+                EnableRealtimeTracing = enableTracing
+            }
+        };
+
+    private static JObject SerializeAsProduction(object payload) =>
+        JObject.Parse(JsonConvert.SerializeObject(payload, ProductionSerializer));
+
+    // ── Compile-time mode constant pinned ─────────────────────────────────
+
+    [Fact]
+    public void EnabledTracingMode_PinnedToAuto()
+    {
+        // The wire literal under session.tracing is hard-pinned so a future
+        // rename / typo is a visible compile-time decision rather than an
+        // invisible refactor.
+        OpenAiRealtimeAiProviderAdapter.EnabledTracingMode.ShouldBe("auto");
+    }
+
+    // ── Default path: null / false → field absent ──────────────────────────
+
+    [Fact]
+    public void BuildSessionConfig_TracingNull_FieldAbsentFromPayload()
+    {
+        // Load-bearing: every existing prod assistant has no RealtimeTracing row →
+        // EnableRealtimeTracing is null → NullValueHandling.Ignore strips the
+        // `tracing` key from session. OpenAI does not retain a trace.
+        var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(OptionsWithTracing(null), RealtimeAiAudioCodec.MULAW));
+
+        json["session"]!["tracing"].ShouldBeNull();
+    }
+
+    [Fact]
+    public void BuildSessionConfig_TracingFalse_FieldAbsentFromPayload()
+    {
+        // An explicit `false` MUST behave identically to null — operators can
+        // persist a row with `{ "enabled": false }` to deliberately document
+        // "we considered tracing and decided against it"; that must not surface
+        // as an enabled trace.
+        var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(OptionsWithTracing(false), RealtimeAiAudioCodec.MULAW));
+
+        json["session"]!["tracing"].ShouldBeNull();
+    }
+
+    [Fact]
+    public void BuildSessionConfig_TracingNull_AdjacentSessionFieldsUnchanged()
+    {
+        // Sanity: null tracing must not perturb any adjacent session-level field.
+        var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(OptionsWithTracing(null), RealtimeAiAudioCodec.MULAW));
+
+        var session = json["session"]!;
+        session["type"]!.Value<string>().ShouldBe("realtime");
+        session["instructions"]!.Value<string>().ShouldBe("you are helpful");
+        session["output_modalities"]!.Values<string>().ShouldBe(new[] { "audio" });
+        session["tracing"].ShouldBeNull();
+    }
+
+    // ── Active opt-in: true → emits "auto" at session level ────────────────
+
+    [Fact]
+    public void BuildSessionConfig_TracingTrue_EmitsAutoAtSessionLevel()
+    {
+        var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(OptionsWithTracing(true), RealtimeAiAudioCodec.MULAW));
+
+        json["session"]!["tracing"]!.Value<string>().ShouldBe(OpenAiRealtimeAiProviderAdapter.EnabledTracingMode);
+    }
+
+    [Fact]
+    public void BuildSessionConfig_TracingTrue_DoesNotPerturbAudioFields()
+    {
+        // Activating tracing must not silently shift any audio field —
+        // tracing is purely an out-of-band metadata flag.
+        var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(OptionsWithTracing(true), RealtimeAiAudioCodec.MULAW));
+
+        var session = json["session"]!;
+        session["audio"]!["input"]!["transcription"]!["model"]!.Value<string>()
+            .ShouldBe(OpenAiRealtimeAiProviderAdapter.DefaultTranscriptionModel);
+        session["audio"]!["input"]!["turn_detection"]!["type"]!.Value<string>().ShouldBe("server_vad");
+        session["audio"]!["input"]!["noise_reduction"].ShouldBeNull();
+        session["audio"]!["output"]!["voice"]!.Value<string>().ShouldBe("alloy");
+        session["audio"]!["output"]!["format"]!["type"]!.Value<string>().ShouldBe("audio/pcmu");
+    }
+
+    // ── Coexistence with adjacent per-assistant configs ────────────────────
+
+    [Fact]
+    public void BuildSessionConfig_TracingAndLanguageAndModelAndCap_AllActivateIndependently()
+    {
+        // Pin the combined shape so a future PR that touches one Phase 5 config
+        // cannot silently break adjacent ones.
+        var options = new RealtimeSessionOptions
+        {
+            ModelConfig = new RealtimeAiModelConfig
+            {
+                Prompt = "you are helpful",
+                Voice = "alloy",
+                Tools = new List<object>(),
+                TranscriptionLanguage = "yue",
+                TranscriptionModel = "gpt-4o-mini-transcribe",
+                MaxResponseOutputTokens = 1200,
+                EnableRealtimeTracing = true
+            }
+        };
+
+        var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(options, RealtimeAiAudioCodec.MULAW));
+
+        var session = json["session"]!;
+        session["audio"]!["input"]!["transcription"]!["model"]!.Value<string>().ShouldBe("gpt-4o-mini-transcribe");
+        session["audio"]!["input"]!["transcription"]!["language"]!.Value<string>().ShouldBe("yue");
+        session["max_response_output_tokens"]!.Value<int>().ShouldBe(1200);
+        session["tracing"]!.Value<string>().ShouldBe("auto");
+    }
+}


### PR DESCRIPTION
## Summary

Adds an optional per-assistant opt-in to OpenAI's official session tracing. Operators activate by inserting a `RealtimeTracing` row with content `{"enabled": true}`. Absent / inactive row or `{"enabled": false}` → no `tracing` field is sent → OpenAI does NOT retain the session trace (current behaviour).

When enabled, the adapter emits `session.tracing = "auto"` and the session shows up in OpenAI's official trace dashboard at https://platform.openai.com/traces with 30-day retention.

## Motivation

Customer escalations sometimes turn on intermittent issues that reproduce only every ~50 calls. Per-assistant tracing opt-in lets ops temporarily enable tracing on the affected assistant, capture the reproduction in OpenAI's trace dashboard, then disable. **No blanket-on policy** — privacy posture stays unchanged for every assistant that has not opted in.

## Default behaviour guarantee

Every existing prod assistant has no `RealtimeTracing` row →
- `ParseEnableRealtimeTracing` returns `null`
- Also returns `null` for an explicit `{"enabled": false}` so operators can persist that state without surprises
- `ModelConfig.EnableRealtimeTracing` is `null`
- Adapter emits `tracing = null`
- Caller's `NullValueHandling.Ignore` strips the property
- Wire payload is identical to today

Existing 12 GA pinning tests all pass — regression boundary preserved.

## Changes

| File | Change |
|---|---|
| `AiSpeechAssistantSessionConfigType.cs` | New enum value `RealtimeTracing` (value = **7**, appended after `OutputAudioSpeed`) |
| `RealtimeSessionOptions.cs` (V2 `RealtimeAiModelConfig`) | New `bool? EnableRealtimeTracing` |
| `AiSpeechAssistantConnectService.Build.Session.cs` | New public-static `ParseEnableRealtimeTracing(object)`; `BuildSessionOptions` wires it |
| `OpenAiRealtimeAiProviderAdapter.cs` | New `public const string EnabledTracingMode = "auto"` (pinned in a unit test); `BuildSessionConfig` emits `tracing = EnabledTracingMode` when opted in |

## Parser contract

Returns `null` (= no tracing) for every shape that should leave tracing OFF:
- null input
- non-JObject input
- empty object `{}`
- `{"enabled": null}`
- non-boolean values (string, integer, array)
- **explicit `{"enabled": false}`** — operators can persist the off state without it surfacing as on

Only an explicit `{"enabled": true}` activates tracing.

## Test plan

- [x] Build: 0 errors
- [x] **`ParseEnableRealtimeTracingTests`** — 13 cases: null, non-object, empty, explicit null, non-bool (3 variants), explicit false, explicit true, additional properties, case sensitivity
- [x] **`OpenAiRealtimeAiProviderAdapterRealtimeTracingTests`** — 7 cases:
  - `EnabledTracingMode` constant pinned to `"auto"`
  - null / false → field absent (load-bearing)
  - true → emits `"auto"` at session level
  - Adjacent audio/session fields unchanged in both states
  - Coexistence with language + model + cap + speed configs
- [x] **Existing GA pinning suite** (12 cases) — all still pass unchanged
- [x] **Full unit suite**: 462/462 pass (after #956 merge into base + 18 new)
- [ ] During next escalation: turn on tracing on one assistant, verify session appears in OpenAI dashboard

## Operator commands

**Enable tracing during escalation** (per assistant):
```sql
INSERT INTO ai_speech_assistant_function_call
    (assistant_id, name, content, type, model_provider, is_active, created_date)
VALUES
    (<id>, 'realtime_tracing', '{"enabled":true}',
     7, <provider>, true, NOW());
```

**Disable after capturing the reproduction**:
```sql
UPDATE ai_speech_assistant_function_call
SET is_active = false
WHERE assistant_id = <id> AND type = 7;
```

> Rebased after #956 (OutputAudioSpeed = 6) merged. Tracing's enum value is **7**.

Base: PR #950 (Round 2 base branch).

## Refs

- https://platform.openai.com/docs/api-reference/realtime-sessions/update
- https://platform.openai.com/traces (operator dashboard)