### PR TITLE
[DRAFT — gated on 2-week obs] Sunset Beta-era response.audio.* event names in V2 adapter

### DIFF
--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Providers/OpenAi/OpenAiRealtimeAiProviderAdapter.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Providers/OpenAi/OpenAiRealtimeAiProviderAdapter.cs
@@ -254,15 +254,18 @@ public class OpenAiRealtimeAiProviderAdapter : IRealtimeAiProviderAdapter
                 case "session.updated":
                     return Result(RealtimeAiWssEventType.SessionInitialized, rawMessage);
 
-                // GA renamed several audio events; accept BOTH the old beta name and the new GA
-                // name so the deploy is robust to any leftover preview snapshots and to the GA
-                // models. https://learn.microsoft.com/en-us/azure/foundry/openai/how-to/realtime-audio-preview-api-migration-guide
-                case "response.audio.delta":
+                // Beta-era event names (`response.audio.delta`, `response.audio.done`,
+                // `response.audio_transcript.delta`, `response.audio_transcript.done`) were
+                // accepted alongside the GA names during the hotfix #934 transition window.
+                // OpenAI completed the GA cutover on 2026-05-07 and has not emitted Beta names
+                // in production logs for ≥ 2 weeks; the dual-case branches are removed here so
+                // a Beta-named event surfaces as Unknown (= operator-visible Serilog warning)
+                // rather than silently working — that surface signal is required to detect any
+                // future provider regression that would re-emit Beta names.
                 case "response.output_audio.delta":
                     var audioPayload = root.TryGetProperty("delta", out var deltaProp) ? deltaProp.GetString() : null;
                     return Result(RealtimeAiWssEventType.ResponseAudioDelta, new RealtimeAiWssAudioData { Base64Payload = audioPayload, ItemId = itemId });
 
-                case "response.audio.done":
                 case "response.output_audio.done":
                     return Result(RealtimeAiWssEventType.ResponseAudioDone);
 
@@ -278,11 +281,9 @@ public class OpenAiRealtimeAiProviderAdapter : IRealtimeAiProviderAdapter
                 case "conversation.item.input_audio_transcription.completed":
                     return Result(RealtimeAiWssEventType.InputAudioTranscriptionCompleted, Transcription("transcript", AiSpeechAssistantSpeaker.User));
 
-                case "response.audio_transcript.delta":
                 case "response.output_audio_transcript.delta":
                     return Result(RealtimeAiWssEventType.OutputAudioTranscriptionPartial, Transcription("delta", AiSpeechAssistantSpeaker.Ai));
 
-                case "response.audio_transcript.done":
                 case "response.output_audio_transcript.done":
                     return Result(RealtimeAiWssEventType.OutputAudioTranscriptionCompleted, Transcription("transcript", AiSpeechAssistantSpeaker.Ai));
 

--- a/src/SmartTalk.IntegrationTests/Services/AiSpeechAssistant/AiSpeechAssistantConnectFixture.FunctionCalls.cs
+++ b/src/SmartTalk.IntegrationTests/Services/AiSpeechAssistant/AiSpeechAssistantConnectFixture.FunctionCalls.cs
@@ -530,7 +530,7 @@ public partial class AiSpeechAssistantConnectFixture
         openaiWs.EnqueueMessage(JsonConvert.SerializeObject(new { type = "session.updated" }));
         openaiWs.EnqueueMessage(JsonConvert.SerializeObject(new
         {
-            type = "response.audio.delta",
+            type = "response.output_audio.delta",
             delta = "dGVzdGF1ZGlvZGF0YQ==",
             item_id = "item_delta_001"
         }));

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterBetaEventSunsetTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterBetaEventSunsetTests.cs
@@ -1,0 +1,102 @@
+using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NSubstitute;
+using Shouldly;
+using SmartTalk.Core.Services.RealtimeAiV2.Adapters.Providers.OpenAi;
+using SmartTalk.Core.Settings.OpenAi;
+using SmartTalk.Messages.Enums.RealtimeAi;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Services.RealtimeAiV2;
+
+/// <summary>
+/// Locks in the post-sunset behaviour: the four Beta-era event names (the ones that
+/// hotfix #934 accepted alongside their GA replacements) now map to
+/// <see cref="RealtimeAiWssEventType.Unknown"/>. The Unknown classification triggers
+/// a Serilog warning at the service layer, giving operators an immediate signal if
+/// OpenAI ever regresses and re-emits a Beta-named event in production.
+///
+/// <para>
+/// Sunset rationale: OpenAI completed the GA cutover on 2026-05-07; hotfix #934
+/// deployed 2026-05-12; this PR is gated on ≥ 2 weeks of clean production logs
+/// (≥ 2026-05-26). Until that observation window passes, this PR stays in draft
+/// state — merging early reintroduces risk of silently dropping audio frames if
+/// OpenAI ever rolls a region back to Beta names.
+/// </para>
+/// </summary>
+public class OpenAiRealtimeAiProviderAdapterBetaEventSunsetTests
+{
+    private static OpenAiRealtimeAiProviderAdapter NewAdapter() =>
+        new(new OpenAiSettings(Substitute.For<IConfiguration>()));
+
+    private static string SerializeEvent(string type, object extras = null)
+    {
+        if (extras == null) return JsonConvert.SerializeObject(new { type });
+
+        var payload = JObject.FromObject(extras);
+        payload["type"] = type;
+        return payload.ToString();
+    }
+
+    // ── Beta-era names now classified as Unknown ──────────────────────────
+
+    [Theory]
+    [InlineData("response.audio.delta")]
+    [InlineData("response.audio.done")]
+    [InlineData("response.audio_transcript.delta")]
+    [InlineData("response.audio_transcript.done")]
+    public void ParseMessage_BetaEventName_NowMapsToUnknown(string betaEventName)
+    {
+        // After sunset, a Beta-named event surfaces as Unknown so the service's
+        // existing Log.Warning fires. The audio handler doesn't fire (= silence on
+        // the call), but the warning is the contract: regression is loud, not silent.
+        var raw = SerializeEvent(betaEventName);
+
+        var parsed = NewAdapter().ParseMessage(raw);
+
+        parsed.Type.ShouldBe(RealtimeAiWssEventType.Unknown);
+    }
+
+    // ── GA-named events keep working unchanged ────────────────────────────
+
+    [Fact]
+    public void ParseMessage_GaAudioDelta_StillProducesResponseAudioDelta()
+    {
+        var raw = SerializeEvent("response.output_audio.delta", new { delta = "AQID", item_id = "itm-1" });
+
+        var parsed = NewAdapter().ParseMessage(raw);
+
+        parsed.Type.ShouldBe(RealtimeAiWssEventType.ResponseAudioDelta);
+    }
+
+    [Fact]
+    public void ParseMessage_GaAudioDone_StillProducesResponseAudioDone()
+    {
+        var raw = SerializeEvent("response.output_audio.done");
+
+        var parsed = NewAdapter().ParseMessage(raw);
+
+        parsed.Type.ShouldBe(RealtimeAiWssEventType.ResponseAudioDone);
+    }
+
+    [Fact]
+    public void ParseMessage_GaTranscriptDelta_StillProducesOutputAudioTranscriptionPartial()
+    {
+        var raw = SerializeEvent("response.output_audio_transcript.delta", new { delta = "hello" });
+
+        var parsed = NewAdapter().ParseMessage(raw);
+
+        parsed.Type.ShouldBe(RealtimeAiWssEventType.OutputAudioTranscriptionPartial);
+    }
+
+    [Fact]
+    public void ParseMessage_GaTranscriptDone_StillProducesOutputAudioTranscriptionCompleted()
+    {
+        var raw = SerializeEvent("response.output_audio_transcript.done", new { transcript = "hello world" });
+
+        var parsed = NewAdapter().ParseMessage(raw);
+
+        parsed.Type.ShouldBe(RealtimeAiWssEventType.OutputAudioTranscriptionCompleted);
+    }
+}

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/RealtimeAiServiceRecordingTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/RealtimeAiServiceRecordingTests.cs
@@ -82,7 +82,7 @@ public class RealtimeAiServiceRecordingTests : RealtimeAiServiceTestBase
 
         var sessionTask = await StartSessionInBackgroundAsync(options);
 
-        await FakeWssClient.SimulateMessageReceivedAsync("{\"type\":\"response.audio.delta\"}");
+        await FakeWssClient.SimulateMessageReceivedAsync("{\"type\":\"response.output_audio.delta\"}");
         await Task.Delay(100);
 
         FakeWs.EnqueueClose();
@@ -240,7 +240,7 @@ public class RealtimeAiServiceRecordingTests : RealtimeAiServiceTestBase
         var sessionTask = await StartSessionInBackgroundAsync(options);
 
         // 1. Provider sends audio delta → IsAiSpeaking=true, AI audio (4 bytes) buffered
-        await FakeWssClient.SimulateMessageReceivedAsync("{\"type\":\"response.audio.delta\"}");
+        await FakeWssClient.SimulateMessageReceivedAsync("{\"type\":\"response.output_audio.delta\"}");
         await Task.Delay(50);
 
         // 2. Provider sends SpeechDetected → IsAiSpeaking should reset to false


### PR DESCRIPTION
## ⚠ DRAFT — Do NOT merge before 2026-05-26

Removes the dual-case branches added by hotfix #934 for the four Beta-era event names. After the OpenAI Realtime API GA cutover on 2026-05-07 and the hotfix deployment on 2026-05-12, OpenAI has only emitted GA-named events in production logs. The dual-case is now tech debt — keeping it silently masks any future regression where OpenAI re-emits a Beta name.

**Merge gate**: ≥ 2 weeks of clean production logs after the hotfix #934 deployment.

```bash
# Pre-merge check — must return 0 results
grep -i 'response\.audio\.\(delta\|done\)\|response\.audio_transcript\.' \
  <prod log aggregator> --since 2026-05-12
```

## Summary

Removes 4 event-name aliases (one direction only — the GA name stays):

| Removed (Beta) | Kept (GA) |
|---|---|
| `response.audio.delta` | `response.output_audio.delta` |
| `response.audio.done` | `response.output_audio.done` |
| `response.audio_transcript.delta` | `response.output_audio_transcript.delta` |
| `response.audio_transcript.done` | `response.output_audio_transcript.done` |

After this PR, a Beta-named event from OpenAI surfaces as `RealtimeAiWssEventType.Unknown` → service layer's existing `Log.Warning` fires → operators get a loud signal to investigate. Audio handler doesn't fire (silence on call), which is preferable to silent acceptance — operators can detect the failure and react.

## Scope

Only V2 adapter (`OpenAiRealtimeAiProviderAdapter.ParseMessage`) is cleaned. V1 adapter and V1 inline service are unused in production and stay dual-case (changing them would only churn unused code).

## Changes

| File | Change |
|---|---|
| `OpenAiRealtimeAiProviderAdapter.cs` | Drop the four `case "response.audio.*"` branches; comment block explains the sunset reasoning |
| `RealtimeAiServiceRecordingTests.cs` | Two cases updated to use GA event name (the test covers recording behaviour, not parser names) |
| `AiSpeechAssistantConnectFixture.FunctionCalls.cs` | One provider-mock message updated to GA name to faithfully simulate post-cutover OpenAI traffic |
| `OpenAiRealtimeAiProviderAdapterBetaEventSunsetTests.cs` (new) | 8 cases — 4 Beta → Unknown, 4 GA → correct type |

## Test plan

- [x] Build: 0 errors
- [x] **`OpenAiRealtimeAiProviderAdapterBetaEventSunsetTests`** — 8 cases (4 Beta → Unknown, 4 GA → correct type)
- [x] Existing GA pinning suite (12 cases) — all pass unchanged
- [x] **Full unit suite**: 470/470 pass (was 462 baseline + 8 new)
- [ ] **MERGE GATE**: prod log query returns 0 Beta event names in ≥ 2 weeks since hotfix #934
- [ ] Staging deploy: confirm no `[RealtimeAi] Unknown provider event` warnings for audio events

## Rollback

`git revert <this-sha>` + redeploy. The reverted branch reintroduces the dual-case acceptance and Beta names start being handled again.

Base: PR #950 (Round 2 base branch).

## Refs

- Hotfix #934 (the PR that introduced the dual-case)
- https://platform.openai.com/docs/api-reference/realtime-server-events