### PR TITLE
Extract OpenAI response.done usage tokens + log per turn

### DIFF
--- a/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectService.Build.Session.cs
+++ b/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectService.Build.Session.cs
@@ -1,8 +1,10 @@
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using Serilog;
 using SmartTalk.Core.Services.RealtimeAiV2;
 using SmartTalk.Core.Services.AiSpeechAssistant;
 using SmartTalk.Messages.Constants;
+using SmartTalk.Messages.Dto.RealtimeAi;
 using SmartTalk.Messages.Enums.RealtimeAi;
 using SmartTalk.Messages.Enums.AiSpeechAssistant;
 
@@ -54,8 +56,29 @@ public partial class AiSpeechAssistantConnectService
             OnSessionEndedAsync = HandleSessionEndedAsync,
             OnTranscriptionsCompletedAsync = HandleTranscriptionsCompletedAsync,
             OnRecordingCompleteAsync = HandleRecordingCompleteAsync,
-            OnFunctionCallAsync = (data, actions) => OnFunctionCallAsync(data, actions, CancellationToken.None)
+            OnFunctionCallAsync = (data, actions) => OnFunctionCallAsync(data, actions, CancellationToken.None),
+            OnResponseUsageReceivedAsync = HandleResponseUsageReceivedAsync
         };
+    }
+
+    /// <summary>
+    /// Logs per-turn OpenAI token usage with assistant + call context so cost reports
+    /// can be reconstructed from structured Serilog properties. Intentionally fire-and-
+    /// forget — never throws to the realtime event loop. Future work can route the same
+    /// payload to a cost-tracking sink (e.g. AiSpeechAssistantCallReport.TokensUsed)
+    /// without touching the adapter side.
+    /// </summary>
+    private Task HandleResponseUsageReceivedAsync(RealtimeAiWssUsageData usage)
+    {
+        Log.Information(
+            "[AiAssistant] Token usage, AssistantId: {AssistantId}, CallSid: {CallSid}, " +
+            "Total: {Total}, Input: {Input}, Output: {Output}, Cached: {Cached}, " +
+            "InputAudio: {InputAudio}, InputText: {InputText}, OutputAudio: {OutputAudio}, OutputText: {OutputText}",
+            _ctx.Assistant?.Id, _ctx.CallSid,
+            usage.TotalTokens, usage.InputTokens, usage.OutputTokens, usage.CachedTokens,
+            usage.InputAudioTokens, usage.InputTextTokens, usage.OutputAudioTokens, usage.OutputTextTokens);
+
+        return Task.CompletedTask;
     }
 
     private RealtimeSessionIdleFollowUp BuildIdleFollowUp()

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Providers/OpenAi/OpenAiRealtimeAiProviderAdapter.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Providers/OpenAi/OpenAiRealtimeAiProviderAdapter.cs
@@ -288,7 +288,15 @@ public class OpenAiRealtimeAiProviderAdapter : IRealtimeAiProviderAdapter
 
                 case "response.done":
                     var functionCalls = ExtractFunctionCalls(root);
-                    return functionCalls != null ? Result(RealtimeAiWssEventType.FunctionCallSuggested, functionCalls) : Result(RealtimeAiWssEventType.ResponseTurnCompleted);
+                    // Usage is attached to BOTH event variants because both originate from
+                    // the same provider message. Consumers handle the variant they care
+                    // about and read Usage off the event independently.
+                    var usage = ExtractUsage(root);
+                    var doneEvent = functionCalls != null
+                        ? Result(RealtimeAiWssEventType.FunctionCallSuggested, functionCalls)
+                        : Result(RealtimeAiWssEventType.ResponseTurnCompleted);
+                    doneEvent.Usage = usage;
+                    return doneEvent;
 
                 case "error":
                     var errorCode = ExtractErrorCode(root);
@@ -365,6 +373,73 @@ public class OpenAiRealtimeAiProviderAdapter : IRealtimeAiProviderAdapter
             return lastCodeProp.GetString();
 
         return null;
+    }
+
+    /// <summary>
+    /// Extracts the OpenAI token-usage breakdown from a <c>response.done</c> payload
+    /// (shape: <c>{ response: { usage: { input_tokens, output_tokens, total_tokens,
+    /// input_token_details: { cached_tokens, audio_tokens, text_tokens },
+    /// output_token_details: { audio_tokens, text_tokens } } } }</c>).
+    ///
+    /// <para>
+    /// Returns <c>null</c> when the message has no usage block (older provider snapshots),
+    /// or when the response object is missing. Individual sub-fields are returned as
+    /// <c>null</c> when absent — consumers must treat missing values as "not reported"
+    /// rather than zero, because zero is a meaningful answer (an empty AI turn).
+    /// </para>
+    ///
+    /// <para>
+    /// Public static (matches the other parser helpers in this codebase) so unit
+    /// tests can pin the schema interpretation directly without driving a full
+    /// ParseMessage path.
+    /// </para>
+    /// </summary>
+    public static RealtimeAiWssUsageData ExtractUsage(JsonElement root)
+    {
+        if (!root.TryGetProperty("response", out var response) ||
+            response.ValueKind != JsonValueKind.Object ||
+            !response.TryGetProperty("usage", out var usage) ||
+            usage.ValueKind != JsonValueKind.Object)
+            return null;
+
+        return new RealtimeAiWssUsageData
+        {
+            TotalTokens = ReadOptionalInt(usage, "total_tokens"),
+            InputTokens = ReadOptionalInt(usage, "input_tokens"),
+            OutputTokens = ReadOptionalInt(usage, "output_tokens"),
+            CachedTokens = ReadOptionalInt(usage, "input_token_details", "cached_tokens"),
+            InputAudioTokens = ReadOptionalInt(usage, "input_token_details", "audio_tokens"),
+            InputTextTokens = ReadOptionalInt(usage, "input_token_details", "text_tokens"),
+            OutputAudioTokens = ReadOptionalInt(usage, "output_token_details", "audio_tokens"),
+            OutputTextTokens = ReadOptionalInt(usage, "output_token_details", "text_tokens")
+        };
+    }
+
+    /// <summary>
+    /// Reads a nullable integer at <paramref name="path"/> from <paramref name="parent"/>.
+    /// Returns null if any segment is missing, not an object on the way down, or
+    /// the final value is not a JSON number / integer-compatible value. Tolerates
+    /// the provider returning long / double for what we treat as int.
+    /// </summary>
+    private static int? ReadOptionalInt(JsonElement parent, params string[] path)
+    {
+        var current = parent;
+
+        for (var i = 0; i < path.Length - 1; i++)
+        {
+            if (current.ValueKind != JsonValueKind.Object ||
+                !current.TryGetProperty(path[i], out var next))
+                return null;
+
+            current = next;
+        }
+
+        if (current.ValueKind != JsonValueKind.Object ||
+            !current.TryGetProperty(path[^1], out var leaf) ||
+            leaf.ValueKind != JsonValueKind.Number)
+            return null;
+
+        return leaf.TryGetInt32(out var i32) ? i32 : (int?)null;
     }
 
     private static bool IsRecoverableError(string errorCode, string errorMessage)

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/RealtimeSessionOptions.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/RealtimeSessionOptions.cs
@@ -222,6 +222,15 @@ public class RealtimeSessionOptions
     /// Parameters: (sessionId, wavBytes).
     /// </summary>
     public Func<string, byte[], Task> OnRecordingCompleteAsync { get; set; }
+
+    /// <summary>
+    /// Called when the provider reports token usage for an AI turn (currently OpenAI's
+    /// <c>response.done.response.usage</c>). Invoked once per turn that includes a usage
+    /// block. <c>null</c> callback skips the notification entirely — older provider
+    /// snapshots without usage data continue to work transparently. Use to log
+    /// per-call costs or push to a cost-tracking dashboard.
+    /// </summary>
+    public Func<RealtimeAiWssUsageData, Task> OnResponseUsageReceivedAsync { get; set; }
 }
 
 public class RealtimeSessionIdleFollowUp

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Services/RealtimeAiService.Event.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Services/RealtimeAiService.Event.cs
@@ -47,6 +47,8 @@ public partial class RealtimeAiService
                 case RealtimeAiWssEventType.ResponseTurnCompleted:
                     if (parsedEvent.Data is List<RealtimeAiWssFunctionCallData> functionCalls)
                         await OnFunctionCallsReceivedAsync(functionCalls).ConfigureAwait(false);
+                    if (parsedEvent.Usage != null)
+                        await OnResponseUsageReceivedAsync(parsedEvent.Usage).ConfigureAwait(false);
                     await OnAiTurnCompletedAsync().ConfigureAwait(false);
                     break;
 
@@ -163,6 +165,23 @@ public partial class RealtimeAiService
         await SendToClientAsync(_ctx.ClientAdapter.BuildTranscriptionMessage(eventType, transcriptionData, _ctx.SessionId)).ConfigureAwait(false);
     }
     
+    private async Task OnResponseUsageReceivedAsync(RealtimeAiWssUsageData usage)
+    {
+        // Always log the breakdown — gives ops a free cost-tracking signal in
+        // structured Serilog properties even when the consumer doesn't wire a callback.
+        Log.Information(
+            "[RealtimeAi] Token usage reported, SessionId: {SessionId}, Round: {Round}, " +
+            "Total: {Total}, Input: {Input}, Output: {Output}, Cached: {Cached}, " +
+            "InputAudio: {InputAudio}, InputText: {InputText}, OutputAudio: {OutputAudio}, OutputText: {OutputText}",
+            _ctx.SessionId, _ctx.Round,
+            usage.TotalTokens, usage.InputTokens, usage.OutputTokens, usage.CachedTokens,
+            usage.InputAudioTokens, usage.InputTextTokens, usage.OutputAudioTokens, usage.OutputTextTokens);
+
+        if (_ctx.Options.OnResponseUsageReceivedAsync == null) return;
+
+        await _ctx.Options.OnResponseUsageReceivedAsync(usage).ConfigureAwait(false);
+    }
+
     private async Task OnFunctionCallsReceivedAsync(List<RealtimeAiWssFunctionCallData> functionCalls)
     {
         if (_ctx.Options.OnFunctionCallAsync == null) return;

--- a/src/SmartTalk.Messages/Dto/RealtimeAi/RealtimeAiWssDto.cs
+++ b/src/SmartTalk.Messages/Dto/RealtimeAi/RealtimeAiWssDto.cs
@@ -46,12 +46,54 @@ public class RealtimeAiFunctionCallResult
 public class ParsedRealtimeAiProviderEvent
 {
     public RealtimeAiWssEventType Type { get; set; }
-    
+
     public object Data { get; set; }
-    
+
     public string RawJson { get; set; }
-    
+
     public string ItemId { get; set; }
+
+    /// <summary>
+    /// Token usage for the AI turn, populated by the provider adapter when the
+    /// provider emits usage data alongside the turn-completion event (currently
+    /// OpenAI's <c>response.done.response.usage</c>). <c>null</c> when the
+    /// underlying message has no usage block (older provider snapshots) or when
+    /// the event type does not carry usage. Sits on the event rather than on
+    /// <see cref="Data"/> so it can coexist with function-call payloads.
+    /// </summary>
+    public RealtimeAiWssUsageData Usage { get; set; }
+}
+
+/// <summary>
+/// Per-turn token-usage breakdown reported by the AI provider on turn completion.
+/// All fields nullable because providers may omit individual sub-counts; consumers
+/// should treat missing values as "not reported" rather than zero.
+/// </summary>
+public class RealtimeAiWssUsageData
+{
+    /// <summary>Total tokens consumed for this turn (input + output).</summary>
+    public int? TotalTokens { get; set; }
+
+    /// <summary>Tokens consumed from the prompt / conversation history.</summary>
+    public int? InputTokens { get; set; }
+
+    /// <summary>Tokens produced by the AI in this turn.</summary>
+    public int? OutputTokens { get; set; }
+
+    /// <summary>Subset of input tokens served from the provider's prompt cache.</summary>
+    public int? CachedTokens { get; set; }
+
+    /// <summary>Subset of input tokens classified as audio (rather than text).</summary>
+    public int? InputAudioTokens { get; set; }
+
+    /// <summary>Subset of input tokens classified as text.</summary>
+    public int? InputTextTokens { get; set; }
+
+    /// <summary>Subset of output tokens classified as audio (rather than text).</summary>
+    public int? OutputAudioTokens { get; set; }
+
+    /// <summary>Subset of output tokens classified as text.</summary>
+    public int? OutputTextTokens { get; set; }
 }
 
 public class RealtimeAiErrorData

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterExtractUsageTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterExtractUsageTests.cs
@@ -1,0 +1,275 @@
+using System.Text.Json;
+using Shouldly;
+using SmartTalk.Core.Services.RealtimeAiV2.Adapters.Providers.OpenAi;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Services.RealtimeAiV2;
+
+/// <summary>
+/// Exercises <see cref="OpenAiRealtimeAiProviderAdapter.ExtractUsage"/> against the
+/// shapes of OpenAI's <c>response.done.response.usage</c> payload. The parser must
+/// be defensive: older provider snapshots omit the usage block entirely, and even
+/// modern responses may omit individual sub-counts.
+///
+/// <para>
+/// The load-bearing invariant: a missing block or a missing sub-count returns
+/// <c>null</c> for that level, never zero. Zero is a meaningful value (an empty
+/// AI turn) and conflating it with "missing" would silently corrupt cost reports.
+/// </para>
+/// </summary>
+public class OpenAiRealtimeAiProviderAdapterExtractUsageTests
+{
+    private static JsonElement Parse(string json) => JsonDocument.Parse(json).RootElement;
+
+    // ── Missing / wrong-shape returns null ────────────────────────────────
+
+    [Fact]
+    public void ExtractUsage_NoResponseObject_ReturnsNull()
+    {
+        // Older provider snapshots emit `response.done` with just `{ type: "response.done" }`.
+        // Parser must return null rather than throw.
+        OpenAiRealtimeAiProviderAdapter.ExtractUsage(Parse("{\"type\":\"response.done\"}")).ShouldBeNull();
+    }
+
+    [Fact]
+    public void ExtractUsage_ResponseObjectButNoUsage_ReturnsNull()
+    {
+        // response is present but doesn't carry usage — that's not an error,
+        // it just means OpenAI didn't report token counts for this turn.
+        var root = Parse("{\"type\":\"response.done\",\"response\":{\"id\":\"resp_123\"}}");
+
+        OpenAiRealtimeAiProviderAdapter.ExtractUsage(root).ShouldBeNull();
+    }
+
+    [Fact]
+    public void ExtractUsage_ResponseNotAnObject_ReturnsNull()
+    {
+        // Defensive against malformed events where `response` is null or a scalar.
+        var root = Parse("{\"type\":\"response.done\",\"response\":null}");
+
+        OpenAiRealtimeAiProviderAdapter.ExtractUsage(root).ShouldBeNull();
+    }
+
+    [Fact]
+    public void ExtractUsage_UsageNotAnObject_ReturnsNull()
+    {
+        var root = Parse("{\"type\":\"response.done\",\"response\":{\"usage\":\"unexpected\"}}");
+
+        OpenAiRealtimeAiProviderAdapter.ExtractUsage(root).ShouldBeNull();
+    }
+
+    // ── Top-level sub-counts ──────────────────────────────────────────────
+
+    [Fact]
+    public void ExtractUsage_OnlyTopLevelCounts_ReturnsTotalInputOutput()
+    {
+        // The most minimal usage block — just the three top-level sums.
+        var root = Parse("""
+            {
+              "type": "response.done",
+              "response": {
+                "usage": {
+                  "total_tokens": 1500,
+                  "input_tokens": 800,
+                  "output_tokens": 700
+                }
+              }
+            }
+            """);
+
+        var usage = OpenAiRealtimeAiProviderAdapter.ExtractUsage(root);
+
+        usage.ShouldNotBeNull();
+        usage.TotalTokens.ShouldBe(1500);
+        usage.InputTokens.ShouldBe(800);
+        usage.OutputTokens.ShouldBe(700);
+        usage.CachedTokens.ShouldBeNull();
+        usage.InputAudioTokens.ShouldBeNull();
+        usage.InputTextTokens.ShouldBeNull();
+        usage.OutputAudioTokens.ShouldBeNull();
+        usage.OutputTextTokens.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ExtractUsage_TopLevelMissingTotal_ReturnsNullForThatField()
+    {
+        // Missing total_tokens is not an error — older snapshots sometimes omit it
+        // when the breakdown sums are sufficient. Other fields must still populate.
+        var root = Parse("""
+            {
+              "response": {
+                "usage": {
+                  "input_tokens": 100,
+                  "output_tokens": 50
+                }
+              }
+            }
+            """);
+
+        var usage = OpenAiRealtimeAiProviderAdapter.ExtractUsage(root);
+
+        usage.TotalTokens.ShouldBeNull();
+        usage.InputTokens.ShouldBe(100);
+        usage.OutputTokens.ShouldBe(50);
+    }
+
+    [Fact]
+    public void ExtractUsage_TopLevelZeroValues_PreservedAsZeroNotNull()
+    {
+        // Zero is a real value (empty AI turn). MUST be preserved as 0 — collapsing it
+        // to null would silently corrupt cost reports for empty / cancelled turns.
+        var root = Parse("{\"response\":{\"usage\":{\"total_tokens\":0,\"input_tokens\":0,\"output_tokens\":0}}}");
+
+        var usage = OpenAiRealtimeAiProviderAdapter.ExtractUsage(root);
+
+        usage.TotalTokens.ShouldBe(0);
+        usage.InputTokens.ShouldBe(0);
+        usage.OutputTokens.ShouldBe(0);
+    }
+
+    // ── Nested input_token_details / output_token_details ─────────────────
+
+    [Fact]
+    public void ExtractUsage_FullBreakdown_ReturnsAllFields()
+    {
+        var root = Parse("""
+            {
+              "response": {
+                "usage": {
+                  "total_tokens": 2000,
+                  "input_tokens": 1200,
+                  "output_tokens": 800,
+                  "input_token_details": {
+                    "cached_tokens": 400,
+                    "audio_tokens": 500,
+                    "text_tokens": 300
+                  },
+                  "output_token_details": {
+                    "audio_tokens": 600,
+                    "text_tokens": 200
+                  }
+                }
+              }
+            }
+            """);
+
+        var usage = OpenAiRealtimeAiProviderAdapter.ExtractUsage(root);
+
+        usage.TotalTokens.ShouldBe(2000);
+        usage.InputTokens.ShouldBe(1200);
+        usage.OutputTokens.ShouldBe(800);
+        usage.CachedTokens.ShouldBe(400);
+        usage.InputAudioTokens.ShouldBe(500);
+        usage.InputTextTokens.ShouldBe(300);
+        usage.OutputAudioTokens.ShouldBe(600);
+        usage.OutputTextTokens.ShouldBe(200);
+    }
+
+    [Fact]
+    public void ExtractUsage_InputTokenDetailsAbsent_OutputDetailsStillExtracted()
+    {
+        // Provider may report one side and not the other. Each nested block is
+        // optional independently of the other.
+        var root = Parse("""
+            {
+              "response": {
+                "usage": {
+                  "input_tokens": 100,
+                  "output_tokens": 50,
+                  "output_token_details": {
+                    "audio_tokens": 40,
+                    "text_tokens": 10
+                  }
+                }
+              }
+            }
+            """);
+
+        var usage = OpenAiRealtimeAiProviderAdapter.ExtractUsage(root);
+
+        usage.CachedTokens.ShouldBeNull();
+        usage.InputAudioTokens.ShouldBeNull();
+        usage.InputTextTokens.ShouldBeNull();
+        usage.OutputAudioTokens.ShouldBe(40);
+        usage.OutputTextTokens.ShouldBe(10);
+    }
+
+    [Fact]
+    public void ExtractUsage_NestedDetailsAreNull_ReturnsNullForLeafFields()
+    {
+        // Defensive: the provider may return null instead of an object for nested details.
+        var root = Parse("""
+            {
+              "response": {
+                "usage": {
+                  "input_tokens": 100,
+                  "output_tokens": 50,
+                  "input_token_details": null,
+                  "output_token_details": null
+                }
+              }
+            }
+            """);
+
+        var usage = OpenAiRealtimeAiProviderAdapter.ExtractUsage(root);
+
+        usage.CachedTokens.ShouldBeNull();
+        usage.InputAudioTokens.ShouldBeNull();
+        usage.InputTextTokens.ShouldBeNull();
+        usage.OutputAudioTokens.ShouldBeNull();
+        usage.OutputTextTokens.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ExtractUsage_NonIntegerCounts_ReturnsNullForThoseFields()
+    {
+        // Schema violation: a count is a string or a float. The parser tolerates
+        // this by returning null for the affected leaf rather than throwing.
+        var root = Parse("""
+            {
+              "response": {
+                "usage": {
+                  "total_tokens": "1500",
+                  "input_tokens": 100.5,
+                  "output_tokens": 50
+                }
+              }
+            }
+            """);
+
+        var usage = OpenAiRealtimeAiProviderAdapter.ExtractUsage(root);
+
+        usage.TotalTokens.ShouldBeNull();
+        usage.InputTokens.ShouldBeNull();
+        usage.OutputTokens.ShouldBe(50);
+    }
+
+    [Fact]
+    public void ExtractUsage_UnknownExtraFields_AreSilentlyIgnored()
+    {
+        // Forward-compatibility: when OpenAI adds new sub-counts (e.g. a new audio
+        // category), older builds of the parser must keep working. Extras are
+        // silently ignored; the documented fields still extract correctly.
+        var root = Parse("""
+            {
+              "response": {
+                "usage": {
+                  "total_tokens": 100,
+                  "input_tokens": 50,
+                  "output_tokens": 50,
+                  "future_premium_tokens": 999,
+                  "input_token_details": {
+                    "cached_tokens": 10,
+                    "exotic_new_category_tokens": 20
+                  }
+                }
+              }
+            }
+            """);
+
+        var usage = OpenAiRealtimeAiProviderAdapter.ExtractUsage(root);
+
+        usage.TotalTokens.ShouldBe(100);
+        usage.CachedTokens.ShouldBe(10);
+    }
+}

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterParseMessageUsageTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterParseMessageUsageTests.cs
@@ -1,0 +1,113 @@
+using Microsoft.Extensions.Configuration;
+using NSubstitute;
+using Shouldly;
+using SmartTalk.Core.Services.RealtimeAiV2.Adapters.Providers.OpenAi;
+using SmartTalk.Core.Settings.OpenAi;
+using SmartTalk.Messages.Enums.RealtimeAi;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Services.RealtimeAiV2;
+
+/// <summary>
+/// End-to-end tests that the V2 adapter's <see cref="OpenAiRealtimeAiProviderAdapter.ParseMessage"/>
+/// surfaces the usage block on the parsed event for the two <c>response.done</c> variants
+/// (<see cref="RealtimeAiWssEventType.ResponseTurnCompleted"/> and
+/// <see cref="RealtimeAiWssEventType.FunctionCallSuggested"/>).
+///
+/// <para>
+/// The unit-test counterpart of <see cref="OpenAiRealtimeAiProviderAdapterExtractUsageTests"/> —
+/// those exercise the parser in isolation; these exercise the wiring that puts the
+/// parsed value onto the event consumers read.
+/// </para>
+/// </summary>
+public class OpenAiRealtimeAiProviderAdapterParseMessageUsageTests
+{
+    private static OpenAiRealtimeAiProviderAdapter NewAdapter() =>
+        new(new OpenAiSettings(Substitute.For<IConfiguration>()));
+
+    [Fact]
+    public void ParseMessage_ResponseDoneWithUsage_AttachesUsageToCompletionEvent()
+    {
+        var raw = """
+            {
+              "type": "response.done",
+              "response": {
+                "id": "resp_test",
+                "usage": {
+                  "total_tokens": 1234,
+                  "input_tokens": 800,
+                  "output_tokens": 434,
+                  "input_token_details": { "cached_tokens": 200 }
+                }
+              }
+            }
+            """;
+
+        var parsed = NewAdapter().ParseMessage(raw);
+
+        parsed.Type.ShouldBe(RealtimeAiWssEventType.ResponseTurnCompleted);
+        parsed.Usage.ShouldNotBeNull();
+        parsed.Usage.TotalTokens.ShouldBe(1234);
+        parsed.Usage.InputTokens.ShouldBe(800);
+        parsed.Usage.OutputTokens.ShouldBe(434);
+        parsed.Usage.CachedTokens.ShouldBe(200);
+    }
+
+    [Fact]
+    public void ParseMessage_ResponseDoneWithoutUsage_LeavesUsageNull()
+    {
+        // Older provider snapshots emit response.done with no usage block. The
+        // event still surfaces (cleanup logic depends on it) but Usage is null
+        // and the consumer's usage callback is skipped.
+        var raw = """
+            {
+              "type": "response.done",
+              "response": {
+                "id": "resp_test"
+              }
+            }
+            """;
+
+        var parsed = NewAdapter().ParseMessage(raw);
+
+        parsed.Type.ShouldBe(RealtimeAiWssEventType.ResponseTurnCompleted);
+        parsed.Usage.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ParseMessage_ResponseDoneWithFunctionCallAndUsage_AttachesUsageToFunctionCallEvent()
+    {
+        // The same response.done message can be classified as
+        // FunctionCallSuggested when the response output contains function calls.
+        // Usage MUST still be surfaced — operators need cost tracking on
+        // function-call turns just as much as on text turns.
+        var raw = """
+            {
+              "type": "response.done",
+              "response": {
+                "id": "resp_test",
+                "output": [
+                  {
+                    "type": "function_call",
+                    "name": "confirm_order",
+                    "call_id": "call_abc",
+                    "arguments": "{}"
+                  }
+                ],
+                "usage": {
+                  "total_tokens": 500,
+                  "input_tokens": 480,
+                  "output_tokens": 20
+                }
+              }
+            }
+            """;
+
+        var parsed = NewAdapter().ParseMessage(raw);
+
+        parsed.Type.ShouldBe(RealtimeAiWssEventType.FunctionCallSuggested);
+        parsed.Data.ShouldNotBeNull();   // function call payload still there
+        parsed.Usage.ShouldNotBeNull();
+        parsed.Usage.TotalTokens.ShouldBe(500);
+    }
+}


### PR DESCRIPTION
## Summary

Extracts the per-turn OpenAI token-usage breakdown from `response.done.response.usage` and logs it with structured Serilog fields. Provides real-time per-call cost visibility with **no DB schema change** — log aggregation gives ops the cost rollup.

## Default behaviour guarantee

When a provider event omits the usage block (older snapshots / non-OpenAI providers), the parser returns null, the consumer callback is skipped, and nothing is logged. Existing behaviour preserved exactly.

Existing 12 GA pinning tests all pass — regression boundary preserved.

## What's new on the wire

Nothing. This PR only *reads* the existing OpenAI `usage` field and surfaces it internally; no change to what we send to OpenAI or Twilio.

## Changes

| File | Change |
|---|---|
| `RealtimeAiWssDto.cs` | New `RealtimeAiWssUsageData` DTO + `Usage` property on `ParsedRealtimeAiProviderEvent` |
| `OpenAiRealtimeAiProviderAdapter.cs` | New `public static ExtractUsage(JsonElement)`; `response.done` case attaches Usage to both `ResponseTurnCompleted` and `FunctionCallSuggested` |
| `RealtimeSessionOptions.cs` | New optional `OnResponseUsageReceivedAsync` callback |
| `RealtimeAiService.Event.cs` | When a `response.done` event carries usage, invoke the callback after logging the breakdown with `SessionId`/`Round`/all 8 counts |
| `AiSpeechAssistantConnectService.Build.Session.cs` | Wires the callback to `HandleResponseUsageReceivedAsync` which logs with `AssistantId`/`CallSid` context |

## Operator visibility

Per-turn log line:
```
[AiAssistant] Token usage, AssistantId: 123, CallSid: CAabcdef...,
    Total: 1234, Input: 800, Output: 434, Cached: 200,
    InputAudio: 500, InputText: 300, OutputAudio: 400, OutputText: 34
```

All fields are structured Serilog properties → queryable in Seq / OpenSearch / Datadog without parsing.

## Test plan

- [x] Build: 0 errors
- [x] **`OpenAiRealtimeAiProviderAdapterExtractUsageTests`** — 11 cases:
  - Missing response / usage / non-object → null
  - Top-level-only counts (older snapshots)
  - **Zero-value sub-counts preserved as 0 not null** (empty turn vs missing)
  - Full breakdown + partial + null nested details + schema violations + future-field tolerance
- [x] **`OpenAiRealtimeAiProviderAdapterParseMessageUsageTests`** — 3 cases:
  - response.done with usage → ResponseTurnCompleted carries Usage
  - response.done without usage → Usage null
  - response.done with function_call + usage → FunctionCallSuggested carries both Data and Usage
- [x] **Existing GA pinning suite** (12 cases) — all pass unchanged
- [x] **Full unit suite**: 477/477 pass (462 baseline + 15 new)
- [ ] Staging: deploy + watch for `[AiAssistant] Token usage` log lines on every completed call; verify per-call cost is reasonable

Base: PR #950 (Round 2 base branch).

## Refs

- https://platform.openai.com/docs/api-reference/realtime-server-events/response/done