### PR TITLE
fixed timeout

### DIFF
--- a/src/SmartTalk.Core/Services/Timer/InactivityTimerManager.cs
+++ b/src/SmartTalk.Core/Services/Timer/InactivityTimerManager.cs
@@ -67,6 +67,11 @@ public class InactivityTimerManager : IInactivityTimerManager
         try
         {
             await Task.Delay(entry.Timeout, entry.Cts.Token).ConfigureAwait(false);
+            
+            // The timer may have been replaced for the same sessionId while this task
+            // was waiting. Only the current active entry is allowed to invoke callback.
+            if (!_timers.TryGetValue(sessionId, out var activeEntry) || !ReferenceEquals(activeEntry, entry)) return;
+            
             await entry.OnTimeout().ConfigureAwait(false);
         }
         catch (OperationCanceledException) { }
@@ -80,10 +85,9 @@ public class InactivityTimerManager : IInactivityTimerManager
         }
         finally
         {
-            // Remove only if the current dictionary value is exactly this timer entry.
-            // Prevents an older timer's finally from removing a newer timer for the same session.
-            ((ICollection<KeyValuePair<string, TimerEntry>>)_timers)
-                .Remove(new KeyValuePair<string, TimerEntry>(sessionId, entry));
+            // Remove only if this exact entry is still mapped. Avoid deleting a newer
+            // timer that might have been started for the same session in the meantime.
+            _timers.TryRemove(new KeyValuePair<string, TimerEntry>(sessionId, entry));
         }
     }
 }

--- a/src/SmartTalk.UnitTests/Services/Timer/InactivityTimerManagerTests.cs
+++ b/src/SmartTalk.UnitTests/Services/Timer/InactivityTimerManagerTests.cs
@@ -73,6 +73,37 @@ public class InactivityTimerManagerTests : IDisposable
         secondTcs.Task.IsCompleted.ShouldBeTrue();
         firstCallbackInvoked.ShouldBeFalse();
     }
+    
+    [Fact]
+    public async Task StartTimer_OldTimerFinishes_ShouldNotRemoveOrphanNewTimer()
+    {
+        var firstStarted = new TaskCompletionSource<bool>();
+        var releaseFirst = new TaskCompletionSource<bool>();
+        var secondCallbackInvoked = false;
+
+        _sut.StartTimer(SessionId, TimeSpan.FromMilliseconds(20), async () =>
+        {
+            firstStarted.TrySetResult(true);
+            await releaseFirst.Task;
+        });
+
+        var firstStartedTask = await Task.WhenAny(firstStarted.Task, Task.Delay(TimeSpan.FromSeconds(5)));
+        firstStartedTask.ShouldBe(firstStarted.Task, "First callback should start");
+
+        _sut.StartTimer(SessionId, TimeSpan.FromMilliseconds(120), () =>
+        {
+            secondCallbackInvoked = true;
+            return Task.CompletedTask;
+        });
+
+        releaseFirst.TrySetResult(true);
+        await Task.Delay(50);
+
+        _sut.StopTimer(SessionId);
+        await Task.Delay(180);
+
+        secondCallbackInvoked.ShouldBeFalse("Second timer should remain cancellable after old timer finishes");
+    }
 
     [Fact]
     public async Task StartTimer_MultipleSessions_ShouldWorkIndependently()


### PR DESCRIPTION

1. `RunTimerAsync` 在执行回调前加了“当前活跃 entry 校验”，旧 timer 不会误触发。  
[InactivityTimerManager.cs:73](/Users/situke/WorkPlace/GitHub/SmartTalk/src/SmartTalk.Core/Services/Timer/InactivityTimerManager.cs:73)

2. `finally` 用 `TryRemove(KeyValuePair<...>)` 做精确移除，不会删掉新 timer。  
[InactivityTimerManager.cs:90](/Users/situke/WorkPlace/GitHub/SmartTalk/src/SmartTalk.Core/Services/Timer/InactivityTimerManager.cs:90)

回归测试覆盖了旧 timer 完成后新 timer 仍可取消的场景。  
[InactivityTimerManagerTests.cs:77](/Users/situke/WorkPlace/GitHub/SmartTalk/src/SmartTalk.UnitTests/Services/Timer/InactivityTimerManagerTests.cs:77)
