### PR TITLE
Extract Fetch/Apply helpers inside each Resolve (cascade preserved)

### DIFF
--- a/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectService.Build.Knowledge.cs
+++ b/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectService.Build.Knowledge.cs
@@ -102,67 +102,146 @@ public partial class AiSpeechAssistantConnectService
         return from.StartsWith("+1") ? from[2..] : from;
     }
 
+    // ── Greeting ──────────────────────────────────────────────────────────
+    //
+    // Each ResolveX preserves the original check-fetch-apply order so the
+    // cross-token cascade (see ShouldResolveCrossTokenCascade_* in the
+    // KnowledgeBase fixture) continues to work: any token literal an earlier
+    // Resolve injects into _ctx.Prompt is processed by a later Resolve.
+    // Internal split into FetchX + ApplyX is a pure structural refactor —
+    // no externally observable change, byte-equivalent prompt output.
+
+    private sealed record GreetingFetchResult(string FetchedGreeting);
+
     private async Task ResolveGreetingAsync(CancellationToken cancellationToken)
     {
-        if (!_ctx.NumberId.HasValue || !_ctx.Prompt.Contains("#{greeting}")) return;
+        var fetched = await FetchGreetingAsync(cancellationToken).ConfigureAwait(false);
+        ApplyGreeting(fetched);
+    }
 
-        var greeting = await _smartiesClient
+    private async Task<GreetingFetchResult> FetchGreetingAsync(CancellationToken cancellationToken)
+    {
+        if (!_ctx.NumberId.HasValue || !_ctx.Prompt.Contains("#{greeting}")) return null;
+
+        var response = await _smartiesClient
             .GetSaleAutoCallNumberAsync(new GetSaleAutoCallNumberRequest { Id = _ctx.NumberId.Value }, cancellationToken).ConfigureAwait(false);
 
-        if (!string.IsNullOrEmpty(greeting.Data.Number.Greeting))
-            _ctx.Knowledge.Greetings = greeting.Data.Number.Greeting;
-        
+        return new GreetingFetchResult(response.Data.Number.Greeting);
+    }
+
+    private void ApplyGreeting(GreetingFetchResult result)
+    {
+        if (result == null) return;
+
+        if (!string.IsNullOrEmpty(result.FetchedGreeting))
+            _ctx.Knowledge.Greetings = result.FetchedGreeting;
+
         _ctx.Prompt = _ctx.Prompt.Replace("#{greeting}", _ctx.Knowledge.Greetings ?? string.Empty);
     }
 
+    // ── Customer items (HiFood / customer_items) ──────────────────────────
+
     private async Task ResolveCustomerItemsAsync(CancellationToken cancellationToken)
     {
+        var fetched = await FetchCustomerItemsAsync(cancellationToken).ConfigureAwait(false);
+        ApplyCustomerItems(fetched);
+    }
 
+    private async Task<string> FetchCustomerItemsAsync(CancellationToken cancellationToken)
+    {
         var hasCustomerItemsToken = _ctx.Prompt.Contains("#{customer_items}", StringComparison.OrdinalIgnoreCase);
-        
         var hasHiFoodItemsToken = _ctx.Prompt.Contains("{HiFood_商品_商品数据}", StringComparison.OrdinalIgnoreCase);
-        
-        if (!hasCustomerItemsToken && !hasHiFoodItemsToken) return;
+
+        if (!hasCustomerItemsToken && !hasHiFoodItemsToken) return null;
 
         var caches = await _salesDataProvider.GetCustomerItemsCacheByAssistantNameAsync(_ctx.Assistant.Name, cancellationToken).ConfigureAwait(false);
         var customerItems = caches.Where(c => !string.IsNullOrEmpty(c.CacheValue)).Select(c => c.CacheValue.Trim()).Distinct().ToList();
 
-        var value = customerItems.Count > 0
+        return customerItems.Count > 0
             ? string.Join(Environment.NewLine + Environment.NewLine, customerItems.Take(50))
             : " ";
+    }
+
+    private void ApplyCustomerItems(string value)
+    {
+        if (value == null) return;
 
         _ctx.Prompt = _ctx.Prompt
             .Replace("#{customer_items}", value)
             .Replace("{HiFood_商品_商品数据}", value);
     }
 
+    // ── Menu items ────────────────────────────────────────────────────────
+
+    private sealed record MenuItemsFetchResult(string MenuItems);
+
     private async Task ResolveMenuItemsAsync(CancellationToken cancellationToken)
     {
-        if (!_ctx.Prompt.Contains("#{menu_items}", StringComparison.OrdinalIgnoreCase)) return;
+        var fetched = await FetchMenuItemsAsync(cancellationToken).ConfigureAwait(false);
+        ApplyMenuItems(fetched);
+    }
+
+    private async Task<MenuItemsFetchResult> FetchMenuItemsAsync(CancellationToken cancellationToken)
+    {
+        if (!_ctx.Prompt.Contains("#{menu_items}", StringComparison.OrdinalIgnoreCase)) return null;
 
         var menuItems = await GenerateMenuItemsAsync(cancellationToken).ConfigureAwait(false);
 
-        _ctx.Prompt = _ctx.Prompt.Replace("#{menu_items}", menuItems ?? "");
+        // Wrap so a null/empty fetch result is still distinguishable from "fetch was skipped".
+        return new MenuItemsFetchResult(menuItems);
     }
+
+    private void ApplyMenuItems(MenuItemsFetchResult result)
+    {
+        if (result == null) return;
+
+        _ctx.Prompt = _ctx.Prompt.Replace("#{menu_items}", result.MenuItems ?? "");
+    }
+
+    // ── Customer info (CRM / customer_info) ───────────────────────────────
 
     private async Task ResolveCustomerInfoAsync(CancellationToken cancellationToken)
     {
+        var fetched = await FetchCustomerInfoAsync(cancellationToken).ConfigureAwait(false);
+        ApplyCustomerInfo(fetched);
+    }
+
+    private async Task<string> FetchCustomerInfoAsync(CancellationToken cancellationToken)
+    {
         var hasCustomerInfoToken = _ctx.Prompt.Contains("#{customer_info}", StringComparison.OrdinalIgnoreCase);
-        
         var hasCrmCustomerToken = _ctx.Prompt.Contains("{CRM_客户_客户数据}", StringComparison.OrdinalIgnoreCase);
-        
-        if (!hasCustomerInfoToken && !hasCrmCustomerToken) return;
+
+        if (!hasCustomerInfoToken && !hasCrmCustomerToken) return null;
 
         var cache = await _salesDataProvider.GetCustomerInfoCacheByPhoneNumberAsync(_ctx.From, cancellationToken).ConfigureAwait(false);
 
-        var value = cache?.CacheValue?.Trim() ?? " ";
+        return cache?.CacheValue?.Trim() ?? " ";
+    }
+
+    private void ApplyCustomerInfo(string value)
+    {
+        if (value == null) return;
 
         _ctx.Prompt = _ctx.Prompt
             .Replace("#{customer_info}", value)
             .Replace("{CRM_客户_客户数据}", value);
     }
 
+    // ── POS prompt variables (products + store hours) ─────────────────────
+
+    private sealed record PosPromptFetchResult(
+        bool NeedProducts,
+        bool NeedStoreHours,
+        List<PosMenuProductBriefDto> Products,
+        string StoreHours);
+
     private async Task ResolvePosPromptVariablesAsync(CancellationToken cancellationToken)
+    {
+        var fetched = await FetchPosPromptVariablesAsync(cancellationToken).ConfigureAwait(false);
+        ApplyPosPromptVariables(fetched);
+    }
+
+    private async Task<PosPromptFetchResult> FetchPosPromptVariablesAsync(CancellationToken cancellationToken)
     {
         var needProducts = HasPromptToken("{POS_菜单_商品名称}")
                            || HasPromptToken("{POS_菜单_商品类别}")
@@ -172,25 +251,33 @@ public partial class AiSpeechAssistantConnectService
                            || HasPromptToken("{POS_菜单_菜单时间}");
         var needStoreHours = HasPromptToken("{POS_店铺信息_营业时间}");
 
-        if (!needProducts && !needStoreHours) return;
+        if (!needProducts && !needStoreHours) return null;
 
         var language = ResolvePosPromptLanguage();
         var products = needProducts
             ? await _posUtilService.GetPosMenuProductBriefsAsync(_ctx.AgentId, language, cancellationToken).ConfigureAwait(false)
-            : [];
+            : new List<PosMenuProductBriefDto>();
 
-        ResolvePosMenuProductNames(products);
-        ResolvePosMenuProductCategories(products);
-        ResolvePosMenuProductSpecifications(products);
-        ResolvePosMenuProductTaxes(products);
-        ResolvePosMenuProductPrices(products);
-        ResolvePosMenuProductTimes(products);
+        var storeHours = needStoreHours
+            ? await _posUtilService.GetPosStoreTimePeriodsAsync(_ctx.AgentId, language, cancellationToken).ConfigureAwait(false)
+            : null;
 
-        if (needStoreHours)
-        {
-            var storeHours = await _posUtilService.GetPosStoreTimePeriodsAsync(_ctx.AgentId, language, cancellationToken).ConfigureAwait(false);
-            ResolvePosStoreBusinessHours(storeHours);
-        }
+        return new PosPromptFetchResult(needProducts, needStoreHours, products, storeHours);
+    }
+
+    private void ApplyPosPromptVariables(PosPromptFetchResult result)
+    {
+        if (result == null) return;
+
+        ResolvePosMenuProductNames(result.Products);
+        ResolvePosMenuProductCategories(result.Products);
+        ResolvePosMenuProductSpecifications(result.Products);
+        ResolvePosMenuProductTaxes(result.Products);
+        ResolvePosMenuProductPrices(result.Products);
+        ResolvePosMenuProductTimes(result.Products);
+
+        if (result.NeedStoreHours)
+            ResolvePosStoreBusinessHours(result.StoreHours);
     }
 
     private void ResolvePosMenuProductNames(List<PosMenuProductBriefDto> products)
@@ -342,13 +429,30 @@ public partial class AiSpeechAssistantConnectService
         };
     }
 
+    // ── Delivery info (CRM 送货日 / delivery_info) ─────────────────────────
+
+    private sealed record DeliveryInfoFetchResult(string DeliveryValue);
+
     private async Task ResolveDeliveryInfoAsync(CancellationToken cancellationToken)
     {
-        if (!HasDeliveryInfoToken(_ctx.Prompt)) return;
+        var fetched = await FetchDeliveryInfoAsync(cancellationToken).ConfigureAwait(false);
+        ApplyDeliveryInfo(fetched);
+    }
+
+    private async Task<DeliveryInfoFetchResult> FetchDeliveryInfoAsync(CancellationToken cancellationToken)
+    {
+        if (!HasDeliveryInfoToken(_ctx.Prompt)) return null;
 
         var cache = await _salesDataProvider.GetDeliveryInfoCacheByPhoneNumberAsync(_ctx.From, cancellationToken).ConfigureAwait(false);
 
-        _ctx.Prompt = ApplyDeliveryInfoTokens(_ctx.Prompt, cache?.CacheValue?.Trim());
+        return new DeliveryInfoFetchResult(cache?.CacheValue?.Trim());
+    }
+
+    private void ApplyDeliveryInfo(DeliveryInfoFetchResult result)
+    {
+        if (result == null) return;
+
+        _ctx.Prompt = ApplyDeliveryInfoTokens(_ctx.Prompt, result.DeliveryValue);
     }
 
     /// <summary>

--- a/src/SmartTalk.IntegrationTests/Services/AiSpeechAssistant/AiSpeechAssistantConnectFixture.KnowledgeBase.cs
+++ b/src/SmartTalk.IntegrationTests/Services/AiSpeechAssistant/AiSpeechAssistantConnectFixture.KnowledgeBase.cs
@@ -13,6 +13,7 @@ using SmartTalk.Core.Services.Jobs;
 using SmartTalk.IntegrationTests.Mocks;
 using SmartTalk.Messages.Commands.AiSpeechAssistant;
 using SmartTalk.Messages.Dto.Agent;
+using SmartTalk.Messages.Dto.Smarties;
 using SmartTalk.Messages.Enums.AiSpeechAssistant;
 using SmartTalk.Messages.Enums.RealtimeAi;
 using Xunit;
@@ -223,6 +224,131 @@ public partial class AiSpeechAssistantConnectFixture
 
         // Session update sent to OpenAI proves the service proceeded past the service hours check
         openaiWs.SentMessages.ShouldNotBeEmpty();
+    }
+
+    [Fact]
+    public async Task ShouldResolveCrossTokenCascade_GreetingContainingCustomerItemsToken_NestedTokenAlsoResolved()
+    {
+        // ── Characterization test for the cross-token cascade invariant ──────────
+        //
+        // The original BuildKnowledgeAsync ran each ResolveX sequentially:
+        //   ResolveGreeting injects greeting text → mutates _ctx.Prompt
+        //   ResolveCustomerItems then re-reads _ctx.Prompt and processes any tokens
+        //   that the greeting injection introduced.
+        //
+        // This test pins that emergent behaviour: an operator who configures a
+        // SaleAutoCallNumber greeting containing `#{customer_items}` expects the
+        // customer items to actually appear in the final prompt, NOT a raw
+        // `#{customer_items}` literal that the LLM would treat as broken markup.
+        //
+        // Any refactor that pre-collects token-presence checks (e.g. a hypothetical
+        // "all fetches first, then all applies" rearrangement) would break this
+        // cascade because the customer-items token-presence check would run against
+        // the pre-greeting prompt and find no token — the greeting injection later
+        // would then leak the raw `#{customer_items}` literal.
+        //
+        // The Resolve order in BuildKnowledgeAsync is: Greeting → CustomerItems →
+        // MenuItems → CustomerInfo → POS → Delivery. Cascade only chains FORWARDS
+        // in that order — a greeting can inject any downstream token; CustomerInfo
+        // cannot inject `#{greeting}` (Greeting already ran). This test exercises
+        // the most-reachable cascade: Greeting → CustomerItems.
+
+        await RunWithUnitOfWork<IRepository, IUnitOfWork>(async (repository, unitOfWork) =>
+        {
+            var agent = new Agent { Name = "TestAgent", IsReceiveCall = true, Type = AgentType.Assistant };
+            await repository.InsertAsync(agent);
+
+            var assistant = new Core.Domain.AISpeechAssistant.AiSpeechAssistant
+            {
+                Name = "CascadeAssistant",
+                AnsweringNumber = TestDidNumber,
+                ModelProvider = RealtimeAiProvider.OpenAi,
+                ModelVoice = "alloy",
+                IsDefault = true,
+                IsDisplay = true
+            };
+            await repository.InsertAsync(assistant);
+            await unitOfWork.SaveChangesAsync();
+
+            await repository.InsertAsync(new AgentAssistant { AgentId = agent.Id, AssistantId = assistant.Id });
+            await repository.InsertAsync(new AiSpeechAssistantKnowledge
+            {
+                AssistantId = assistant.Id,
+                Prompt = "Greeting: #{greeting} End.",
+                IsActive = true,
+                Version = "1.0"
+            });
+
+            // Customer-items cache that the cascade should reach. Distinct literals
+            // so the assertion can confirm the cascade actually resolved the token
+            // (not just that the raw literal happens to be absent for some other reason).
+            // The cache row is keyed by the fixed "customer_items" CacheKey + the
+            // assistant Name in Filter — see SalesDataProvider.CustomerItemsCacheKey.
+            await repository.InsertAsync(new Core.Domain.Sales.AiSpeechAssistantKnowledgeVariableCache
+            {
+                CacheKey = "customer_items",
+                Filter = "CascadeAssistant",
+                CacheValue = "CASCADE_MARKER_PIZZA_LARGE"
+            });
+        });
+
+        // Smarties returns a greeting that EMBEDS the downstream token literal.
+        // The original code's cascade then processes that token when ResolveCustomerItems runs.
+        var smartiesMock = Substitute.For<ISmartiesClient>();
+        smartiesMock.GetSaleAutoCallNumberAsync(Arg.Any<GetSaleAutoCallNumberRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new GetSaleAutoCallNumberResponse
+            {
+                Data = new GetSaleAutoCallNumberResponseData
+                {
+                    Number = new SettingNumberDto
+                    {
+                        Greeting = "Welcome! Today's items: #{customer_items}"
+                    }
+                }
+            });
+
+        var twilioWs = new MockWebSocket();
+        twilioWs.EnqueueMessage(JsonConvert.SerializeObject(new
+        {
+            @event = "start",
+            start = new { callSid = "CA_CASCADE_TEST", streamSid = "MZ_CASCADE_TEST" }
+        }));
+
+        var openaiWs = CreateProviderMock();
+        openaiWs.EnqueueMessage(JsonConvert.SerializeObject(new { type = "session.updated" }));
+
+        var command = new ConnectAiSpeechAssistantCommand
+        {
+            From = TestCallerNumber,
+            To = TestDidNumber,
+            Host = TestHost,
+            TwilioWebSocket = twilioWs,
+            NumberId = 42   // Must be non-null so ResolveGreetingAsync fires
+        };
+
+        await Run<IMediator>(async mediator =>
+        {
+            await mediator.SendAsync(command);
+        }, builder =>
+        {
+            builder.RegisterInstance(Substitute.For<ISmartTalkBackgroundJobClient>()).As<ISmartTalkBackgroundJobClient>();
+            builder.RegisterInstance(smartiesMock).AsImplementedInterfaces();
+            openaiWs.Register(builder);
+        });
+
+        openaiWs.SentMessages.ShouldNotBeEmpty();
+        var sessionUpdate = Encoding.UTF8.GetString(openaiWs.SentMessages.First());
+
+        // Greeting was injected
+        sessionUpdate.ShouldContain("Welcome!");
+
+        // CASCADE invariant: the downstream token embedded in the greeting MUST
+        // have been resolved. The raw `#{customer_items}` literal MUST NOT remain.
+        sessionUpdate.ShouldNotContain("#{customer_items}");
+
+        // The customer-items cache value MUST appear in the final prompt — the
+        // proof that the cascade actually fetched and substituted, not just stripped.
+        sessionUpdate.ShouldContain("CASCADE_MARKER_PIZZA_LARGE");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Internal-only refactor of `AiSpeechAssistantConnectService.Build.Knowledge.cs`: each `ResolveX` method's body is split into a private `FetchX` (pure read, no `_ctx` mutation) plus a private `ApplyX` (pure mutation, no I/O). The `ResolveX` method itself stays in place as a one-line orchestrator.

**`BuildKnowledgeAsync` orchestration is UNCHANGED** — still awaits each `ResolveX` sequentially in the original order. The cross-token cascade (e.g. a Greeting that contains `#{customer_items}` is processed by ResolveCustomerItems) is fully preserved.

## Commit history — TDD discipline

This PR is two commits, deliberately ordered:

1. **`Pin cross-token cascade behaviour in BuildKnowledgeAsync`** — adds the characterization test against the ORIGINAL code. The test would fail any refactor that pre-collects token-presence checks across multiple Resolves.
2. **`Extract Fetch/Apply helpers inside each Resolve method (cascade preserved)`** — applies the refactor. The cascade test stays green because each `ResolveX` still performs its check-fetch-apply in tight sequence on the freshest `_ctx.Prompt`.

If you `git reset` to the test commit alone, the test runs against the un-refactored code and passes. If you then apply the refactor commit, the same test still passes. The test is the regression boundary.

## Why earlier attempt was rolled back

Independent code review caught a critical issue: the original PR did "all six fetches first, then all six applies", which broke the cross-token cascade. Concrete failure scenario:

| | Original code | Old refactor (rolled back) |
|---|---|---|
| Greeting injects `#{customer_items}` | ResolveCustomerItems then resolves it | Token-check happened earlier; raw `#{customer_items}` leaks to the LLM |

The new refactor scope was pulled back to strictly cascade-safe changes. Phase 7.2 parallelisation needs its own design treatment.

## Per-Resolve new shape

```csharp
private async Task ResolveGreetingAsync(CancellationToken ct)
{
    var fetched = await FetchGreetingAsync(ct).ConfigureAwait(false);
    ApplyGreeting(fetched);
}

private async Task<GreetingFetchResult> FetchGreetingAsync(CancellationToken ct) { /* pure read */ }
private void ApplyGreeting(GreetingFetchResult result)         { /* pure mutate */ }
```

Repeated for: Greeting, CustomerItems, MenuItems, CustomerInfo, POS, DeliveryInfo.

## Value of this refactor

- Each `FetchX` is individually replaceable (e.g. for a future cache layer) without touching `ApplyX` logic
- `ApplyX` methods become pure functions over their input + `_ctx`, easier to reason about
- Fetch / Apply boundary is documented, opening the door for future parallelisation once cascade has been addressed

## Test plan

- [x] **`ShouldResolveCrossTokenCascade_GreetingContainingCustomerItemsToken_NestedTokenAlsoResolved`** — the load-bearing characterization test (commit 1)
- [x] Existing 4 `KnowledgeBase` integration tests untouched
- [x] **Full unit suite**: 462/462 pass
- [x] Build: 0 errors
- [ ] CI: integration tests run against real DB, including the new cascade test

## Why byte-equivalent argument

1. `BuildKnowledgeAsync`'s `await` sequence is **identical to before**
2. Each `ResolveX`'s external contract (params, return, side effects) is **identical to before**
3. `FetchX` + `ApplyX` combined cover exactly the same operations the original `ResolveX` performed, in the same order
4. The cascade test fails any deviation from (1)–(3)

## Future work (Round 3)

Phase 7.2 (parallel fetch via `Task.WhenAll`) is blocked pending a cascade-policy decision: either (a) prove operator policy forbids `#{...}` literals inside operator-configured strings, or (b) add explicit cascade detection that re-fetches when an Apply introduces a downstream token. Out of scope for this PR.

Base: PR #950 (Round 2 base branch).