### PR TITLE
Round 3 stability and perf overhaul (base)

### DIFF
--- a/src/SmartTalk.Core/Domain/Account/UserAccount.cs
+++ b/src/SmartTalk.Core/Domain/Account/UserAccount.cs
@@ -3,6 +3,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 using SmartTalk.Core.Domain.Pos;
 using SmartTalk.Core.Domain.Security;
 using SmartTalk.Core.Domain.System;
+using SmartTalk.Core.Utils;
 using SmartTalk.Messages.Dto.Agent;
 using SmartTalk.Messages.Dto.Pos;
 using SmartTalk.Messages.Enums;
@@ -17,7 +18,7 @@ namespace SmartTalk.Core.Domain.Account
         public UserAccount()
         {
             Uuid = Guid.NewGuid();
-            CreatedOn = new DateTimeOffset(TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, TimeZoneInfo.FindSystemTimeZoneById("America/Los_Angeles")).DateTime, TimeSpan.Zero);
+            CreatedOn = new DateTimeOffset(TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, PstTimeZone.Get()).DateTime, TimeSpan.Zero);
             ModifiedOn = DateTimeOffset.Now;
         }
         

--- a/src/SmartTalk.Core/Jobs/RecurringJobs/SchedulingPhoneOrderDailyDataBroadcastRecurringJob.cs
+++ b/src/SmartTalk.Core/Jobs/RecurringJobs/SchedulingPhoneOrderDailyDataBroadcastRecurringJob.cs
@@ -1,5 +1,6 @@
 ﻿using Mediator.Net;
 using SmartTalk.Core.Settings.PhoneOrder;
+using SmartTalk.Core.Utils;
 using SmartTalk.Messages.Commands.PhoneOrder;
 
 namespace SmartTalk.Core.Jobs.RecurringJobs;
@@ -24,5 +25,5 @@ public class SchedulingPhoneOrderDailyDataBroadcastRecurringJob : IRecurringJob
     
     public string CronExpression => _cronExpressionSetting.Value;
     
-    public TimeZoneInfo TimeZone => TimeZoneInfo.FindSystemTimeZoneById("America/Los_Angeles");
+    public TimeZoneInfo TimeZone => PstTimeZone.Get();
 }

--- a/src/SmartTalk.Core/Mappings/PhoneOrderMapping.cs
+++ b/src/SmartTalk.Core/Mappings/PhoneOrderMapping.cs
@@ -1,5 +1,6 @@
 using AutoMapper;
 using SmartTalk.Core.Domain.PhoneOrder;
+using SmartTalk.Core.Utils;
 using SmartTalk.Messages.Dto.AiSpeechAssistant;
 using SmartTalk.Messages.Dto.EasyPos;
 using SmartTalk.Messages.Dto.PhoneOrder;
@@ -12,7 +13,7 @@ public class PhoneOrderMapping : Profile
     public PhoneOrderMapping()
     {
         CreateMap<PhoneOrderRecord, PhoneOrderRecordDto>()
-            .ForMember(dest => dest.CreatedDate, opt => opt.MapFrom(src => TimeZoneInfo.ConvertTimeFromUtc(src.CreatedDate.UtcDateTime, TimeZoneInfo.FindSystemTimeZoneById("America/Los_Angeles"))));
+            .ForMember(dest => dest.CreatedDate, opt => opt.MapFrom(src => TimeZoneInfo.ConvertTimeFromUtc(src.CreatedDate.UtcDateTime, PstTimeZone.Get())));
         
         CreateMap<PhoneOrderRecordDto, PhoneOrderRecord>();
         CreateMap<PhoneOrderConversation, PhoneOrderConversationDto>().ReverseMap();

--- a/src/SmartTalk.Core/Services/AiKids/AiKidRealtimeService.cs
+++ b/src/SmartTalk.Core/Services/AiKids/AiKidRealtimeService.cs
@@ -5,6 +5,7 @@ using SmartTalk.Core.Services.Jobs;
 using SmartTalk.Core.Services.Http.Clients;
 using SmartTalk.Core.Services.AiSpeechAssistant;
 using SmartTalk.Core.Services.RealtimeAi.Services;
+using SmartTalk.Core.Utils;
 using SmartTalk.Messages.Commands.AiKids;
 using SmartTalk.Messages.Dto.RealtimeAi;
 using SmartTalk.Messages.Dto.Smarties;
@@ -118,7 +119,7 @@ public class AiKidRealtimeService : IAiKidRealtimeService
     {
         if (assistant?.Knowledge == null || string.IsNullOrEmpty(assistant.Knowledge?.Prompt)) return string.Empty;
 
-        var pstTime = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time"));
+        var pstTime = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, PstTimeZone.Get());
         var currentTime = pstTime.ToString("yyyy-MM-dd HH:mm:ss");
 
         var finalPrompt = assistant.Knowledge.Prompt

--- a/src/SmartTalk.Core/Services/AiKids/AiKidRealtimeServiceV2.cs
+++ b/src/SmartTalk.Core/Services/AiKids/AiKidRealtimeServiceV2.cs
@@ -8,6 +8,7 @@ using SmartTalk.Core.Services.Http.Clients;
 using SmartTalk.Core.Services.Jobs;
 using SmartTalk.Core.Services.RealtimeAiV2;
 using SmartTalk.Core.Services.RealtimeAiV2.Services;
+using SmartTalk.Core.Utils;
 using SmartTalk.Messages.Commands.AiKids;
 using SmartTalk.Messages.Commands.Attachments;
 using SmartTalk.Messages.Dto.Attachments;
@@ -170,7 +171,7 @@ public class AiKidRealtimeServiceV2 : IAiKidRealtimeServiceV2
         if (assistant?.Knowledge == null || string.IsNullOrEmpty(assistant.Knowledge.Prompt))
             return string.Empty;
 
-        var pstTime = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time"));
+        var pstTime = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, PstTimeZone.Get());
         var currentTime = pstTime.ToString("yyyy-MM-dd HH:mm:ss");
 
         var finalPrompt = assistant.Knowledge.Prompt

--- a/src/SmartTalk.Core/Services/AiSpeechAssistant/AiSpeechAssistantService.cs
+++ b/src/SmartTalk.Core/Services/AiSpeechAssistant/AiSpeechAssistantService.cs
@@ -262,7 +262,7 @@ public partial class AiSpeechAssistantService : IAiSpeechAssistantService
         
         Log.Information("Matching Ai speech assistant: {@Assistant}、{@Knowledge}、{@UserProfile}", assistant, knowledge, userProfile);
         
-        var pstTime = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time"));
+        var pstTime = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, PstTimeZone.Get());
         var currentTime = pstTime.ToString("yyyy-MM-dd HH:mm:ss");
 
         var finalPrompt = knowledge.Prompt
@@ -1292,7 +1292,7 @@ public partial class AiSpeechAssistantService : IAiSpeechAssistantService
         
         var utcNow = DateTimeOffset.UtcNow;
 
-        var pstZone = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+        var pstZone = PstTimeZone.Get();
 
         var pstTime = TimeZoneInfo.ConvertTime(utcNow, pstZone);
         

--- a/src/SmartTalk.Core/Services/AutoTest/IAutoTestDataImportHandler.cs
+++ b/src/SmartTalk.Core/Services/AutoTest/IAutoTestDataImportHandler.cs
@@ -2,6 +2,7 @@ using Serilog;
 using SmartTalk.Core.Ioc;
 using SmartTalk.Core.Services.AutoTest.SalesAiOrder;
 using SmartTalk.Core.Services.Jobs;
+using SmartTalk.Core.Utils;
 using SmartTalk.Messages.Enums.AutoTest;
 
 namespace SmartTalk.Core.Services.AutoTest;
@@ -55,7 +56,7 @@ public class ApiDataImportHandler : IAutoTestDataImportHandler
                     var startUtc = startDateObj is DateTime dt1 ? dt1 : DateTime.Parse(startDateObj.ToString());
                     var endUtc = endDateObj is DateTime dt2 ? dt2 : DateTime.Parse(endDateObj.ToString());
 
-                    var pstZone = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+                    var pstZone = PstTimeZone.Get();
 
                     var startPstDate = TimeZoneInfo.ConvertTimeFromUtc(startUtc, pstZone).Date;
                     var endPstDate = TimeZoneInfo.ConvertTimeFromUtc(endUtc, pstZone).Date;

--- a/src/SmartTalk.Core/Services/AutoTest/SalesAiOrder/AutoTestSalesPhoneOrderProcessJobService.cs
+++ b/src/SmartTalk.Core/Services/AutoTest/SalesAiOrder/AutoTestSalesPhoneOrderProcessJobService.cs
@@ -27,6 +27,7 @@ using SmartTalk.Messages.Dto.SpeechMatics;
 using SmartTalk.Core.Services.Http.Clients;
 using SmartTalk.Core.Services.SpeechMatics;
 using SmartTalk.Core.Services.Caching.Redis;
+using SmartTalk.Core.Utils;
 using SmartTalk.Messages.Enums.SpeechMatics;
 using SmartTalk.Core.Services.AiSpeechAssistant;
 using SmartTalk.Core.Services.Attachments;
@@ -181,7 +182,7 @@ public class AutoTestSalesPhoneOrderProcessJobService : IAutoTestSalesPhoneOrder
                 return; 
             }
             
-            var pstZone = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time"); 
+            var pstZone = PstTimeZone.Get();
             var singleDayRecords = callRecords.SelectMany(r => new[] 
             { 
                 new { Phone = NormalizePhone(r.FromNumber), Record = r }, 
@@ -636,8 +637,7 @@ public class AutoTestSalesPhoneOrderProcessJobService : IAutoTestSalesPhoneOrder
     private async Task<List<ChatMessage>> ConfigureRecordAnalyzePromptAsync(
         Domain.AISpeechAssistant.AiSpeechAssistant aiSpeechAssistant, byte[] audioContent, CancellationToken cancellationToken)
     {
-        var pstTime = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow,
-            TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time"));
+        var pstTime = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, PstTimeZone.Get());
         var currentTime = pstTime.ToString("yyyy-MM-dd HH:mm:ss");
         
         var customerItemsCacheList = await _salesDataProvider.GetCustomerItemsCacheByAssistantNameAsync(aiSpeechAssistant.Name, cancellationToken);
@@ -815,7 +815,7 @@ public class AutoTestSalesPhoneOrderProcessJobService : IAutoTestSalesPhoneOrder
         var knowledge = await _aiSpeechAssistantDataProvider.GetAiSpeechAssistantKnowledgeAsync(assistantId: assistant.Id, isActive: true, cancellationToken: cancellationToken).ConfigureAwait(false);
         if (knowledge == null) return null;
         
-        var pstTime = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time"));
+        var pstTime = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, PstTimeZone.Get());
         var currentTime = pstTime.ToString("yyyy-MM-dd HH:mm:ss");
         var finalPrompt = knowledge.Prompt
             .Replace("#{current_time}", currentTime)
@@ -936,7 +936,7 @@ public class AutoTestSalesPhoneOrderProcessJobService : IAutoTestSalesPhoneOrder
                 return null;
             }
             
-            var pacificZone = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+            var pacificZone = PstTimeZone.Get();
             var sapStartDate = TimeZoneInfo.ConvertTimeFromUtc(record.StartTimeUtc, pacificZone).Date;
             
             var sapResp = await RetrySapAsync(() =>

--- a/src/SmartTalk.Core/Services/Linphone/LinphoneService.cs
+++ b/src/SmartTalk.Core/Services/Linphone/LinphoneService.cs
@@ -5,6 +5,7 @@ using SmartTalk.Core.Ioc;
 using SmartTalk.Core.Domain.Linphone;
 using SmartTalk.Core.Services.Caching;
 using SmartTalk.Core.Services.Http.Clients;
+using SmartTalk.Core.Utils;
 using SmartTalk.Messages.Dto.Linphone;
 using SmartTalk.Messages.Enums.Linphone;
 using SmartTalk.Messages.Requests.Linphone;
@@ -256,7 +257,7 @@ public class LinphoneService : ILinphoneService
     public async Task<GetLinphoneDataResponse> GetLinphoneDataAsync(GetLinphoneDataRequest request, CancellationToken cancellationToken)
     {
         var specifiedDate = request.Time.Date;
-        var pstOffset = TimeZoneInfo.FindSystemTimeZoneById("America/Los_Angeles").GetUtcOffset(specifiedDate);
+        var pstOffset = PstTimeZone.Get().GetUtcOffset(specifiedDate);
         var startPst = new DateTimeOffset(specifiedDate, pstOffset);
         var endPst = startPst.AddDays(1);
 
@@ -276,7 +277,7 @@ public class LinphoneService : ILinphoneService
 
             var linphoneDates = new List<LinphoneData>();
             
-            var pacificZone = TimeZoneInfo.FindSystemTimeZoneById("America/Los_Angeles");
+            var pacificZone = PstTimeZone.Get();
             
             var tasks = externalLinphoneGroupedCdrs.Select(async group =>
             {

--- a/src/SmartTalk.Core/Services/PhoneOrder/PhoneOrderProcessJobService.Record.cs
+++ b/src/SmartTalk.Core/Services/PhoneOrder/PhoneOrderProcessJobService.Record.cs
@@ -107,7 +107,7 @@ public partial class PhoneOrderProcessJobService
             Log.Warning("Fetched incoming phone number from Twilio failed: {Message}", e.Message);
         }
         
-        var pstTime = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time"));
+        var pstTime = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, PstTimeZone.Get());
         var currentTime = pstTime.ToString("yyyy-MM-dd HH:mm:ss");
         var callSubjectCn = "通话主题:";
         var callSubjectEn = "Conversation topic:";
@@ -263,7 +263,7 @@ public partial class PhoneOrderProcessJobService
     {
         var timezone = !string.IsNullOrWhiteSpace(agent.Timezone)
             ? TimeZoneInfo.FindSystemTimeZoneById(agent.Timezone)
-            : TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+            : PstTimeZone.Get();
         var nowDate = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, timezone);
 
         var utcDate = TimeZoneInfo.ConvertTimeToUtc(nowDate.Date, timezone);
@@ -437,7 +437,7 @@ public partial class PhoneOrderProcessJobService
                 .ConfigureAwait(false);
         if (!extractedOrders.Any()) return;
 
-        var pacificZone = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+        var pacificZone = PstTimeZone.Get();
         var pacificNow = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, pacificZone);
 
         foreach (var storeOrder in extractedOrders)

--- a/src/SmartTalk.Core/Services/PhoneOrder/PhoneOrderProcessJobService.cs
+++ b/src/SmartTalk.Core/Services/PhoneOrder/PhoneOrderProcessJobService.cs
@@ -12,6 +12,7 @@ using SmartTalk.Core.Services.Sale;
 using SmartTalk.Core.Services.SpeechMatics;
 using SmartTalk.Core.Settings.OpenAi;
 using SmartTalk.Core.Settings.Twilio;
+using SmartTalk.Core.Utils;
 using SmartTalk.Core.Services.Twilio;
 using SmartTalk.Messages.Commands.PhoneOrder;
 
@@ -94,7 +95,7 @@ public partial class PhoneOrderProcessJobService : IPhoneOrderProcessJobService
 
     private (DateTimeOffset Start, DateTimeOffset End) GetQueryTimeRange()
     {
-        var pacificZone = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+        var pacificZone = PstTimeZone.Get();
         
         var startLocal = new DateTime(2025, 8, 1, 0, 0, 0);
         var endLocal = new DateTime(2025, 8, 31, 23, 59, 59);

--- a/src/SmartTalk.Core/Services/PhoneOrder/PhoneOrderService.Record.cs
+++ b/src/SmartTalk.Core/Services/PhoneOrder/PhoneOrderService.Record.cs
@@ -17,6 +17,7 @@ using SmartTalk.Core.Domain.PhoneOrder;
 using SmartTalk.Core.Domain.SpeechMatics;
 using SmartTalk.Core.Services.Linphone;
 using SmartTalk.Core.Domain.Pos;
+using SmartTalk.Core.Utils;
 using SmartTalk.Messages.Dto.PhoneOrder;
 using SmartTalk.Messages.Dto.Attachments;
 using SmartTalk.Messages.Enums.PhoneOrder;
@@ -576,7 +577,7 @@ public partial class PhoneOrderService
 
         if (match.Success) time = match.Groups[1].Value;
 
-        return TimeZoneInfo.ConvertTime(DateTimeOffset.FromUnixTimeSeconds(long.Parse(time)), TimeZoneInfo.FindSystemTimeZoneById("America/Los_Angeles"));
+        return TimeZoneInfo.ConvertTime(DateTimeOffset.FromUnixTimeSeconds(long.Parse(time)), PstTimeZone.Get());
     }
 
     private async Task UpdatePhoneOrderRecordSpecificFieldsAsync(int recordId, int modifiedBy, string tips, string lastModifiedByName, CancellationToken cancellationToken)
@@ -626,7 +627,7 @@ public partial class PhoneOrderService
     {
         if (!inputDate.HasValue) return (null, null);
 
-        var pstTimeZone = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+        var pstTimeZone = PstTimeZone.Get();
 
         var pstDate = new DateTime(inputDate.Value.Year, inputDate.Value.Month, inputDate.Value.Day, 0, 0, 0);
         var pstStart = new DateTimeOffset(pstDate, pstTimeZone.GetUtcOffset(pstDate));
@@ -810,7 +811,7 @@ public partial class PhoneOrderService
     {
         if (month < 1 || month > 12) throw new ArgumentOutOfRangeException(nameof(month));
 
-        var tz = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time"); // PT, 含 DST
+        var tz = PstTimeZone.Get(); // PT, 含 DST
 
         var startLocal = new DateTime(year, month, 1, 0, 0, 0, DateTimeKind.Unspecified);
 
@@ -889,7 +890,7 @@ public partial class PhoneOrderService
     
     private string ConvertUtcToPst(DateTimeOffset utcTime)
     {
-        var pstTimeZone = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+        var pstTimeZone = PstTimeZone.Get();
         
         var pstTime = TimeZoneInfo.ConvertTimeFromUtc(utcTime.UtcDateTime, pstTimeZone);
         

--- a/src/SmartTalk.Core/Services/PhoneOrder/PhoneOrderService.Send.cs
+++ b/src/SmartTalk.Core/Services/PhoneOrder/PhoneOrderService.Send.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text;
+using SmartTalk.Core.Utils;
 using SmartTalk.Messages.Dto.WeChat;
 using SmartTalk.Messages.Commands.PhoneOrder;
 using SmartTalk.Messages.Enums.WeChat;
@@ -94,7 +95,7 @@ public partial class PhoneOrderService : IPhoneOrderService
     private static (DateTimeOffset today, DateTimeOffset yesterday) PstTime()
     {
         var utcNow = DateTimeOffset.UtcNow;
-        var pstZone = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+        var pstZone = PstTimeZone.Get();
 
         var today = TimeZoneInfo.ConvertTime(utcNow, pstZone);
         var yesterday = today.AddDays(-1);

--- a/src/SmartTalk.Core/Services/Printer/PrinterService.cs
+++ b/src/SmartTalk.Core/Services/Printer/PrinterService.cs
@@ -26,6 +26,7 @@ using SmartTalk.Core.Services.Jobs;
 using SmartTalk.Core.Services.PhoneOrder;
 using SmartTalk.Core.Services.Pos;
 using SmartTalk.Core.Settings.Printer;
+using SmartTalk.Core.Utils;
 using SmartTalk.Message.Commands.Printer;
 using SmartTalk.Message.Events.Printer;
 using SmartTalk.Messages.Commands.Pos;
@@ -457,7 +458,7 @@ public class PrinterService : IPrinterService
 
             var storeName = JsonConvert.DeserializeObject<Dictionary<string, Dictionary<string, string>>>(store.Names).GetValueOrDefault("en")?.GetValueOrDefault("name");
 
-            var text = new SendWorkWechatGroupRobotTextDto { Content = $"✅SMT Cloud Printer Online\nTime: {TimeZoneInfo.ConvertTimeFromUtc(DateTimeOffset.Now.UtcDateTime, TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time")):yyyy-MM-dd HH:mm:ss}\nStore: {storeName}"};
+            var text = new SendWorkWechatGroupRobotTextDto { Content = $"✅SMT Cloud Printer Online\nTime: {TimeZoneInfo.ConvertTimeFromUtc(DateTimeOffset.Now.UtcDateTime, PstTimeZone.Get()):yyyy-MM-dd HH:mm:ss}\nStore: {storeName}"};
             text.MentionedMobileList = "@all";
         
             await _weChatClient.SendWorkWechatRobotMessagesAsync(_printerSendErrorLogSetting.CloudPrinterSendErrorLogRobotUrl, new SendWorkWechatGroupRobotMessageDto
@@ -543,9 +544,9 @@ public class PrinterService : IPrinterService
             var storeName = JsonConvert.DeserializeObject<Dictionary<string, Dictionary<string, string>>>(store.Names).GetValueOrDefault("en")?.GetValueOrDefault("name");
             
             if (@event.MerchPrinterOrderDto.PrintFormat == PrintFormat.Order)
-                text = new SendWorkWechatGroupRobotTextDto { Content = $"🆘SMT Cloud Print Error Infor🆘\n\nPrint Error: {merchPrinterLog.Message}\nPrint Time: {TimeZoneInfo.ConvertTimeFromUtc(@event.MerchPrinterOrderDto.PrintDate.UtcDateTime, TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time")):yyyy-MM-dd HH:mm:ss}\nStore: {storeName}\nOrder Date:{order.CreatedDate.ToString("yyyy-MM-dd")}\nOrder NO: #{order.OrderNo}"};
+                text = new SendWorkWechatGroupRobotTextDto { Content = $"🆘SMT Cloud Print Error Infor🆘\n\nPrint Error: {merchPrinterLog.Message}\nPrint Time: {TimeZoneInfo.ConvertTimeFromUtc(@event.MerchPrinterOrderDto.PrintDate.UtcDateTime, PstTimeZone.Get()):yyyy-MM-dd HH:mm:ss}\nStore: {storeName}\nOrder Date:{order.CreatedDate.ToString("yyyy-MM-dd")}\nOrder NO: #{order.OrderNo}"};
             else
-                text = new SendWorkWechatGroupRobotTextDto { Content = $"🆘SMT Cloud Print Error Infor🆘\n\nPrint Error: {merchPrinterLog.Message}\nPrint Time: {TimeZoneInfo.ConvertTimeFromUtc(@event.MerchPrinterOrderDto.PrintDate.UtcDateTime, TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time")):yyyy-MM-dd HH:mm:ss}\nStore: {storeName}\nOrder Date:{@event.MerchPrinterOrderDto.PrintDate.ToString("yyyy-MM-dd")}\nOrder Id: #{@event.MerchPrinterOrderDto.OrderId}"};
+                text = new SendWorkWechatGroupRobotTextDto { Content = $"🆘SMT Cloud Print Error Infor🆘\n\nPrint Error: {merchPrinterLog.Message}\nPrint Time: {TimeZoneInfo.ConvertTimeFromUtc(@event.MerchPrinterOrderDto.PrintDate.UtcDateTime, PstTimeZone.Get()):yyyy-MM-dd HH:mm:ss}\nStore: {storeName}\nOrder Date:{@event.MerchPrinterOrderDto.PrintDate.ToString("yyyy-MM-dd")}\nOrder Id: #{@event.MerchPrinterOrderDto.OrderId}"};
            
             text.MentionedMobileList = "@all";
         
@@ -860,7 +861,7 @@ public class PrinterService : IPrinterService
              
              var storeName = JsonConvert.DeserializeObject<Dictionary<string, Dictionary<string, string>>>(store.Names).GetValueOrDefault("en")?.GetValueOrDefault("name");
              
-             var text = new SendWorkWechatGroupRobotTextDto { Content = $"❌SMT Cloud Printer Offline\nTime: {TimeZoneInfo.ConvertTimeFromUtc(DateTimeOffset.Now.UtcDateTime, TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time")):yyyy-MM-dd HH:mm:ss}\nStore: {storeName}"};
+             var text = new SendWorkWechatGroupRobotTextDto { Content = $"❌SMT Cloud Printer Offline\nTime: {TimeZoneInfo.ConvertTimeFromUtc(DateTimeOffset.Now.UtcDateTime, PstTimeZone.Get()):yyyy-MM-dd HH:mm:ss}\nStore: {storeName}"};
              text.MentionedMobileList = "@all";
         
              await _weChatClient.SendWorkWechatRobotMessagesAsync(_printerSendErrorLogSetting.CloudPrinterSendErrorLogRobotUrl, new SendWorkWechatGroupRobotMessageDto

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Clients/Twilio/TwilioRealtimeAiClientAdapter.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Clients/Twilio/TwilioRealtimeAiClientAdapter.cs
@@ -77,25 +77,16 @@ public class TwilioRealtimeAiClientAdapter : IRealtimeAiClientAdapter
         };
     }
 
-    /// <summary>
-    /// Twilio's media-streams protocol ships <c>media.timestamp</c> as a string of
-    /// milliseconds since stream start. Returns null when the field is absent or
-    /// cannot be parsed — a single malformed timestamp must not drop the whole
-    /// media frame, the audio payload is more critical than the timing metadata.
-    /// </summary>
+    // Twilio doc'd shape is string ms; real payloads occasionally use the numeric form.
+    // Bad / missing timestamp must not drop the audio frame.
     private static long? ExtractMediaTimestamp(JsonElement media)
     {
         if (!media.TryGetProperty("timestamp", out var tsProp)) return null;
 
-        // Twilio docs specify string form, but real-world payloads occasionally surface
-        // the numeric form (older preview snapshots, future protocol revisions). Accept
-        // both rather than silently dropping one variant.
-        if (tsProp.ValueKind == JsonValueKind.String &&
-            long.TryParse(tsProp.GetString(), out var parsed))
+        if (tsProp.ValueKind == JsonValueKind.String && long.TryParse(tsProp.GetString(), out var parsed))
             return parsed;
 
-        if (tsProp.ValueKind == JsonValueKind.Number &&
-            tsProp.TryGetInt64(out var direct))
+        if (tsProp.ValueKind == JsonValueKind.Number && tsProp.TryGetInt64(out var direct))
             return direct;
 
         return null;

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Clients/Twilio/TwilioRealtimeAiClientAdapter.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Clients/Twilio/TwilioRealtimeAiClientAdapter.cs
@@ -68,12 +68,37 @@ public class TwilioRealtimeAiClientAdapter : IRealtimeAiClientAdapter
             return new ParsedClientMessage { Type = RealtimeAiClientMessageType.Unknown };
 
         var mediaType = media.TryGetProperty("type", out var t) ? t.GetString() : null;
+        var timestamp = ExtractMediaTimestamp(media);
 
         return mediaType switch
         {
-            "video" => new ParsedClientMessage { Type = RealtimeAiClientMessageType.Image, Payload = payload },
-            _ => new ParsedClientMessage { Type = RealtimeAiClientMessageType.Audio, Payload = payload }
+            "video" => new ParsedClientMessage { Type = RealtimeAiClientMessageType.Image, Payload = payload, Timestamp = timestamp },
+            _ => new ParsedClientMessage { Type = RealtimeAiClientMessageType.Audio, Payload = payload, Timestamp = timestamp }
         };
+    }
+
+    /// <summary>
+    /// Twilio's media-streams protocol ships <c>media.timestamp</c> as a string of
+    /// milliseconds since stream start. Returns null when the field is absent or
+    /// cannot be parsed — a single malformed timestamp must not drop the whole
+    /// media frame, the audio payload is more critical than the timing metadata.
+    /// </summary>
+    private static long? ExtractMediaTimestamp(JsonElement media)
+    {
+        if (!media.TryGetProperty("timestamp", out var tsProp)) return null;
+
+        // Twilio docs specify string form, but real-world payloads occasionally surface
+        // the numeric form (older preview snapshots, future protocol revisions). Accept
+        // both rather than silently dropping one variant.
+        if (tsProp.ValueKind == JsonValueKind.String &&
+            long.TryParse(tsProp.GetString(), out var parsed))
+            return parsed;
+
+        if (tsProp.ValueKind == JsonValueKind.Number &&
+            tsProp.TryGetInt64(out var direct))
+            return direct;
+
+        return null;
     }
 
     public object BuildAudioDeltaMessage(string base64Payload, string sessionId)

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/IRealtimeAiClientAdapter.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/IRealtimeAiClientAdapter.cs
@@ -18,11 +18,8 @@ public class ParsedClientMessage
     public Dictionary<string, string> Metadata { get; set; }
 
     /// <summary>
-    /// Optional millisecond timestamp the client emitted alongside this message.
-    /// Currently populated only by <see cref="Clients.Twilio.TwilioRealtimeAiClientAdapter"/>
-    /// from the <c>media.timestamp</c> field; web / default clients leave it null.
-    /// Phase 10.3 reads this on user-speech-detected to compute the OpenAI
-    /// <c>conversation.item.truncate audio_end_ms</c> for the in-flight assistant turn.
+    /// Optional millisecond timestamp from the client. Populated by Twilio from
+    /// <c>media.timestamp</c>; web / default clients leave it null.
     /// </summary>
     public long? Timestamp { get; set; }
 }

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/IRealtimeAiClientAdapter.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/IRealtimeAiClientAdapter.cs
@@ -9,13 +9,22 @@ public enum RealtimeAiClientMessageType { Audio, Image, Text, Start, Stop, Unkno
 public class ParsedClientMessage
 {
     public string Payload { get; set; }
-    
+
     public RealtimeAiClientMessageType Type { get; set; }
 
     /// <summary>
     /// Metadata from lifecycle events (e.g. CallSid, StreamSid from Twilio "start").
     /// </summary>
     public Dictionary<string, string> Metadata { get; set; }
+
+    /// <summary>
+    /// Optional millisecond timestamp the client emitted alongside this message.
+    /// Currently populated only by <see cref="Clients.Twilio.TwilioRealtimeAiClientAdapter"/>
+    /// from the <c>media.timestamp</c> field; web / default clients leave it null.
+    /// Phase 10.3 reads this on user-speech-detected to compute the OpenAI
+    /// <c>conversation.item.truncate audio_end_ms</c> for the in-flight assistant turn.
+    /// </summary>
+    public long? Timestamp { get; set; }
 }
 
 public interface IRealtimeAiClientAdapter : IScopedDependency

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/IRealtimeAiProviderAdapter.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/IRealtimeAiProviderAdapter.cs
@@ -17,11 +17,8 @@ public interface IRealtimeAiProviderAdapter : IScopedDependency
     string BuildTextUserMessage(string text, string sessionId);
 
     /// <summary>
-    /// Builds the provider-specific message that truncates the in-flight assistant
-    /// turn at <paramref name="audioEndMs"/> milliseconds, called when the user barges
-    /// in. Returns <c>null</c> when the provider has no equivalent (Google's Live API
-    /// relies on its server-side VAD instead of an explicit client truncate). The
-    /// caller skips <c>SendToProviderAsync</c> on null without warning.
+    /// Builds the provider truncate message at user barge-in. Returns null when the
+    /// provider has no equivalent; the caller skips sending on null.
     /// </summary>
     string BuildTruncateMessage(string itemId, long audioEndMs);
 

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/IRealtimeAiProviderAdapter.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/IRealtimeAiProviderAdapter.cs
@@ -16,7 +16,14 @@ public interface IRealtimeAiProviderAdapter : IScopedDependency
     
     string BuildTextUserMessage(string text, string sessionId);
 
-    object BuildInterruptMessage(string lastAssistantItemIdToInterrupt);
+    /// <summary>
+    /// Builds the provider-specific message that truncates the in-flight assistant
+    /// turn at <paramref name="audioEndMs"/> milliseconds, called when the user barges
+    /// in. Returns <c>null</c> when the provider has no equivalent (Google's Live API
+    /// relies on its server-side VAD instead of an explicit client truncate). The
+    /// caller skips <c>SendToProviderAsync</c> on null without warning.
+    /// </summary>
+    string BuildTruncateMessage(string itemId, long audioEndMs);
 
     string BuildFunctionCallReplyMessage(RealtimeAiWssFunctionCallData functionCall, string output);
 

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Providers/Google/GoogleRealtimeAiProviderAdapter.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Providers/Google/GoogleRealtimeAiProviderAdapter.cs
@@ -99,21 +99,14 @@ public class GoogleRealtimeAiProviderAdapter : IRealtimeAiProviderAdapter
         return JsonSerializer.Serialize(message);
     }
     
-    public object BuildInterruptMessage(string lastAssistantItemIdToInterrupt)
-    {
-        if (!string.IsNullOrEmpty(lastAssistantItemIdToInterrupt))
-        {
-            var message = new
-            {
-                type = "conversation.interrupt",
-                item_id_to_interrupt = lastAssistantItemIdToInterrupt
-            };
-            return message;
-        }
-
-        Log.Warning("[RealtimeAi] Cannot build interrupt message, missing item ID");
-        return null;
-    }
+    /// <summary>
+    /// Google's Live API relies on its own server-side VAD to handle user barge-in;
+    /// there is no client-sent equivalent of OpenAI's <c>conversation.item.truncate</c>.
+    /// Returns null so the V2 service skips <c>SendToProviderAsync</c> without warning,
+    /// while still letting Twilio receive the <c>clear</c> frame that actually stops
+    /// playback. The signature is preserved for cross-provider symmetry with OpenAI.
+    /// </summary>
+    public string BuildTruncateMessage(string itemId, long audioEndMs) => null;
 
     public string BuildFunctionCallReplyMessage(RealtimeAiWssFunctionCallData functionCall, string output)
     {

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Providers/Google/GoogleRealtimeAiProviderAdapter.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Providers/Google/GoogleRealtimeAiProviderAdapter.cs
@@ -99,13 +99,7 @@ public class GoogleRealtimeAiProviderAdapter : IRealtimeAiProviderAdapter
         return JsonSerializer.Serialize(message);
     }
     
-    /// <summary>
-    /// Google's Live API relies on its own server-side VAD to handle user barge-in;
-    /// there is no client-sent equivalent of OpenAI's <c>conversation.item.truncate</c>.
-    /// Returns null so the V2 service skips <c>SendToProviderAsync</c> without warning,
-    /// while still letting Twilio receive the <c>clear</c> frame that actually stops
-    /// playback. The signature is preserved for cross-provider symmetry with OpenAI.
-    /// </summary>
+    // Google's Live API handles barge-in via its own server-side VAD; no client-sent truncate.
     public string BuildTruncateMessage(string itemId, long audioEndMs) => null;
 
     public string BuildFunctionCallReplyMessage(RealtimeAiWssFunctionCallData functionCall, string output)

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Providers/OpenAi/OpenAiRealtimeAiProviderAdapter.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Providers/OpenAi/OpenAiRealtimeAiProviderAdapter.cs
@@ -230,13 +230,6 @@ public class OpenAiRealtimeAiProviderAdapter : IRealtimeAiProviderAdapter
         return JsonSerializer.Serialize(message);
     }
     
-    /// <summary>
-    /// Builds the OpenAI GA <c>conversation.item.truncate</c> event. Per the GA contract
-    /// this truncates the assistant message's audio in OpenAI's conversation history at
-    /// the given offset so subsequent turns reference only what the user actually heard.
-    /// Returns null when <paramref name="itemId"/> is missing — sending the event without
-    /// an item id would be rejected by the GA server.
-    /// </summary>
     public string BuildTruncateMessage(string itemId, long audioEndMs)
     {
         if (string.IsNullOrEmpty(itemId))
@@ -250,9 +243,6 @@ public class OpenAiRealtimeAiProviderAdapter : IRealtimeAiProviderAdapter
             type = "conversation.item.truncate",
             item_id = itemId,
             content_index = 0,
-            // OpenAI rejects negative offsets; the service-side caller already clamps via
-            // Math.Max(0, ...) but we guard here too so a faulty consumer cannot ship a
-            // bad payload.
             audio_end_ms = Math.Max(0L, audioEndMs)
         });
     }

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Providers/OpenAi/OpenAiRealtimeAiProviderAdapter.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Providers/OpenAi/OpenAiRealtimeAiProviderAdapter.cs
@@ -230,20 +230,31 @@ public class OpenAiRealtimeAiProviderAdapter : IRealtimeAiProviderAdapter
         return JsonSerializer.Serialize(message);
     }
     
-    public object BuildInterruptMessage(string lastAssistantItemIdToInterrupt)
+    /// <summary>
+    /// Builds the OpenAI GA <c>conversation.item.truncate</c> event. Per the GA contract
+    /// this truncates the assistant message's audio in OpenAI's conversation history at
+    /// the given offset so subsequent turns reference only what the user actually heard.
+    /// Returns null when <paramref name="itemId"/> is missing — sending the event without
+    /// an item id would be rejected by the GA server.
+    /// </summary>
+    public string BuildTruncateMessage(string itemId, long audioEndMs)
     {
-        if (!string.IsNullOrEmpty(lastAssistantItemIdToInterrupt))
+        if (string.IsNullOrEmpty(itemId))
         {
-            var message = new
-            {
-                type = "conversation.interrupt",
-                item_id_to_interrupt = lastAssistantItemIdToInterrupt
-            };
-            return message;
+            Log.Warning("[RealtimeAi] Cannot build truncate message, missing item ID");
+            return null;
         }
 
-        Log.Warning("[RealtimeAi] Cannot build interrupt message, missing item ID");
-        return null;
+        return JsonSerializer.Serialize(new
+        {
+            type = "conversation.item.truncate",
+            item_id = itemId,
+            content_index = 0,
+            // OpenAI rejects negative offsets; the service-side caller already clamps via
+            // Math.Max(0, ...) but we guard here too so a faulty consumer cannot ship a
+            // bad payload.
+            audio_end_ms = Math.Max(0L, audioEndMs)
+        });
     }
 
     public string BuildFunctionCallReplyMessage(RealtimeAiWssFunctionCallData functionCall, string output)

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Services/RealtimeAiService.Event.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Services/RealtimeAiService.Event.cs
@@ -101,6 +101,13 @@ public partial class RealtimeAiService
 
         _ctx.IsAiSpeaking = true;
 
+        // Track the latest assistant item_id for Phase 10.3 barge-in. Adapter populates
+        // this on every OpenAI response.output_audio.delta; Google adapter leaves it null
+        // (Google's protocol does not surface a per-delta id). Either way, an empty value
+        // must not clobber a previously-tracked id from earlier in the same turn.
+        if (!string.IsNullOrEmpty(aiAudioData.ItemId))
+            _ctx.LastAssistantItemId = aiAudioData.ItemId;
+
         var clientBase64 = await TranscodeAudioAsync(aiAudioData.Base64Payload, AudioSource.Provider).ConfigureAwait(false);
 
         await SendAudioToClientAsync(clientBase64).ConfigureAwait(false);
@@ -122,6 +129,10 @@ public partial class RealtimeAiService
 
         _ctx.Round += 1;
         _ctx.IsAiSpeaking = false;
+
+        // The interrupt window for this turn has closed; clear so the next user-barge-in
+        // opportunity (Phase 10.3) can't send a stale id that the provider would reject.
+        _ctx.LastAssistantItemId = null;
 
         var idleFollowUp = _ctx.Options.IdleFollowUp;
 

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Services/RealtimeAiService.Event.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Services/RealtimeAiService.Event.cs
@@ -108,6 +108,14 @@ public partial class RealtimeAiService
         if (!string.IsNullOrEmpty(aiAudioData.ItemId))
             _ctx.LastAssistantItemId = aiAudioData.ItemId;
 
+        // Capture the stream-time at which the AI started speaking THIS turn (set-once
+        // per turn). Phase 10.3 will compute audio_end_ms = LatestMediaTimestamp - this
+        // value to tell OpenAI exactly where to truncate the assistant message in its
+        // conversation history. Set only on the FIRST delta of the turn so subsequent
+        // deltas don't shift the anchor forwards.
+        if (!_ctx.ResponseStartTimestampTwilio.HasValue && _ctx.LatestMediaTimestamp.HasValue)
+            _ctx.ResponseStartTimestampTwilio = _ctx.LatestMediaTimestamp;
+
         var clientBase64 = await TranscodeAudioAsync(aiAudioData.Base64Payload, AudioSource.Provider).ConfigureAwait(false);
 
         await SendAudioToClientAsync(clientBase64).ConfigureAwait(false);
@@ -133,6 +141,11 @@ public partial class RealtimeAiService
         // The interrupt window for this turn has closed; clear so the next user-barge-in
         // opportunity (Phase 10.3) can't send a stale id that the provider would reject.
         _ctx.LastAssistantItemId = null;
+
+        // Reset the per-turn stream-time anchor. The next turn's first ResponseAudioDelta
+        // will set it again. LatestMediaTimestamp deliberately keeps its value — it's the
+        // running clock, not a per-turn quantity.
+        _ctx.ResponseStartTimestampTwilio = null;
 
         var idleFollowUp = _ctx.Options.IdleFollowUp;
 

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Services/RealtimeAiService.Event.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Services/RealtimeAiService.Event.cs
@@ -101,18 +101,11 @@ public partial class RealtimeAiService
 
         _ctx.IsAiSpeaking = true;
 
-        // Track the latest assistant item_id for Phase 10.3 barge-in. Adapter populates
-        // this on every OpenAI response.output_audio.delta; Google adapter leaves it null
-        // (Google's protocol does not surface a per-delta id). Either way, an empty value
-        // must not clobber a previously-tracked id from earlier in the same turn.
+        // Empty item_id must not clobber a previously-tracked id from earlier in the same turn.
         if (!string.IsNullOrEmpty(aiAudioData.ItemId))
             _ctx.LastAssistantItemId = aiAudioData.ItemId;
 
-        // Capture the stream-time at which the AI started speaking THIS turn (set-once
-        // per turn). Phase 10.3 will compute audio_end_ms = LatestMediaTimestamp - this
-        // value to tell OpenAI exactly where to truncate the assistant message in its
-        // conversation history. Set only on the FIRST delta of the turn so subsequent
-        // deltas don't shift the anchor forwards.
+        // Anchor is set once per turn — first delta wins so subsequent deltas don't shift it.
         if (!_ctx.ResponseStartTimestampTwilio.HasValue && _ctx.LatestMediaTimestamp.HasValue)
             _ctx.ResponseStartTimestampTwilio = _ctx.LatestMediaTimestamp;
 
@@ -128,34 +121,15 @@ public partial class RealtimeAiService
         if (_ctx.Options.IdleFollowUp != null)
             _inactivityTimerManager.StopTimer(_ctx.SessionId);
 
-        // Client `clear` frame goes FIRST — it's the time-critical signal that the
-        // user is waiting on (stops Twilio playback the user can still hear). The
-        // provider truncate is a history-correction follow-up that doesn't affect
-        // what the user perceives in the moment.
+        // `clear` first (time-critical playback stop), truncate after (history correction).
         await SendToClientAsync(_ctx.ClientAdapter.BuildSpeechDetectedMessage(_ctx.SessionId)).ConfigureAwait(false);
-
-        // Phase 10.3 barge-in: tell the provider exactly where the user heard the AI
-        // cut off so the conversation history reflects only what the user actually
-        // experienced. Skipped silently when any of the tracking values is missing
-        // (cold session, web client without timestamps, etc.).
         await SendBargeInTruncateIfApplicableAsync().ConfigureAwait(false);
     }
 
     /// <summary>
-    /// Builds and sends a provider truncate event when all three tracking values are
-    /// populated:
-    /// <list type="bullet">
-    ///   <item><see cref="RealtimeAiSessionContext.LastAssistantItemId"/> (Phase 10.1)</item>
-    ///   <item><see cref="RealtimeAiSessionContext.LatestMediaTimestamp"/> (Phase 10.2 running clock)</item>
-    ///   <item><see cref="RealtimeAiSessionContext.ResponseStartTimestampTwilio"/> (Phase 10.2 per-turn anchor)</item>
-    /// </list>
-    /// If any is missing, skip silently — the existing Twilio <c>clear</c> frame still
-    /// stops playback immediately; we just lose the OpenAI history precision (an
-    /// acceptable degraded mode). After sending, the interrupt window for this turn
-    /// is consumed; clear the per-turn fields so a subsequent speech-detected event
-    /// can't re-truncate the same already-truncated item (which OpenAI would reject).
-    /// <see cref="RealtimeAiSessionContext.LatestMediaTimestamp"/> deliberately keeps
-    /// its value because it's the running stream clock.
+    /// Sends a provider truncate when item_id, stream clock, and per-turn anchor are
+    /// all set. Skipped silently otherwise. Clears per-turn state after sending so a
+    /// second speech-detected in the same turn cannot re-truncate the same item.
     /// </summary>
     private async Task SendBargeInTruncateIfApplicableAsync()
     {
@@ -186,13 +160,8 @@ public partial class RealtimeAiService
         _ctx.Round += 1;
         _ctx.IsAiSpeaking = false;
 
-        // The interrupt window for this turn has closed; clear so the next user-barge-in
-        // opportunity (Phase 10.3) can't send a stale id that the provider would reject.
+        // Clear per-turn barge-in state. LatestMediaTimestamp keeps its value (running clock).
         _ctx.LastAssistantItemId = null;
-
-        // Reset the per-turn stream-time anchor. The next turn's first ResponseAudioDelta
-        // will set it again. LatestMediaTimestamp deliberately keeps its value — it's the
-        // running clock, not a per-turn quantity.
         _ctx.ResponseStartTimestampTwilio = null;
 
         var idleFollowUp = _ctx.Options.IdleFollowUp;

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Services/RealtimeAiService.Event.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Services/RealtimeAiService.Event.cs
@@ -128,7 +128,55 @@ public partial class RealtimeAiService
         if (_ctx.Options.IdleFollowUp != null)
             _inactivityTimerManager.StopTimer(_ctx.SessionId);
 
+        // Client `clear` frame goes FIRST — it's the time-critical signal that the
+        // user is waiting on (stops Twilio playback the user can still hear). The
+        // provider truncate is a history-correction follow-up that doesn't affect
+        // what the user perceives in the moment.
         await SendToClientAsync(_ctx.ClientAdapter.BuildSpeechDetectedMessage(_ctx.SessionId)).ConfigureAwait(false);
+
+        // Phase 10.3 barge-in: tell the provider exactly where the user heard the AI
+        // cut off so the conversation history reflects only what the user actually
+        // experienced. Skipped silently when any of the tracking values is missing
+        // (cold session, web client without timestamps, etc.).
+        await SendBargeInTruncateIfApplicableAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Builds and sends a provider truncate event when all three tracking values are
+    /// populated:
+    /// <list type="bullet">
+    ///   <item><see cref="RealtimeAiSessionContext.LastAssistantItemId"/> (Phase 10.1)</item>
+    ///   <item><see cref="RealtimeAiSessionContext.LatestMediaTimestamp"/> (Phase 10.2 running clock)</item>
+    ///   <item><see cref="RealtimeAiSessionContext.ResponseStartTimestampTwilio"/> (Phase 10.2 per-turn anchor)</item>
+    /// </list>
+    /// If any is missing, skip silently — the existing Twilio <c>clear</c> frame still
+    /// stops playback immediately; we just lose the OpenAI history precision (an
+    /// acceptable degraded mode). After sending, the interrupt window for this turn
+    /// is consumed; clear the per-turn fields so a subsequent speech-detected event
+    /// can't re-truncate the same already-truncated item (which OpenAI would reject).
+    /// <see cref="RealtimeAiSessionContext.LatestMediaTimestamp"/> deliberately keeps
+    /// its value because it's the running stream clock.
+    /// </summary>
+    private async Task SendBargeInTruncateIfApplicableAsync()
+    {
+        var itemId = _ctx.LastAssistantItemId;
+        var clock = _ctx.LatestMediaTimestamp;
+        var anchor = _ctx.ResponseStartTimestampTwilio;
+
+        if (string.IsNullOrEmpty(itemId) || !clock.HasValue || !anchor.HasValue) return;
+
+        var elapsedMs = Math.Max(0L, clock.Value - anchor.Value);
+
+        var truncateMessage = _ctx.ProviderAdapter.BuildTruncateMessage(itemId, elapsedMs);
+
+        if (truncateMessage != null)
+        {
+            await SendToProviderAsync(truncateMessage).ConfigureAwait(false);
+            Log.Information("[RealtimeAi] Barge-in truncate sent, SessionId: {SessionId}, ItemId: {ItemId}, AudioEndMs: {AudioEndMs}", _ctx.SessionId, itemId, elapsedMs);
+        }
+
+        _ctx.LastAssistantItemId = null;
+        _ctx.ResponseStartTimestampTwilio = null;
     }
 
     private async Task OnAiTurnCompletedAsync()

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Services/RealtimeAiService.Orchestration.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Services/RealtimeAiService.Orchestration.cs
@@ -67,6 +67,14 @@ public partial class RealtimeAiService
         {
             var parsed = _ctx.ClientAdapter.ParseMessage(rawMessage);
 
+            // Twilio populates this on every media frame; web / default clients leave it
+            // null and we keep whatever value the previous Twilio frame deposited. The
+            // value drives Phase 10.3's audio_end_ms truncate calculation, so updating
+            // before the dispatch switch is intentional — even messages we don't act on
+            // (e.g. video frames) advance the stream clock.
+            if (parsed.Timestamp.HasValue)
+                _ctx.LatestMediaTimestamp = parsed.Timestamp.Value;
+
             switch (parsed.Type)
             {
                 case RealtimeAiClientMessageType.Start:

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Services/RealtimeAiService.Orchestration.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Services/RealtimeAiService.Orchestration.cs
@@ -67,11 +67,8 @@ public partial class RealtimeAiService
         {
             var parsed = _ctx.ClientAdapter.ParseMessage(rawMessage);
 
-            // Twilio populates this on every media frame; web / default clients leave it
-            // null and we keep whatever value the previous Twilio frame deposited. The
-            // value drives Phase 10.3's audio_end_ms truncate calculation, so updating
-            // before the dispatch switch is intentional — even messages we don't act on
-            // (e.g. video frames) advance the stream clock.
+            // Advance the stream clock for every frame that carries a timestamp, including
+            // those we don't dispatch (e.g. video).
             if (parsed.Timestamp.HasValue)
                 _ctx.LatestMediaTimestamp = parsed.Timestamp.Value;
 

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Services/RealtimeAiSessionContext.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Services/RealtimeAiSessionContext.cs
@@ -30,36 +30,10 @@ public class RealtimeAiSessionContext
     public bool IsProviderResponseInProgress;
     public bool HasPendingProviderResponseTrigger;
 
-    /// <summary>
-    /// The provider <c>item_id</c> of the AI's current in-flight assistant turn,
-    /// captured from every <see cref="Messages.Enums.RealtimeAi.RealtimeAiWssEventType.ResponseAudioDelta"/>
-    /// that carries one. Phase 10.3 will read this to build the OpenAI
-    /// <c>conversation.interrupt</c> message at user-barge-in time. <c>null</c>
-    /// between turns (cleared by <c>OnAiTurnCompletedAsync</c>) so a stale id
-    /// from a previous turn cannot be sent on the next interrupt opportunity.
-    /// Phase 10.1 wires the tracking; today no consumer reads it.
-    /// </summary>
+    // Barge-in state: item_id of the in-flight assistant turn + stream-time anchor.
+    // Both cleared after the truncate is sent or the turn completes.
     public string LastAssistantItemId { get; set; }
-
-    /// <summary>
-    /// Most recent <c>media.timestamp</c> (ms since stream start) parsed from a
-    /// client-direction media frame. Twilio populates this on every incoming
-    /// audio chunk; web / default clients leave it null because they have no
-    /// equivalent timing signal. Phase 10.3 subtracts <see cref="ResponseStartTimestampTwilio"/>
-    /// from this value to compute <c>audio_end_ms</c> for the OpenAI
-    /// <c>conversation.item.truncate</c> sent at user barge-in time.
-    /// Phase 10.2 wires the tracking; today no consumer reads it.
-    /// </summary>
     public long? LatestMediaTimestamp { get; set; }
-
-    /// <summary>
-    /// The <see cref="LatestMediaTimestamp"/> snapshot taken on the FIRST
-    /// <c>ResponseAudioDelta</c> of the current AI turn — i.e. the stream-time
-    /// at which the AI started speaking this turn. Set lazily (only when null)
-    /// to capture the first delta; cleared by <c>OnAiTurnCompletedAsync</c>
-    /// alongside <see cref="LastAssistantItemId"/>. <c>null</c> between turns
-    /// and for non-Twilio clients.
-    /// </summary>
     public long? ResponseStartTimestampTwilio { get; set; }
 
     // Recording — buffer encapsulates the previous (MemoryStream + SemaphoreSlim)

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Services/RealtimeAiSessionContext.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Services/RealtimeAiSessionContext.cs
@@ -41,6 +41,27 @@ public class RealtimeAiSessionContext
     /// </summary>
     public string LastAssistantItemId { get; set; }
 
+    /// <summary>
+    /// Most recent <c>media.timestamp</c> (ms since stream start) parsed from a
+    /// client-direction media frame. Twilio populates this on every incoming
+    /// audio chunk; web / default clients leave it null because they have no
+    /// equivalent timing signal. Phase 10.3 subtracts <see cref="ResponseStartTimestampTwilio"/>
+    /// from this value to compute <c>audio_end_ms</c> for the OpenAI
+    /// <c>conversation.item.truncate</c> sent at user barge-in time.
+    /// Phase 10.2 wires the tracking; today no consumer reads it.
+    /// </summary>
+    public long? LatestMediaTimestamp { get; set; }
+
+    /// <summary>
+    /// The <see cref="LatestMediaTimestamp"/> snapshot taken on the FIRST
+    /// <c>ResponseAudioDelta</c> of the current AI turn — i.e. the stream-time
+    /// at which the AI started speaking this turn. Set lazily (only when null)
+    /// to capture the first delta; cleared by <c>OnAiTurnCompletedAsync</c>
+    /// alongside <see cref="LastAssistantItemId"/>. <c>null</c> between turns
+    /// and for non-Twilio clients.
+    /// </summary>
+    public long? ResponseStartTimestampTwilio { get; set; }
+
     // Recording — buffer encapsulates the previous (MemoryStream + SemaphoreSlim)
     // pair behind a single interface; PR 3.2 will swap implementations via env var.
     public IRecordingBuffer AudioBuffer { get; set; }

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Services/RealtimeAiSessionContext.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Services/RealtimeAiSessionContext.cs
@@ -30,6 +30,17 @@ public class RealtimeAiSessionContext
     public bool IsProviderResponseInProgress;
     public bool HasPendingProviderResponseTrigger;
 
+    /// <summary>
+    /// The provider <c>item_id</c> of the AI's current in-flight assistant turn,
+    /// captured from every <see cref="Messages.Enums.RealtimeAi.RealtimeAiWssEventType.ResponseAudioDelta"/>
+    /// that carries one. Phase 10.3 will read this to build the OpenAI
+    /// <c>conversation.interrupt</c> message at user-barge-in time. <c>null</c>
+    /// between turns (cleared by <c>OnAiTurnCompletedAsync</c>) so a stale id
+    /// from a previous turn cannot be sent on the next interrupt opportunity.
+    /// Phase 10.1 wires the tracking; today no consumer reads it.
+    /// </summary>
+    public string LastAssistantItemId { get; set; }
+
     // Recording — buffer encapsulates the previous (MemoryStream + SemaphoreSlim)
     // pair behind a single interface; PR 3.2 will swap implementations via env var.
     public IRecordingBuffer AudioBuffer { get; set; }

--- a/src/SmartTalk.Core/Services/Webhook/TwilioWebhookService.cs
+++ b/src/SmartTalk.Core/Services/Webhook/TwilioWebhookService.cs
@@ -1,6 +1,7 @@
 using Serilog;
 using AutoMapper;
 using SmartTalk.Core.Ioc;
+using SmartTalk.Core.Utils;
 using SmartTalk.Core.Extensions;
 using SmartTalk.Messages.Dto.WeChat;
 using System.Text.RegularExpressions;
@@ -138,7 +139,7 @@ public class TwilioWebhookService : ITwilioWebhookService
 
     private async Task SendWorkWechatRobotMessagesAsync(string content, bool atAll, CancellationToken cancellationToken)
     {
-        var pacificTime = DateTimeOffset.UtcNow.ConvertFromUtc(TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time"));
+        var pacificTime = DateTimeOffset.UtcNow.ConvertFromUtc(PstTimeZone.Get());
         var currentDate = pacificTime.ToString("yyyy-MM-dd");
         var currentTime = pacificTime.ToString("HH:mm");
 

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/GoogleRealtimeAiProviderAdapterTruncateMessageTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/GoogleRealtimeAiProviderAdapterTruncateMessageTests.cs
@@ -1,0 +1,34 @@
+using Microsoft.Extensions.Configuration;
+using NSubstitute;
+using Shouldly;
+using SmartTalk.Core.Services.RealtimeAiV2.Adapters.Providers.Google;
+using SmartTalk.Core.Settings.Google;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Services.RealtimeAiV2;
+
+/// <summary>
+/// Pins that the Google adapter's <c>BuildTruncateMessage</c> returns null. Google's
+/// Live API relies on its server-side VAD to handle barge-in; sending a client-side
+/// truncate would either be ignored or generate a protocol-error log on Google's side.
+/// The caller (<c>RealtimeAiService.SendBargeInTruncateIfApplicableAsync</c>) checks
+/// for null and skips <c>SendToProviderAsync</c>, while the Twilio <c>clear</c> frame
+/// still flushes the audio buffer at the client side.
+/// </summary>
+public class GoogleRealtimeAiProviderAdapterTruncateMessageTests
+{
+    private static GoogleRealtimeAiProviderAdapter NewAdapter() =>
+        new(new GoogleSettings(Substitute.For<IConfiguration>()));
+
+    [Fact]
+    public void BuildTruncateMessage_ValidInput_ReturnsNull()
+    {
+        NewAdapter().BuildTruncateMessage("item_abc", 1500).ShouldBeNull();
+    }
+
+    [Fact]
+    public void BuildTruncateMessage_NullInput_ReturnsNull()
+    {
+        NewAdapter().BuildTruncateMessage(null, 0).ShouldBeNull();
+    }
+}

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/GoogleRealtimeAiProviderAdapterTruncateMessageTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/GoogleRealtimeAiProviderAdapterTruncateMessageTests.cs
@@ -8,12 +8,9 @@ using Xunit;
 namespace SmartTalk.UnitTests.Services.RealtimeAiV2;
 
 /// <summary>
-/// Pins that the Google adapter's <c>BuildTruncateMessage</c> returns null. Google's
-/// Live API relies on its server-side VAD to handle barge-in; sending a client-side
-/// truncate would either be ignored or generate a protocol-error log on Google's side.
-/// The caller (<c>RealtimeAiService.SendBargeInTruncateIfApplicableAsync</c>) checks
-/// for null and skips <c>SendToProviderAsync</c>, while the Twilio <c>clear</c> frame
-/// still flushes the audio buffer at the client side.
+/// Pins that the Google adapter's <c>BuildTruncateMessage</c> returns null —
+/// Google's Live API handles barge-in via server-side VAD with no client-sent
+/// truncate equivalent.
 /// </summary>
 public class GoogleRealtimeAiProviderAdapterTruncateMessageTests
 {

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterItemIdTrackingTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterItemIdTrackingTests.cs
@@ -1,0 +1,128 @@
+using Microsoft.Extensions.Configuration;
+using NSubstitute;
+using Shouldly;
+using SmartTalk.Core.Services.RealtimeAiV2.Adapters.Providers.OpenAi;
+using SmartTalk.Core.Settings.OpenAi;
+using SmartTalk.Messages.Dto.RealtimeAi;
+using SmartTalk.Messages.Enums.RealtimeAi;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Services.RealtimeAiV2;
+
+/// <summary>
+/// Pins that the V2 OpenAI adapter surfaces the per-message <c>item_id</c> on both
+/// <see cref="ParsedRealtimeAiProviderEvent.ItemId"/> and (for audio deltas)
+/// <see cref="RealtimeAiWssAudioData.ItemId"/>.
+///
+/// <para>
+/// Captured separately from the existing <c>BetaEventSunset</c> / <c>ParseMessageUsage</c>
+/// suites because those assert on event type and usage; they do not pin the
+/// <c>item_id</c> propagation, which is the regression boundary for the Phase 10
+/// barge-in work (Phase 10.3 will read <see cref="RealtimeAiSessionContext.LastAssistantItemId"/>
+/// to build the OpenAI <c>conversation.interrupt</c> message; if the adapter ever
+/// drops <c>item_id</c>, barge-in stops working silently).
+/// </para>
+/// </summary>
+public class OpenAiRealtimeAiProviderAdapterItemIdTrackingTests
+{
+    private static OpenAiRealtimeAiProviderAdapter NewAdapter() =>
+        new(new OpenAiSettings(Substitute.For<IConfiguration>()));
+
+    [Fact]
+    public void ParseMessage_ResponseAudioDeltaWithItemId_PopulatesItemIdOnAudioData()
+    {
+        var raw = """
+            {
+              "type": "response.output_audio.delta",
+              "item_id": "item_abc123",
+              "delta": "AQID"
+            }
+            """;
+
+        var parsed = NewAdapter().ParseMessage(raw);
+
+        parsed.Type.ShouldBe(RealtimeAiWssEventType.ResponseAudioDelta);
+        var audio = parsed.Data.ShouldBeOfType<RealtimeAiWssAudioData>();
+        audio.ItemId.ShouldBe("item_abc123");
+        audio.Base64Payload.ShouldBe("AQID");
+    }
+
+    [Fact]
+    public void ParseMessage_ResponseAudioDeltaWithItemId_AlsoSetsItemIdOnParsedEvent()
+    {
+        // The top-level ItemId on ParsedRealtimeAiProviderEvent must be in sync with the
+        // audio-data ItemId so that consumers reading from either path see the same value.
+        var raw = """
+            {
+              "type": "response.output_audio.delta",
+              "item_id": "item_xyz789",
+              "delta": "BAUG"
+            }
+            """;
+
+        var parsed = NewAdapter().ParseMessage(raw);
+
+        parsed.ItemId.ShouldBe("item_xyz789");
+        ((RealtimeAiWssAudioData)parsed.Data).ItemId.ShouldBe(parsed.ItemId);
+    }
+
+    [Fact]
+    public void ParseMessage_ResponseAudioDeltaWithoutItemId_LeavesItemIdNull()
+    {
+        // Defensive: providers may emit deltas without item_id (older snapshots, edge
+        // events). The adapter must not synthesize a value or crash; it must leave
+        // both fields as null so downstream consumers can detect "no id available".
+        var raw = """
+            {
+              "type": "response.output_audio.delta",
+              "delta": "AQID"
+            }
+            """;
+
+        var parsed = NewAdapter().ParseMessage(raw);
+
+        parsed.Type.ShouldBe(RealtimeAiWssEventType.ResponseAudioDelta);
+        parsed.ItemId.ShouldBeNull();
+        ((RealtimeAiWssAudioData)parsed.Data).ItemId.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ParseMessage_NonAudioEventWithItemId_PopulatesParsedEventItemId()
+    {
+        // item_id appears on non-audio events too (e.g. response.output_audio_transcript.delta).
+        // It must propagate to ParsedRealtimeAiProviderEvent.ItemId regardless of event type
+        // so Phase 10 can correlate transcripts to specific assistant items if needed.
+        var raw = """
+            {
+              "type": "response.output_audio_transcript.delta",
+              "item_id": "item_transcript_1",
+              "delta": "hello"
+            }
+            """;
+
+        var parsed = NewAdapter().ParseMessage(raw);
+
+        parsed.Type.ShouldBe(RealtimeAiWssEventType.OutputAudioTranscriptionPartial);
+        parsed.ItemId.ShouldBe("item_transcript_1");
+    }
+
+    [Fact]
+    public void ParseMessage_TurnCompletedEvent_ItemIdNotRequired()
+    {
+        // response.done events don't carry item_id at the top level; consumers must not
+        // rely on it being present for turn completion. This pins the contract so a
+        // future barge-in / cleanup refactor that incorrectly required ItemId on turn-end
+        // would surface here.
+        var raw = """
+            {
+              "type": "response.done",
+              "response": { "id": "resp_test" }
+            }
+            """;
+
+        var parsed = NewAdapter().ParseMessage(raw);
+
+        parsed.Type.ShouldBe(RealtimeAiWssEventType.ResponseTurnCompleted);
+        parsed.ItemId.ShouldBeNull();
+    }
+}

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterItemIdTrackingTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterItemIdTrackingTests.cs
@@ -10,18 +10,10 @@ using Xunit;
 namespace SmartTalk.UnitTests.Services.RealtimeAiV2;
 
 /// <summary>
-/// Pins that the V2 OpenAI adapter surfaces the per-message <c>item_id</c> on both
+/// Pins that the OpenAI adapter surfaces <c>item_id</c> on both
 /// <see cref="ParsedRealtimeAiProviderEvent.ItemId"/> and (for audio deltas)
-/// <see cref="RealtimeAiWssAudioData.ItemId"/>.
-///
-/// <para>
-/// Captured separately from the existing <c>BetaEventSunset</c> / <c>ParseMessageUsage</c>
-/// suites because those assert on event type and usage; they do not pin the
-/// <c>item_id</c> propagation, which is the regression boundary for the Phase 10
-/// barge-in work (Phase 10.3 will read <see cref="RealtimeAiSessionContext.LastAssistantItemId"/>
-/// to build the OpenAI <c>conversation.interrupt</c> message; if the adapter ever
-/// drops <c>item_id</c>, barge-in stops working silently).
-/// </para>
+/// <see cref="RealtimeAiWssAudioData.ItemId"/> — the regression boundary for
+/// barge-in: if the adapter drops <c>item_id</c>, barge-in stops working silently.
 /// </summary>
 public class OpenAiRealtimeAiProviderAdapterItemIdTrackingTests
 {
@@ -50,8 +42,7 @@ public class OpenAiRealtimeAiProviderAdapterItemIdTrackingTests
     [Fact]
     public void ParseMessage_ResponseAudioDeltaWithItemId_AlsoSetsItemIdOnParsedEvent()
     {
-        // The top-level ItemId on ParsedRealtimeAiProviderEvent must be in sync with the
-        // audio-data ItemId so that consumers reading from either path see the same value.
+        // Both surfaces must carry the same id so consumers reading either path agree.
         var raw = """
             {
               "type": "response.output_audio.delta",
@@ -69,9 +60,8 @@ public class OpenAiRealtimeAiProviderAdapterItemIdTrackingTests
     [Fact]
     public void ParseMessage_ResponseAudioDeltaWithoutItemId_LeavesItemIdNull()
     {
-        // Defensive: providers may emit deltas without item_id (older snapshots, edge
-        // events). The adapter must not synthesize a value or crash; it must leave
-        // both fields as null so downstream consumers can detect "no id available".
+        // Adapter must not synthesise a value when id is absent — consumers rely on null
+        // to detect "no id available".
         var raw = """
             {
               "type": "response.output_audio.delta",
@@ -89,9 +79,7 @@ public class OpenAiRealtimeAiProviderAdapterItemIdTrackingTests
     [Fact]
     public void ParseMessage_NonAudioEventWithItemId_PopulatesParsedEventItemId()
     {
-        // item_id appears on non-audio events too (e.g. response.output_audio_transcript.delta).
-        // It must propagate to ParsedRealtimeAiProviderEvent.ItemId regardless of event type
-        // so Phase 10 can correlate transcripts to specific assistant items if needed.
+        // item_id appears on transcript deltas too — must propagate regardless of event type.
         var raw = """
             {
               "type": "response.output_audio_transcript.delta",
@@ -109,10 +97,7 @@ public class OpenAiRealtimeAiProviderAdapterItemIdTrackingTests
     [Fact]
     public void ParseMessage_TurnCompletedEvent_ItemIdNotRequired()
     {
-        // response.done events don't carry item_id at the top level; consumers must not
-        // rely on it being present for turn completion. This pins the contract so a
-        // future barge-in / cleanup refactor that incorrectly required ItemId on turn-end
-        // would surface here.
+        // response.done carries no top-level item_id; consumers must not require it on turn-end.
         var raw = """
             {
               "type": "response.done",

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterTruncateMessageTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterTruncateMessageTests.cs
@@ -1,0 +1,89 @@
+using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json.Linq;
+using NSubstitute;
+using Shouldly;
+using SmartTalk.Core.Services.RealtimeAiV2.Adapters.Providers.OpenAi;
+using SmartTalk.Core.Settings.OpenAi;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Services.RealtimeAiV2;
+
+/// <summary>
+/// Pins the GA <c>conversation.item.truncate</c> shape built by the OpenAI V2 adapter
+/// for Phase 10.3 barge-in. If OpenAI ever rejects this payload, the Twilio <c>clear</c>
+/// frame still stops playback, but the assistant message in OpenAI's history reverts
+/// to the un-truncated form and the next turn responds as if the user heard the AI
+/// finish (subtly wrong restaurant-call context).
+/// </summary>
+public class OpenAiRealtimeAiProviderAdapterTruncateMessageTests
+{
+    private static OpenAiRealtimeAiProviderAdapter NewAdapter() =>
+        new(new OpenAiSettings(Substitute.For<IConfiguration>()));
+
+    [Fact]
+    public void BuildTruncateMessage_ValidInput_EmitsCanonicalGaShape()
+    {
+        var json = NewAdapter().BuildTruncateMessage("item_abc123", 1500);
+
+        json.ShouldNotBeNull();
+        var parsed = JObject.Parse(json);
+        parsed["type"]!.Value<string>().ShouldBe("conversation.item.truncate");
+        parsed["item_id"]!.Value<string>().ShouldBe("item_abc123");
+        parsed["content_index"]!.Value<int>().ShouldBe(0);
+        parsed["audio_end_ms"]!.Value<long>().ShouldBe(1500);
+    }
+
+    [Fact]
+    public void BuildTruncateMessage_ZeroAudioEndMs_StillEmitsZeroNotOmits()
+    {
+        // OpenAI accepts audio_end_ms = 0 (means "user interrupted before any audio
+        // played"); the field must still be present in the payload. A common refactor
+        // mistake is to treat 0 as "default" and omit the key, which OpenAI would
+        // reject as a missing required field.
+        var json = NewAdapter().BuildTruncateMessage("item_abc", 0);
+
+        var parsed = JObject.Parse(json!);
+        parsed["audio_end_ms"]!.Value<long>().ShouldBe(0);
+    }
+
+    [Fact]
+    public void BuildTruncateMessage_NegativeAudioEndMs_ClampsToZero()
+    {
+        // Service-side caller already clamps, but the adapter guards too — a faulty
+        // future consumer that bypassed the clamp must not ship a payload OpenAI
+        // would reject.
+        var json = NewAdapter().BuildTruncateMessage("item_abc", -42);
+
+        var parsed = JObject.Parse(json!);
+        parsed["audio_end_ms"]!.Value<long>().ShouldBe(0);
+    }
+
+    [Fact]
+    public void BuildTruncateMessage_NullItemId_ReturnsNull()
+    {
+        // Sending the event without item_id would be rejected by the GA server.
+        // Returning null lets the caller skip SendToProviderAsync without a warning
+        // (the per-turn anchor may also be null in this case, e.g. cold session).
+        NewAdapter().BuildTruncateMessage(null, 100).ShouldBeNull();
+    }
+
+    [Fact]
+    public void BuildTruncateMessage_EmptyItemId_ReturnsNull()
+    {
+        // Empty string is treated identically to null — both indicate "no in-flight
+        // assistant turn to truncate". The skip is silent to avoid noise on every
+        // user-speech-detected event during cold-session warm-up.
+        NewAdapter().BuildTruncateMessage("", 100).ShouldBeNull();
+    }
+
+    [Fact]
+    public void BuildTruncateMessage_LargeAudioEndMs_RoundTripsExact()
+    {
+        // Long-running calls (hour-plus restaurant queues) can push audio_end_ms beyond
+        // int range. Pin that the long path holds without precision loss.
+        var json = NewAdapter().BuildTruncateMessage("item_long", 9_000_000_000L);
+
+        var parsed = JObject.Parse(json!);
+        parsed["audio_end_ms"]!.Value<long>().ShouldBe(9_000_000_000L);
+    }
+}

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterTruncateMessageTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterTruncateMessageTests.cs
@@ -9,11 +9,9 @@ using Xunit;
 namespace SmartTalk.UnitTests.Services.RealtimeAiV2;
 
 /// <summary>
-/// Pins the GA <c>conversation.item.truncate</c> shape built by the OpenAI V2 adapter
-/// for Phase 10.3 barge-in. If OpenAI ever rejects this payload, the Twilio <c>clear</c>
-/// frame still stops playback, but the assistant message in OpenAI's history reverts
-/// to the un-truncated form and the next turn responds as if the user heard the AI
-/// finish (subtly wrong restaurant-call context).
+/// Pins the GA <c>conversation.item.truncate</c> shape built by the OpenAI adapter
+/// at user barge-in. Wrong payload → OpenAI rejects → next turn responds as if the
+/// user heard the full AI utterance (subtly wrong restaurant-call context).
 /// </summary>
 public class OpenAiRealtimeAiProviderAdapterTruncateMessageTests
 {
@@ -36,10 +34,7 @@ public class OpenAiRealtimeAiProviderAdapterTruncateMessageTests
     [Fact]
     public void BuildTruncateMessage_ZeroAudioEndMs_StillEmitsZeroNotOmits()
     {
-        // OpenAI accepts audio_end_ms = 0 (means "user interrupted before any audio
-        // played"); the field must still be present in the payload. A common refactor
-        // mistake is to treat 0 as "default" and omit the key, which OpenAI would
-        // reject as a missing required field.
+        // OpenAI accepts 0; the field must still be present (don't treat 0 as "default and omit").
         var json = NewAdapter().BuildTruncateMessage("item_abc", 0);
 
         var parsed = JObject.Parse(json!);
@@ -49,9 +44,7 @@ public class OpenAiRealtimeAiProviderAdapterTruncateMessageTests
     [Fact]
     public void BuildTruncateMessage_NegativeAudioEndMs_ClampsToZero()
     {
-        // Service-side caller already clamps, but the adapter guards too — a faulty
-        // future consumer that bypassed the clamp must not ship a payload OpenAI
-        // would reject.
+        // Adapter clamps even though the caller already does — defensive against future consumers.
         var json = NewAdapter().BuildTruncateMessage("item_abc", -42);
 
         var parsed = JObject.Parse(json!);
@@ -61,26 +54,19 @@ public class OpenAiRealtimeAiProviderAdapterTruncateMessageTests
     [Fact]
     public void BuildTruncateMessage_NullItemId_ReturnsNull()
     {
-        // Sending the event without item_id would be rejected by the GA server.
-        // Returning null lets the caller skip SendToProviderAsync without a warning
-        // (the per-turn anchor may also be null in this case, e.g. cold session).
         NewAdapter().BuildTruncateMessage(null, 100).ShouldBeNull();
     }
 
     [Fact]
     public void BuildTruncateMessage_EmptyItemId_ReturnsNull()
     {
-        // Empty string is treated identically to null — both indicate "no in-flight
-        // assistant turn to truncate". The skip is silent to avoid noise on every
-        // user-speech-detected event during cold-session warm-up.
         NewAdapter().BuildTruncateMessage("", 100).ShouldBeNull();
     }
 
     [Fact]
     public void BuildTruncateMessage_LargeAudioEndMs_RoundTripsExact()
     {
-        // Long-running calls (hour-plus restaurant queues) can push audio_end_ms beyond
-        // int range. Pin that the long path holds without precision loss.
+        // Long calls can exceed int range — pin the long path to keep precision.
         var json = NewAdapter().BuildTruncateMessage("item_long", 9_000_000_000L);
 
         var parsed = JObject.Parse(json!);

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/RealtimeAiServiceBargeInTruncateTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/RealtimeAiServiceBargeInTruncateTests.cs
@@ -1,0 +1,261 @@
+using NSubstitute;
+using Shouldly;
+using SmartTalk.Core.Services.RealtimeAiV2.Adapters;
+using SmartTalk.Messages.Dto.RealtimeAi;
+using SmartTalk.Messages.Enums.RealtimeAi;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Services.RealtimeAiV2;
+
+/// <summary>
+/// End-to-end pins for Phase 10.3 V2 barge-in. Exercises the full
+/// <c>OnAiDetectedUserSpeechAsync</c> path with item_id (Phase 10.1),
+/// LatestMediaTimestamp + ResponseStartTimestampTwilio (Phase 10.2)
+/// already populated by upstream events, and asserts the provider
+/// <c>BuildTruncateMessage</c> is called with the elapsed-time math
+/// — the regression boundary for restaurant calls where users barge
+/// in mid-greeting and OpenAI's conversation history must stay aligned
+/// with what the user actually heard.
+/// </summary>
+public class RealtimeAiServiceBargeInTruncateTests : RealtimeAiServiceTestBase
+{
+    [Fact]
+    public async Task SpeechDetected_AfterAiSpokeWithItemIdAndTimestamps_SendsTruncate()
+    {
+        const string itemId = "item_barge_in";
+        const long clientStartTimestamp = 1000;
+        const long clientEndTimestamp = 1750;
+        const long expectedElapsedMs = 750;
+
+        var providerCall = 0;
+        ProviderAdapter.ParseMessage(Arg.Any<string>())
+            .Returns(_ =>
+            {
+                providerCall++;
+                return providerCall == 1
+                    ? new ParsedRealtimeAiProviderEvent
+                    {
+                        Type = RealtimeAiWssEventType.ResponseAudioDelta,
+                        Data = new RealtimeAiWssAudioData { Base64Payload = "AQID", ItemId = itemId }
+                    }
+                    : new ParsedRealtimeAiProviderEvent { Type = RealtimeAiWssEventType.SpeechDetected };
+            });
+
+        var clientCall = 0;
+        ClientAdapter.ParseMessage(Arg.Any<string>())
+            .Returns(_ =>
+            {
+                clientCall++;
+                return new ParsedClientMessage
+                {
+                    Type = RealtimeAiClientMessageType.Audio,
+                    Payload = "AQID",
+                    Timestamp = clientCall == 1 ? clientStartTimestamp : clientEndTimestamp
+                };
+            });
+
+        ProviderAdapter.BuildTruncateMessage(Arg.Any<string>(), Arg.Any<long>()).Returns("{}");
+
+        var sessionTask = await StartSessionInBackgroundAsync();
+
+        // 1. User audio @ ts=1000 → LatestMediaTimestamp = 1000
+        FakeWs.EnqueueClientMessage("{\"media\":{\"payload\":\"x\",\"timestamp\":\"1000\"}}");
+        await Task.Delay(50);
+
+        // 2. AI audio delta with item_id → LastAssistantItemId set, anchor = 1000
+        await FakeWssClient.SimulateMessageReceivedAsync("{\"type\":\"response.output_audio.delta\"}");
+        await Task.Delay(50);
+
+        // 3. User audio @ ts=1750 → LatestMediaTimestamp = 1750
+        FakeWs.EnqueueClientMessage("{\"media\":{\"payload\":\"y\",\"timestamp\":\"1750\"}}");
+        await Task.Delay(50);
+
+        // 4. SpeechDetected → barge-in: BuildTruncateMessage(itemId, 1750-1000=750)
+        await FakeWssClient.SimulateMessageReceivedAsync("{\"type\":\"input_audio_buffer.speech_started\"}");
+        await Task.Delay(100);
+
+        FakeWs.EnqueueClose();
+        await sessionTask;
+
+        ProviderAdapter.Received(1).BuildTruncateMessage(itemId, expectedElapsedMs);
+    }
+
+    [Fact]
+    public async Task SpeechDetected_WithoutPriorAiAudio_DoesNotSendTruncate()
+    {
+        // Cold-session edge case: user starts speaking before AI has produced any
+        // audio. LastAssistantItemId stays null; truncate must be skipped silently.
+        ProviderAdapter.ParseMessage(Arg.Any<string>())
+            .Returns(new ParsedRealtimeAiProviderEvent { Type = RealtimeAiWssEventType.SpeechDetected });
+
+        ClientAdapter.ParseMessage(Arg.Any<string>())
+            .Returns(new ParsedClientMessage { Type = RealtimeAiClientMessageType.Audio, Payload = "AQID", Timestamp = 1000 });
+
+        var sessionTask = await StartSessionInBackgroundAsync();
+
+        FakeWs.EnqueueClientMessage("{\"media\":{\"payload\":\"x\",\"timestamp\":\"1000\"}}");
+        await Task.Delay(50);
+
+        await FakeWssClient.SimulateMessageReceivedAsync("{\"type\":\"input_audio_buffer.speech_started\"}");
+        await Task.Delay(50);
+
+        FakeWs.EnqueueClose();
+        await sessionTask;
+
+        ProviderAdapter.DidNotReceive().BuildTruncateMessage(Arg.Any<string>(), Arg.Any<long>());
+    }
+
+    [Fact]
+    public async Task SpeechDetected_AiSpokeButNoClientTimestamp_DoesNotSendTruncate()
+    {
+        // Web (DefaultRealtimeAiClientAdapter) does not surface a stream clock. Without
+        // LatestMediaTimestamp the per-turn anchor never gets set, so the elapsed-time
+        // math has no input — skip the truncate rather than ship a bogus offset.
+        var providerCall = 0;
+        ProviderAdapter.ParseMessage(Arg.Any<string>())
+            .Returns(_ =>
+            {
+                providerCall++;
+                return providerCall == 1
+                    ? new ParsedRealtimeAiProviderEvent
+                    {
+                        Type = RealtimeAiWssEventType.ResponseAudioDelta,
+                        Data = new RealtimeAiWssAudioData { Base64Payload = "AQID", ItemId = "item_test" }
+                    }
+                    : new ParsedRealtimeAiProviderEvent { Type = RealtimeAiWssEventType.SpeechDetected };
+            });
+
+        ClientAdapter.ParseMessage(Arg.Any<string>())
+            .Returns(new ParsedClientMessage { Type = RealtimeAiClientMessageType.Audio, Payload = "AQID" /* no Timestamp */ });
+
+        var sessionTask = await StartSessionInBackgroundAsync();
+
+        FakeWs.EnqueueClientMessage("{\"media\":{\"payload\":\"x\"}}");
+        await Task.Delay(50);
+
+        await FakeWssClient.SimulateMessageReceivedAsync("{\"type\":\"response.output_audio.delta\"}");
+        await Task.Delay(50);
+
+        await FakeWssClient.SimulateMessageReceivedAsync("{\"type\":\"input_audio_buffer.speech_started\"}");
+        await Task.Delay(50);
+
+        FakeWs.EnqueueClose();
+        await sessionTask;
+
+        ProviderAdapter.DidNotReceive().BuildTruncateMessage(Arg.Any<string>(), Arg.Any<long>());
+    }
+
+    [Fact]
+    public async Task SpeechDetectedTwiceInARow_OnlyTruncatesOnce()
+    {
+        // After a successful truncate the per-turn fields are cleared so a second
+        // speech-detected within the same turn can't re-truncate the now-already-truncated
+        // item (OpenAI would error). Pin this so a future refactor of the cleanup
+        // doesn't reintroduce double-truncate.
+        const string itemId = "item_once";
+
+        var providerCall = 0;
+        ProviderAdapter.ParseMessage(Arg.Any<string>())
+            .Returns(_ =>
+            {
+                providerCall++;
+                return providerCall == 1
+                    ? new ParsedRealtimeAiProviderEvent
+                    {
+                        Type = RealtimeAiWssEventType.ResponseAudioDelta,
+                        Data = new RealtimeAiWssAudioData { Base64Payload = "AQID", ItemId = itemId }
+                    }
+                    : new ParsedRealtimeAiProviderEvent { Type = RealtimeAiWssEventType.SpeechDetected };
+            });
+
+        ClientAdapter.ParseMessage(Arg.Any<string>())
+            .Returns(new ParsedClientMessage { Type = RealtimeAiClientMessageType.Audio, Payload = "AQID", Timestamp = 500 });
+
+        ProviderAdapter.BuildTruncateMessage(Arg.Any<string>(), Arg.Any<long>()).Returns("{}");
+
+        var sessionTask = await StartSessionInBackgroundAsync();
+
+        FakeWs.EnqueueClientMessage("{\"media\":{\"payload\":\"x\",\"timestamp\":\"500\"}}");
+        await Task.Delay(50);
+
+        await FakeWssClient.SimulateMessageReceivedAsync("{\"type\":\"response.output_audio.delta\"}");
+        await Task.Delay(50);
+
+        // First barge-in
+        await FakeWssClient.SimulateMessageReceivedAsync("{\"type\":\"input_audio_buffer.speech_started\"}");
+        await Task.Delay(50);
+
+        // Second barge-in (no new AI delta in between)
+        await FakeWssClient.SimulateMessageReceivedAsync("{\"type\":\"input_audio_buffer.speech_started\"}");
+        await Task.Delay(50);
+
+        FakeWs.EnqueueClose();
+        await sessionTask;
+
+        ProviderAdapter.Received(1).BuildTruncateMessage(itemId, Arg.Any<long>());
+    }
+
+    [Fact]
+    public async Task SpeechDetected_AcrossTurns_TruncatesEachTurnIndependently()
+    {
+        // Two complete turns of AI speech, each interrupted. Both must emit a truncate
+        // with their own item_id and elapsed time — confirms the per-turn anchor
+        // re-arms after OnAiTurnCompletedAsync clears it.
+        var providerCall = 0;
+        ProviderAdapter.ParseMessage(Arg.Any<string>())
+            .Returns(_ =>
+            {
+                providerCall++;
+                return providerCall switch
+                {
+                    1 => new ParsedRealtimeAiProviderEvent
+                    {
+                        Type = RealtimeAiWssEventType.ResponseAudioDelta,
+                        Data = new RealtimeAiWssAudioData { Base64Payload = "AQID", ItemId = "item_turn_1" }
+                    },
+                    2 => new ParsedRealtimeAiProviderEvent
+                    {
+                        Type = RealtimeAiWssEventType.ResponseTurnCompleted,
+                        Data = new List<RealtimeAiWssFunctionCallData>()
+                    },
+                    3 => new ParsedRealtimeAiProviderEvent
+                    {
+                        Type = RealtimeAiWssEventType.ResponseAudioDelta,
+                        Data = new RealtimeAiWssAudioData { Base64Payload = "AQID", ItemId = "item_turn_2" }
+                    },
+                    _ => new ParsedRealtimeAiProviderEvent { Type = RealtimeAiWssEventType.SpeechDetected }
+                };
+            });
+
+        ClientAdapter.ParseMessage(Arg.Any<string>())
+            .Returns(new ParsedClientMessage { Type = RealtimeAiClientMessageType.Audio, Payload = "AQID", Timestamp = 100 });
+
+        ProviderAdapter.BuildTruncateMessage(Arg.Any<string>(), Arg.Any<long>()).Returns("{}");
+
+        var sessionTask = await StartSessionInBackgroundAsync();
+
+        // Clock established
+        FakeWs.EnqueueClientMessage("{\"media\":{\"payload\":\"x\",\"timestamp\":\"100\"}}");
+        await Task.Delay(50);
+
+        // Turn 1: AI delta + completed
+        await FakeWssClient.SimulateMessageReceivedAsync("{\"type\":\"response.output_audio.delta\"}");
+        await Task.Delay(50);
+        await FakeWssClient.SimulateMessageReceivedAsync("{\"type\":\"response.done\"}");
+        await Task.Delay(50);
+
+        // Turn 2: AI delta then barge-in
+        await FakeWssClient.SimulateMessageReceivedAsync("{\"type\":\"response.output_audio.delta\"}");
+        await Task.Delay(50);
+        await FakeWssClient.SimulateMessageReceivedAsync("{\"type\":\"input_audio_buffer.speech_started\"}");
+        await Task.Delay(50);
+
+        FakeWs.EnqueueClose();
+        await sessionTask;
+
+        // Only turn 2's item_id should be truncated — turn 1 was completed normally
+        // and its anchor was cleared by OnAiTurnCompletedAsync.
+        ProviderAdapter.Received(1).BuildTruncateMessage("item_turn_2", Arg.Any<long>());
+        ProviderAdapter.DidNotReceive().BuildTruncateMessage("item_turn_1", Arg.Any<long>());
+    }
+}

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/RealtimeAiServiceBargeInTruncateTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/RealtimeAiServiceBargeInTruncateTests.cs
@@ -8,14 +8,11 @@ using Xunit;
 namespace SmartTalk.UnitTests.Services.RealtimeAiV2;
 
 /// <summary>
-/// End-to-end pins for Phase 10.3 V2 barge-in. Exercises the full
-/// <c>OnAiDetectedUserSpeechAsync</c> path with item_id (Phase 10.1),
-/// LatestMediaTimestamp + ResponseStartTimestampTwilio (Phase 10.2)
-/// already populated by upstream events, and asserts the provider
-/// <c>BuildTruncateMessage</c> is called with the elapsed-time math
-/// — the regression boundary for restaurant calls where users barge
-/// in mid-greeting and OpenAI's conversation history must stay aligned
-/// with what the user actually heard.
+/// End-to-end pins for V2 user-barge-in. Drives the full
+/// <c>OnAiDetectedUserSpeechAsync</c> path with item_id + clock + anchor populated
+/// by upstream events and asserts the provider truncate is built with the right
+/// elapsed-time math — the regression boundary for mid-greeting barge-ins where
+/// OpenAI's history must stay aligned with what the user actually heard.
 /// </summary>
 public class RealtimeAiServiceBargeInTruncateTests : RealtimeAiServiceTestBase
 {
@@ -83,8 +80,7 @@ public class RealtimeAiServiceBargeInTruncateTests : RealtimeAiServiceTestBase
     [Fact]
     public async Task SpeechDetected_WithoutPriorAiAudio_DoesNotSendTruncate()
     {
-        // Cold-session edge case: user starts speaking before AI has produced any
-        // audio. LastAssistantItemId stays null; truncate must be skipped silently.
+        // Cold session: user speaks before AI produced any audio → LastAssistantItemId null → skip.
         ProviderAdapter.ParseMessage(Arg.Any<string>())
             .Returns(new ParsedRealtimeAiProviderEvent { Type = RealtimeAiWssEventType.SpeechDetected });
 
@@ -108,9 +104,7 @@ public class RealtimeAiServiceBargeInTruncateTests : RealtimeAiServiceTestBase
     [Fact]
     public async Task SpeechDetected_AiSpokeButNoClientTimestamp_DoesNotSendTruncate()
     {
-        // Web (DefaultRealtimeAiClientAdapter) does not surface a stream clock. Without
-        // LatestMediaTimestamp the per-turn anchor never gets set, so the elapsed-time
-        // math has no input — skip the truncate rather than ship a bogus offset.
+        // Web client has no stream clock → anchor never sets → skip rather than ship a bogus offset.
         var providerCall = 0;
         ProviderAdapter.ParseMessage(Arg.Any<string>())
             .Returns(_ =>
@@ -148,10 +142,8 @@ public class RealtimeAiServiceBargeInTruncateTests : RealtimeAiServiceTestBase
     [Fact]
     public async Task SpeechDetectedTwiceInARow_OnlyTruncatesOnce()
     {
-        // After a successful truncate the per-turn fields are cleared so a second
-        // speech-detected within the same turn can't re-truncate the now-already-truncated
-        // item (OpenAI would error). Pin this so a future refactor of the cleanup
-        // doesn't reintroduce double-truncate.
+        // After truncate the per-turn fields are cleared so a second speech-detected
+        // in the same turn cannot re-truncate the already-truncated item.
         const string itemId = "item_once";
 
         var providerCall = 0;
@@ -198,9 +190,7 @@ public class RealtimeAiServiceBargeInTruncateTests : RealtimeAiServiceTestBase
     [Fact]
     public async Task SpeechDetected_AcrossTurns_TruncatesEachTurnIndependently()
     {
-        // Two complete turns of AI speech, each interrupted. Both must emit a truncate
-        // with their own item_id and elapsed time — confirms the per-turn anchor
-        // re-arms after OnAiTurnCompletedAsync clears it.
+        // Each turn's anchor re-arms after OnAiTurnCompletedAsync clears it.
         var providerCall = 0;
         ProviderAdapter.ParseMessage(Arg.Any<string>())
             .Returns(_ =>
@@ -253,8 +243,7 @@ public class RealtimeAiServiceBargeInTruncateTests : RealtimeAiServiceTestBase
         FakeWs.EnqueueClose();
         await sessionTask;
 
-        // Only turn 2's item_id should be truncated — turn 1 was completed normally
-        // and its anchor was cleared by OnAiTurnCompletedAsync.
+        // Only turn 2's item_id is truncated — turn 1 completed normally so its anchor was cleared.
         ProviderAdapter.Received(1).BuildTruncateMessage("item_turn_2", Arg.Any<long>());
         ProviderAdapter.DidNotReceive().BuildTruncateMessage("item_turn_1", Arg.Any<long>());
     }

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/TwilioRealtimeAiClientAdapterMediaTimestampTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/TwilioRealtimeAiClientAdapterMediaTimestampTests.cs
@@ -1,0 +1,141 @@
+using Shouldly;
+using SmartTalk.Core.Services.RealtimeAiV2.Adapters;
+using SmartTalk.Core.Services.RealtimeAiV2.Adapters.Clients.Twilio;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Services.RealtimeAiV2;
+
+/// <summary>
+/// Pins that the Twilio client adapter surfaces <c>media.timestamp</c> on
+/// <see cref="SmartTalk.Core.Services.RealtimeAiV2.Adapters.ParsedClientMessage.Timestamp"/>.
+///
+/// <para>
+/// Phase 10.3 will use the running <c>_ctx.LatestMediaTimestamp</c> minus the per-turn
+/// <c>_ctx.ResponseStartTimestampTwilio</c> snapshot to compute <c>audio_end_ms</c> for
+/// the OpenAI <c>conversation.item.truncate</c> sent at user barge-in time. If the
+/// adapter ever stopped extracting <c>media.timestamp</c>, barge-in would still fire
+/// (the Twilio <c>clear</c> event already stops playback), but the conversation
+/// history sent to OpenAI for the next turn would carry the un-truncated assistant
+/// utterance and confuse subsequent prompt context.
+/// </para>
+/// </summary>
+public class TwilioRealtimeAiClientAdapterMediaTimestampTests
+{
+    private static TwilioRealtimeAiClientAdapter NewAdapter() => new();
+
+    [Fact]
+    public void ParseMessage_MediaWithStringTimestamp_PopulatesTimestamp()
+    {
+        // Canonical Twilio shape per Media Streams docs: timestamp is a string of
+        // milliseconds since the stream started.
+        const string raw = """
+            {
+              "event": "media",
+              "streamSid": "MZ-test",
+              "media": { "payload": "AQID", "timestamp": "1234" }
+            }
+            """;
+
+        var parsed = NewAdapter().ParseMessage(raw);
+
+        parsed.Type.ShouldBe(RealtimeAiClientMessageType.Audio);
+        parsed.Timestamp.ShouldBe(1234L);
+    }
+
+    [Fact]
+    public void ParseMessage_MediaWithNumericTimestamp_PopulatesTimestamp()
+    {
+        // Real-world payloads occasionally surface the numeric form (older preview
+        // snapshots, future protocol revisions). Accept both rather than silently
+        // dropping one variant — the audio payload is too critical to lose.
+        const string raw = """
+            {
+              "event": "media",
+              "streamSid": "MZ-test",
+              "media": { "payload": "AQID", "timestamp": 4567 }
+            }
+            """;
+
+        var parsed = NewAdapter().ParseMessage(raw);
+
+        parsed.Type.ShouldBe(RealtimeAiClientMessageType.Audio);
+        parsed.Timestamp.ShouldBe(4567L);
+    }
+
+    [Fact]
+    public void ParseMessage_MediaWithoutTimestamp_LeavesTimestampNull()
+    {
+        // Some Twilio snapshots / connect-flow setups don't include timestamp.
+        // The adapter must not synthesise one (would break Phase 10.3 elapsed math).
+        const string raw = """
+            {
+              "event": "media",
+              "streamSid": "MZ-test",
+              "media": { "payload": "AQID" }
+            }
+            """;
+
+        var parsed = NewAdapter().ParseMessage(raw);
+
+        parsed.Type.ShouldBe(RealtimeAiClientMessageType.Audio);
+        parsed.Timestamp.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ParseMessage_MediaWithNonNumericStringTimestamp_LeavesTimestampNull()
+    {
+        // Malformed timestamp string must not drop the audio frame. The payload is
+        // delivered (Type = Audio, Payload is populated); only Timestamp is null.
+        const string raw = """
+            {
+              "event": "media",
+              "streamSid": "MZ-test",
+              "media": { "payload": "AQID", "timestamp": "not-a-number" }
+            }
+            """;
+
+        var parsed = NewAdapter().ParseMessage(raw);
+
+        parsed.Type.ShouldBe(RealtimeAiClientMessageType.Audio);
+        parsed.Payload.ShouldBe("AQID");
+        parsed.Timestamp.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ParseMessage_StartEvent_LeavesTimestampNull()
+    {
+        // Lifecycle events don't carry timestamp; the field must stay null so the
+        // service doesn't accidentally clobber LatestMediaTimestamp with zero between
+        // genuine media frames.
+        const string raw = """
+            {
+              "event": "start",
+              "start": { "streamSid": "MZ-test", "callSid": "CA-test" }
+            }
+            """;
+
+        var parsed = NewAdapter().ParseMessage(raw);
+
+        parsed.Type.ShouldBe(RealtimeAiClientMessageType.Start);
+        parsed.Timestamp.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ParseMessage_VideoMediaWithTimestamp_PopulatesTimestamp()
+    {
+        // Image frames also advance the stream clock. They go to a different handler
+        // but must still update LatestMediaTimestamp via the parser surface.
+        const string raw = """
+            {
+              "event": "media",
+              "streamSid": "MZ-test",
+              "media": { "payload": "AQID", "type": "video", "timestamp": "9999" }
+            }
+            """;
+
+        var parsed = NewAdapter().ParseMessage(raw);
+
+        parsed.Type.ShouldBe(RealtimeAiClientMessageType.Image);
+        parsed.Timestamp.ShouldBe(9999L);
+    }
+}

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/TwilioRealtimeAiClientAdapterMediaTimestampTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/TwilioRealtimeAiClientAdapterMediaTimestampTests.cs
@@ -6,18 +6,10 @@ using Xunit;
 namespace SmartTalk.UnitTests.Services.RealtimeAiV2;
 
 /// <summary>
-/// Pins that the Twilio client adapter surfaces <c>media.timestamp</c> on
-/// <see cref="SmartTalk.Core.Services.RealtimeAiV2.Adapters.ParsedClientMessage.Timestamp"/>.
-///
-/// <para>
-/// Phase 10.3 will use the running <c>_ctx.LatestMediaTimestamp</c> minus the per-turn
-/// <c>_ctx.ResponseStartTimestampTwilio</c> snapshot to compute <c>audio_end_ms</c> for
-/// the OpenAI <c>conversation.item.truncate</c> sent at user barge-in time. If the
-/// adapter ever stopped extracting <c>media.timestamp</c>, barge-in would still fire
-/// (the Twilio <c>clear</c> event already stops playback), but the conversation
-/// history sent to OpenAI for the next turn would carry the un-truncated assistant
-/// utterance and confuse subsequent prompt context.
-/// </para>
+/// Pins that the Twilio adapter surfaces <c>media.timestamp</c> on
+/// <see cref="ParsedClientMessage.Timestamp"/> — the input to the barge-in elapsed-time
+/// calculation. Losing this field would silently un-truncate OpenAI's conversation
+/// history.
 /// </summary>
 public class TwilioRealtimeAiClientAdapterMediaTimestampTests
 {
@@ -26,8 +18,7 @@ public class TwilioRealtimeAiClientAdapterMediaTimestampTests
     [Fact]
     public void ParseMessage_MediaWithStringTimestamp_PopulatesTimestamp()
     {
-        // Canonical Twilio shape per Media Streams docs: timestamp is a string of
-        // milliseconds since the stream started.
+        // Canonical Twilio shape: timestamp is a string of ms since stream start.
         const string raw = """
             {
               "event": "media",
@@ -45,9 +36,7 @@ public class TwilioRealtimeAiClientAdapterMediaTimestampTests
     [Fact]
     public void ParseMessage_MediaWithNumericTimestamp_PopulatesTimestamp()
     {
-        // Real-world payloads occasionally surface the numeric form (older preview
-        // snapshots, future protocol revisions). Accept both rather than silently
-        // dropping one variant — the audio payload is too critical to lose.
+        // Numeric form occasionally appears in real payloads — accept it as well as the doc'd string form.
         const string raw = """
             {
               "event": "media",
@@ -65,8 +54,7 @@ public class TwilioRealtimeAiClientAdapterMediaTimestampTests
     [Fact]
     public void ParseMessage_MediaWithoutTimestamp_LeavesTimestampNull()
     {
-        // Some Twilio snapshots / connect-flow setups don't include timestamp.
-        // The adapter must not synthesise one (would break Phase 10.3 elapsed math).
+        // Adapter must not synthesise a timestamp when absent — would break elapsed math.
         const string raw = """
             {
               "event": "media",
@@ -84,8 +72,7 @@ public class TwilioRealtimeAiClientAdapterMediaTimestampTests
     [Fact]
     public void ParseMessage_MediaWithNonNumericStringTimestamp_LeavesTimestampNull()
     {
-        // Malformed timestamp string must not drop the audio frame. The payload is
-        // delivered (Type = Audio, Payload is populated); only Timestamp is null.
+        // Malformed timestamp must not drop the audio frame — payload is delivered, only Timestamp is null.
         const string raw = """
             {
               "event": "media",
@@ -104,9 +91,7 @@ public class TwilioRealtimeAiClientAdapterMediaTimestampTests
     [Fact]
     public void ParseMessage_StartEvent_LeavesTimestampNull()
     {
-        // Lifecycle events don't carry timestamp; the field must stay null so the
-        // service doesn't accidentally clobber LatestMediaTimestamp with zero between
-        // genuine media frames.
+        // Lifecycle events have no timestamp — must stay null so they don't clobber the running clock.
         const string raw = """
             {
               "event": "start",
@@ -123,8 +108,7 @@ public class TwilioRealtimeAiClientAdapterMediaTimestampTests
     [Fact]
     public void ParseMessage_VideoMediaWithTimestamp_PopulatesTimestamp()
     {
-        // Image frames also advance the stream clock. They go to a different handler
-        // but must still update LatestMediaTimestamp via the parser surface.
+        // Video frames advance the stream clock too — different handler, same parser surface.
         const string raw = """
             {
               "event": "media",


### PR DESCRIPTION
## Summary

Base branch for the Round 3 V2 stability and perf improvements. **No production code in this PR yet** — each Phase / feature lands as its own PR targeting this branch. When the collection has been observed in staging for ≥ 48h with no regression, this branch merges into main as a single atomic batch (same pattern as Round 1 #922 and Round 2 #950).

## Scope (planned sub-PRs)

Carries forward the remaining items from the original 23-PR roadmap, prioritised by risk × value:

- **Phase 4.1-redo** — re-investigate and re-land the per-assistant config plumbing that was reverted in #948
- **Phase 5.2 / 5.3 / 5.4 / 5.5** — remaining Realtime API opt-ins (semantic VAD, noise reduction, temperature, voice extensions)
- **Phase 6.1–6.7** — function call output structured-response abstraction (one base PR + per-function follow-ups)
- **Phase 7.2** — parallel knowledge fetch via `Task.WhenAll` (cascade already preserved by #961)
- **Phase 8.1 / 8.2** — Tools/TurnDetect config cache + prompt token regex consolidation
- **Phase 10.1 / 10.2 / 10.3** — OpenAI `item_id` tracking, Twilio mark queue, full barge-in

## Storage / rollout pattern (carried over from Round 2)

- Reuses `ai_speech_assistant_function_call` per-assistant config-map table; new knobs are new `AiSpeechAssistantSessionConfigType` enum values — no `ALTER TABLE` per knob
- NULL row (existing prod state) → adapter uses today's hard-coded default → byte-equivalent output
- Non-null row → per-assistant override activates
- Rollback per-assistant, per-knob via `is_active = false`

## Sub-PR convention

- Each sub-PR targets this branch (`feat/v2-stability-perf-round-3`), not `main`
- No direct commits to this branch — everything lands via PR + merge
- Each sub-PR ships its own tests proving the all-null path remains byte-equivalent to current prod
- Planning / tracking docs stay out of the repo (in `docs/` local; see `docs/v2-stability-perf-rollout-plan.md`)

## Test plan

- [ ] Each sub-PR: full unit suite green + targeted tests for the new behaviour
- [ ] Staging observation ≥ 48h with no regression before merging this base into main