### PR TITLE
Pin OpenAI Realtime API voice list + DefaultVoice constant

### DIFF
--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Providers/OpenAi/OpenAiRealtimeAiProviderAdapter.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Providers/OpenAi/OpenAiRealtimeAiProviderAdapter.cs
@@ -37,6 +37,41 @@ public class OpenAiRealtimeAiProviderAdapter : IRealtimeAiProviderAdapter
     /// </summary>
     public const string EnabledTracingMode = "auto";
 
+    /// <summary>
+    /// Compile-time default <c>audio.output.voice</c> when an assistant has no explicit
+    /// <see cref="RealtimeAiModelConfig.Voice"/> override. Matches OpenAI's historical
+    /// default and is one of the values in <see cref="SupportedVoices"/>.
+    /// </summary>
+    public const string DefaultVoice = "alloy";
+
+    /// <summary>
+    /// The voice IDs OpenAI's Realtime API accepts as of 2026-05-20. The adapter does
+    /// NOT enforce this list — operators can opt into a future OpenAI voice without a
+    /// code change, and OpenAI rejects unknown values server-side. The pin exists so
+    /// (a) UI / operator tooling has a single source of truth for the dropdown and
+    /// (b) a unit test asserts every entry stays in sync with the OpenAI docs.
+    ///
+    /// <para>
+    /// Source: https://platform.openai.com/docs/guides/realtime — Voice Options.
+    /// </para>
+    /// </summary>
+    public static readonly IReadOnlyList<string> SupportedVoices = new[]
+    {
+        "alloy",
+        "ash",
+        "ballad",
+        "coral",
+        "echo",
+        "fable",
+        "onyx",
+        "nova",
+        "sage",
+        "shimmer",
+        "verse",
+        "marin",
+        "cedar"
+    };
+
     private readonly OpenAiSettings _openAiSettings;
 
     public OpenAiRealtimeAiProviderAdapter(OpenAiSettings openAiSettings)
@@ -114,7 +149,11 @@ public class OpenAiRealtimeAiProviderAdapter : IRealtimeAiProviderAdapter
                     output = new
                     {
                         format = ConvertCodecToGaFormat(clientCodec),
-                        voice = string.IsNullOrEmpty(modelConfig.Voice) ? "alloy" : modelConfig.Voice,
+                        // Single source of truth for the default; SupportedVoices documents
+                        // the full operator-selectable list. The adapter does NOT validate
+                        // against the list — operators can opt into a future OpenAI voice
+                        // without a code change, and OpenAI rejects unknown ones server-side.
+                        voice = string.IsNullOrEmpty(modelConfig.Voice) ? DefaultVoice : modelConfig.Voice,
                         // null for every assistant without an OutputAudioSpeed row; the
                         // caller's NullValueHandling.Ignore (RealtimeAiService.Connect.cs:23)
                         // strips the key entirely, so OpenAI uses its default 1.0.

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterVoiceListTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterVoiceListTests.cs
@@ -1,0 +1,155 @@
+using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NSubstitute;
+using Shouldly;
+using SmartTalk.Core.Services.RealtimeAiV2;
+using SmartTalk.Core.Services.RealtimeAiV2.Adapters.Providers.OpenAi;
+using SmartTalk.Core.Settings.OpenAi;
+using SmartTalk.Messages.Enums.RealtimeAi;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Services.RealtimeAiV2;
+
+/// <summary>
+/// Pins the OpenAI Realtime API voice list and the default-voice constant.
+///
+/// <para>
+/// The literals are mirrored from OpenAI's documented voice options. The pin exists
+/// so any drift between the OpenAI docs and our list is a visible code change rather
+/// than a silent dropdown-population bug, and so UI / operator tooling has a single
+/// source of truth.
+/// </para>
+///
+/// <para>
+/// The adapter does NOT enforce membership — operators may opt into a future OpenAI
+/// voice without a code change, and OpenAI rejects unknown values server-side. The
+/// last test pins the pass-through behaviour so we never silently substitute.
+/// </para>
+/// </summary>
+public class OpenAiRealtimeAiProviderAdapterVoiceListTests
+{
+    private static readonly JsonSerializerSettings ProductionSerializer = new()
+    {
+        NullValueHandling = NullValueHandling.Ignore
+    };
+
+    private static OpenAiRealtimeAiProviderAdapter NewAdapter() =>
+        new(new OpenAiSettings(Substitute.For<IConfiguration>()));
+
+    private static RealtimeSessionOptions OptionsWithVoice(string voice) =>
+        new()
+        {
+            ModelConfig = new RealtimeAiModelConfig
+            {
+                Prompt = "you are helpful",
+                Voice = voice,
+                Tools = new List<object>()
+            }
+        };
+
+    private static JObject SerializeAsProduction(object payload) =>
+        JObject.Parse(JsonConvert.SerializeObject(payload, ProductionSerializer));
+
+    // ── Constants pinned ───────────────────────────────────────────────────
+
+    [Fact]
+    public void DefaultVoice_IsAlloy()
+    {
+        // The historical default is "alloy". Changing it is a deliberate decision —
+        // every assistant without an explicit Voice override would switch to the new
+        // value on deploy. Hard-pin the literal so the change is visible in code review.
+        OpenAiRealtimeAiProviderAdapter.DefaultVoice.ShouldBe("alloy");
+    }
+
+    [Fact]
+    public void SupportedVoices_ContainsExactly13DocumentedVoices()
+    {
+        // Source: https://platform.openai.com/docs/guides/realtime as of 2026-05-20.
+        // Order matches a stable ID alphabetisation so a diff against this assertion
+        // makes the addition / removal obvious in code review.
+        OpenAiRealtimeAiProviderAdapter.SupportedVoices.ShouldBe(new[]
+        {
+            "alloy",
+            "ash",
+            "ballad",
+            "coral",
+            "echo",
+            "fable",
+            "onyx",
+            "nova",
+            "sage",
+            "shimmer",
+            "verse",
+            "marin",
+            "cedar"
+        });
+    }
+
+    [Fact]
+    public void SupportedVoices_ContainsTheDefaultVoice()
+    {
+        // The default we send must be one of the values OpenAI accepts — otherwise
+        // every assistant without an explicit Voice override would fail at session.update.
+        OpenAiRealtimeAiProviderAdapter.SupportedVoices.ShouldContain(OpenAiRealtimeAiProviderAdapter.DefaultVoice);
+    }
+
+    [Fact]
+    public void SupportedVoices_HasNoDuplicates()
+    {
+        // Defensive: a duplicate would not break anything, but it suggests sloppy
+        // editing when the list was last updated. Catch at test time, not in review.
+        OpenAiRealtimeAiProviderAdapter.SupportedVoices.Distinct().Count()
+            .ShouldBe(OpenAiRealtimeAiProviderAdapter.SupportedVoices.Count);
+    }
+
+    // ── Adapter wires the default + passes through every list entry ───────
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void BuildSessionConfig_VoiceNullOrEmpty_UsesDefault(string voice)
+    {
+        var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(OptionsWithVoice(voice), RealtimeAiAudioCodec.MULAW));
+
+        json["session"]!["audio"]!["output"]!["voice"]!.Value<string>()
+            .ShouldBe(OpenAiRealtimeAiProviderAdapter.DefaultVoice);
+    }
+
+    [Theory]
+    [InlineData("alloy")]
+    [InlineData("ash")]
+    [InlineData("ballad")]
+    [InlineData("coral")]
+    [InlineData("echo")]
+    [InlineData("fable")]
+    [InlineData("onyx")]
+    [InlineData("nova")]
+    [InlineData("sage")]
+    [InlineData("shimmer")]
+    [InlineData("verse")]
+    [InlineData("marin")]
+    [InlineData("cedar")]
+    public void BuildSessionConfig_EveryDocumentedVoice_EmittedVerbatim(string voice)
+    {
+        // Each documented voice must pass through the adapter unchanged. Failure here
+        // would mean the adapter silently coerced an operator-selected voice into a
+        // different one — a UX regression hard to debug from logs alone.
+        var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(OptionsWithVoice(voice), RealtimeAiAudioCodec.MULAW));
+
+        json["session"]!["audio"]!["output"]!["voice"]!.Value<string>().ShouldBe(voice);
+    }
+
+    [Fact]
+    public void BuildSessionConfig_UnknownVoice_PassesThroughVerbatim()
+    {
+        // Forward-compatibility: when OpenAI adds a new voice (e.g. "midnight"),
+        // operators can opt into it immediately. The adapter does NOT validate the
+        // string — OpenAI rejects unknown values server-side with a clear error,
+        // which is strictly better than the adapter silently swapping in DefaultVoice
+        // and leaving the operator wondering why their selection had no effect.
+        var json = SerializeAsProduction(NewAdapter().BuildSessionConfig(OptionsWithVoice("midnight"), RealtimeAiAudioCodec.MULAW));
+
+        json["session"]!["audio"]!["output"]!["voice"]!.Value<string>().ShouldBe("midnight");
+    }
+}


### PR DESCRIPTION
## Summary

Codifies the OpenAI Realtime API supported-voice list as `OpenAiRealtimeAiProviderAdapter.SupportedVoices` and the historical default as `DefaultVoice = "alloy"`. Replaces the inline string `"alloy"` in `BuildSessionConfig` with the constant.

## Default behaviour guarantee

Every existing assistant continues to get the same voice. The only change is the default literal moved from an inline string to a same-valued constant — **byte-equivalent serialised JSON**.

## Motivation

Two reasons to pin the list:

1. **Single source of truth for UI tooling** — voice-selector dropdowns can reference `SupportedVoices` directly, no separate hardcoded list to drift from this one
2. **Diff-visible OpenAI doc changes** — a diff against the pinning test makes any add / remove / rename in OpenAI's docs visible in code review

The adapter does **NOT** validate against the list — operators can opt into a future voice (e.g. `"midnight"`) without a code change. OpenAI rejects unknown values server-side, which is strictly better than the adapter silently coercing the operator's selection.

## Changes

| File | Change |
|---|---|
| `OpenAiRealtimeAiProviderAdapter.cs` | New `public const string DefaultVoice = "alloy"`; new `public static readonly IReadOnlyList<string> SupportedVoices` (13 voices); `BuildSessionConfig` uses the constant |

## Test plan

- [x] Build: 0 errors
- [x] **`OpenAiRealtimeAiProviderAdapterVoiceListTests`** — 20 cases:
  - `DefaultVoice` constant pinned to `"alloy"`
  - `SupportedVoices` contains exactly the 13 documented entries (in pinned order)
  - `SupportedVoices` contains `DefaultVoice`
  - `SupportedVoices` has no duplicates
  - null / empty voice → uses `DefaultVoice`
  - Each of the 13 voices passes through verbatim
  - Unknown voice (`"midnight"`) passes through verbatim (forward-compat)
- [x] **Full unit suite**: 482/482 pass (was 462 baseline + 20 new)

## Operator notes

Operators set the voice per assistant via the existing `ai_speech_assistant.model_voice` column. No new config-map row needed — voice has always been a column.

## Refs

- https://platform.openai.com/docs/guides/realtime (Voice Options)