### PR TITLE
Add regression coverage around the InactivityTimerManager fix

### DIFF
--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/RealtimeAiServiceIdleFollowUpTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/RealtimeAiServiceIdleFollowUpTests.cs
@@ -1,6 +1,8 @@
 using NSubstitute;
 using Shouldly;
 using SmartTalk.Core.Services.RealtimeAiV2;
+using SmartTalk.Core.Services.RealtimeAiV2.Services;
+using SmartTalk.Core.Services.Timer;
 using SmartTalk.Messages.Dto.RealtimeAi;
 using SmartTalk.Messages.Enums.RealtimeAi;
 using Xunit;
@@ -370,5 +372,138 @@ public class RealtimeAiServiceIdleFollowUpTests : RealtimeAiServiceTestBase
 
         actionInvoked.ShouldBeFalse();
         ProviderAdapter.DidNotReceive().BuildTextUserMessage(Arg.Any<string>(), Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task ActiveConversation_RapidTurnsWithUserInterruptions_NoSpuriousFollowUpFires()
+    {
+        // End-to-end integration test for the idle-follow-up behaviour at the service
+        // level. The other RealtimeAiServiceIdleFollowUpTests in this file use the
+        // inherited TimerManager mock and therefore don't exercise the real timer
+        // cancellation path. This test bypasses the mock and constructs a separate
+        // SUT with a real InactivityTimerManager so that Start/Stop ordering against
+        // realistic AI-turn-completed / user-speech-detected events runs through
+        // production code end-to-end.
+        //
+        // What this test pins (the integration-level invariant):
+        //   When every AI-turn-completed event is followed by a user-speech-detected
+        //   event before the idle timeout elapses, the idle follow-up callback must
+        //   NEVER fire. In production this callback schedules a Hangfire
+        //   HangupCallAsync job that disconnects the caller, so any leak is a
+        //   call-stability bug.
+        //
+        // Background (the bug the InactivityTimerManager fix protects against):
+        //   1. OnAiTurnCompletedAsync starts timer T1 for the idle follow-up.
+        //   2. OnAiDetectedUserSpeechAsync calls StopTimer (cancels T1, removes from dict).
+        //   3. Next OnAiTurnCompletedAsync starts timer T2 (puts T2 in dict).
+        //   4. Pre-fix: T1's cancelled RunTimerAsync hits finally and unconditionally
+        //      TryRemoves the dict entry, clobbering T2.
+        //   5. T2 still runs (CTS never cancelled). Subsequent StopTimers become
+        //      no-ops for it.
+        //   6. After T2's timeout: OnTimeoutAsync fires → Hangfire schedules
+        //      HangupCallAsync → user disconnected mid-conversation.
+        //   Post-fix: the finally uses ICollection.Remove(KVP) with value-match, so
+        //   T1's cleanup cannot clobber T2's registration.
+        //
+        // Note on scope: this test pins the integration-level invariant under
+        // realistic event timings. It is not the deterministic regression trigger
+        // for the specific finally-vs-StartTimer race window — that is
+        // `InactivityTimerManagerTests.StartTimer_PreviousTimerFinally_ShouldNotRemoveNewTimer`,
+        // which uses TaskCompletionSource-controlled callback blocking to force
+        // the interleaving every run. This test catches regressions where the
+        // real timer manager fails to cooperate with the service-level event
+        // pipeline (e.g. StopTimer not wired to OnAiDetectedUserSpeechAsync,
+        // StartTimer not wired to OnAiTurnCompletedAsync).
+
+        var realTimerManager = new InactivityTimerManager();
+        var sut = new RealtimeAiService(Switcher, realTimerManager);
+
+        var followUpInvoked = 0;
+
+        // Route raw WS messages to the appropriate parsed event type. The default
+        // ProviderAdapter setup uses a single Returns value, but this test cycles
+        // between two distinct event types, so we route per call by inspecting the
+        // raw message contents.
+        ProviderAdapter.ParseMessage(Arg.Any<string>())
+            .Returns(ci =>
+            {
+                var raw = ci.ArgAt<string>(0);
+                if (raw.Contains("response.done"))
+                    return new ParsedRealtimeAiProviderEvent
+                    {
+                        Type = RealtimeAiWssEventType.ResponseTurnCompleted,
+                        Data = new List<RealtimeAiWssFunctionCallData>()
+                    };
+                if (raw.Contains("input_audio_buffer.speech_started"))
+                    return new ParsedRealtimeAiProviderEvent
+                    {
+                        Type = RealtimeAiWssEventType.SpeechDetected
+                    };
+                return new ParsedRealtimeAiProviderEvent { Type = RealtimeAiWssEventType.Unknown };
+            });
+
+        var options = CreateDefaultOptions(o =>
+        {
+            o.IdleFollowUp = new RealtimeSessionIdleFollowUp
+            {
+                // 1 second is the smallest value supported by TimeoutSeconds (int).
+                // Cycle below is faster than this so a correctly-cancelling timer
+                // never fires; any race-induced leak would surface as a spurious fire.
+                TimeoutSeconds = 1,
+                FollowUpMessage = "Are you still there?",
+                OnTimeoutAsync = () =>
+                {
+                    Interlocked.Increment(ref followUpInvoked);
+                    return Task.CompletedTask;
+                }
+            };
+        });
+
+        // Manually start the session against the SUT with the real timer manager.
+        // (The inherited StartSessionInBackgroundAsync helper uses the base's Sut
+        // which has the mock timer, so we duplicate the small amount of setup here.)
+        var sessionStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var sessionTask = Task.Run(async () =>
+        {
+            try
+            {
+                _ = Task.Delay(50).ContinueWith(_ => sessionStarted.TrySetResult());
+                await sut.ConnectAsync(options, CancellationToken.None).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) { }
+            catch (Exception ex) { sessionStarted.TrySetException(ex); }
+        });
+        await sessionStarted.Task.ConfigureAwait(false);
+        await Task.Delay(50).ConfigureAwait(false);
+
+        // Simulate a rapid 30-cycle conversation: AI-turn-completed → user-speech.
+        // Each AI-turn-completed starts the timer (1s timeout). Each user-speech
+        // stops it. The 30ms gap between events is far smaller than the 1s timeout,
+        // so a correctly-functioning timer never fires. If the race were present,
+        // the cumulative effect of 30 Start/Stop pairs would leak at least one
+        // entry into the "running but not in dict" state, and that entry would
+        // fire its callback ~1s later.
+        for (var i = 0; i < 30; i++)
+        {
+            await FakeWssClient.SimulateMessageReceivedAsync("{\"type\":\"response.done\"}");
+            await Task.Delay(15).ConfigureAwait(false);
+            await FakeWssClient.SimulateMessageReceivedAsync("{\"type\":\"input_audio_buffer.speech_started\"}");
+            await Task.Delay(15).ConfigureAwait(false);
+        }
+
+        // Final cycle: simulate a final AI-turn-completed (timer starts) followed
+        // immediately by closing the WebSocket. Cleanup must cancel the timer; no
+        // follow-up should fire during cleanup.
+        await FakeWssClient.SimulateMessageReceivedAsync("{\"type\":\"response.done\"}");
+        await Task.Delay(50).ConfigureAwait(false);
+
+        FakeWs.EnqueueClose();
+        await sessionTask;
+
+        // Wait beyond the 1s timeout. Any leaked entry would fire by now.
+        await Task.Delay(1500).ConfigureAwait(false);
+
+        followUpInvoked.ShouldBe(0,
+            "Idle follow-up must never fire during an active conversation where every AI turn is followed by a user-speech-detected event");
     }
 }

--- a/src/SmartTalk.UnitTests/Services/Timer/InactivityTimerManagerTests.cs
+++ b/src/SmartTalk.UnitTests/Services/Timer/InactivityTimerManagerTests.cs
@@ -135,6 +135,58 @@ public class InactivityTimerManagerTests : IDisposable
     }
 
     [Fact]
+    public async Task StartTimer_RapidSequentialStartStopCycles_NoSpuriousCallback()
+    {
+        // Real-world production pattern: every AI turn completion calls StartTimer; every
+        // user-speech-detected event calls StopTimer; conversation oscillates rapidly.
+        //
+        // Background (the bug this fix protects against): each StopTimer cancels the entry's
+        // CTS, the cancelled RunTimerAsync hits its finally block which (pre-fix) did
+        // unconditional `_timers.TryRemove(sessionId)`. If a new StartTimer raced in between
+        // the StopTimer and the cancelled finally, the finally clobbered the *new* timer's
+        // dict registration. The new timer's Task.Delay then ran with a never-cancelled CTS,
+        // IsTimerRunning returned false (so subsequent StopTimer calls became no-ops for it),
+        // and after timeout the callback fired — in production scheduling a Hangfire
+        // HangupCallAsync job and disconnecting the user mid-conversation.
+        //
+        // Post-fix: the finally uses ICollection.Remove with key+value match, so an old
+        // cancelled timer's finally cannot clobber a new timer's registration.
+        //
+        // What THIS test pins: the broader invariant — under rapid Start/Stop pairing
+        // (the production AI-turn / user-speech alternation), NO callback should ever
+        // fire and the dict must end up empty. It catches a class of regressions:
+        // StopTimer failing to cancel its CTS, StartTimer failing to replace the old
+        // entry, leaked entries from any future race. It does NOT, on its own,
+        // deterministically reproduce the specific finally-vs-StartTimer race window
+        // — tight synchronous loops let each cancelled finally complete before the
+        // next iteration adds a fresh entry, so the racy clobber rarely lands.
+        //
+        // The deterministic regression guard for the specific race is
+        // `StartTimer_PreviousTimerFinally_ShouldNotRemoveNewTimer` above, which uses
+        // TaskCompletionSource-controlled callback blocking to interleave a second
+        // StartTimer with a still-suspended finally and asserts the new entry survives.
+
+        var callbackCount = 0;
+
+        for (var i = 0; i < 50; i++)
+        {
+            _sut.StartTimer(SessionId, TimeSpan.FromMilliseconds(20), () =>
+            {
+                Interlocked.Increment(ref callbackCount);
+                return Task.CompletedTask;
+            });
+            _sut.StopTimer(SessionId);
+        }
+
+        // Wait far longer than the 20ms timeout. Any leaked / un-cancelled entry would
+        // have fired its callback by now. With the fix this stays at zero.
+        await Task.Delay(500);
+
+        callbackCount.ShouldBe(0, "No callback should fire when every StartTimer is followed by StopTimer, no matter how rapid the cycles");
+        _sut.IsTimerRunning(SessionId).ShouldBeFalse("Dict must be empty after the final StopTimer");
+    }
+
+    [Fact]
     public async Task StartTimer_CallbackException_ShouldNotCrashAndShouldBeReusable()
     {
         var callbackReached = new TaskCompletionSource<bool>();


### PR DESCRIPTION
## Summary

- Add two test-only safety nets around the InactivityTimerManager race-condition fix (`RunTimerAsync` finally block previously clobbering a freshly-registered entry, surfaced in prod as spurious idle-follow-up disconnects).
- The specific race is already deterministically pinned by `InactivityTimerManagerTests.StartTimer_PreviousTimerFinally_ShouldNotRemoveNewTimer` (existing test, uses TaskCompletionSource-controlled callback blocking to force the interleaving every run). These two new tests add complementary coverage at a wider boundary:
  - **Unit-level invariant**: `StartTimer_RapidSequentialStartStopCycles_NoSpuriousCallback` — under rapid Start/Stop pairing (production AI-turn / user-speech alternation), no callback fires and the dict ends empty. Catches adjacent regressions: StopTimer failing to cancel its CTS, StartTimer failing to replace the old entry, leaked orphaned entries from any future race.
  - **Integration-level invariant**: `ActiveConversation_RapidTurnsWithUserInterruptions_NoSpuriousFollowUpFires` — the other idle-follow-up tests in that file use the inherited `TimerManager` mock, so they don't exercise the real cancellation path. This one constructs a separate SUT with a real `InactivityTimerManager` and alternates `response.done` / `input_audio_buffer.speech_started` events through the service.

Both tests are framed honestly in their doc-comments: they pin invariants that the fix is required to maintain, but they are **not** the deterministic regression trigger for the specific finally-vs-StartTimer race — that role stays with the existing TaskCompletionSource-driven test. Comments explicitly point future readers to the existing test so the scope isn't misread.

No production code changes.

## Test plan

- [x] `dotnet build src/SmartTalk.UnitTests/SmartTalk.UnitTests.csproj` — 0 errors
- [x] Targeted: 28/28 pass on `InactivityTimerManagerTests` + `RealtimeAiServiceIdleFollowUpTests`
- [x] Full unit suite: 333/333 pass
- [ ] Staging deploy on the base branch (#950 observation window) — separate from this PR