### PR TITLE
Consolidate FindSystemTimeZoneById callers onto PstTimeZone helper

### DIFF
--- a/src/SmartTalk.Core/Domain/Account/UserAccount.cs
+++ b/src/SmartTalk.Core/Domain/Account/UserAccount.cs
@@ -3,6 +3,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 using SmartTalk.Core.Domain.Pos;
 using SmartTalk.Core.Domain.Security;
 using SmartTalk.Core.Domain.System;
+using SmartTalk.Core.Utils;
 using SmartTalk.Messages.Dto.Agent;
 using SmartTalk.Messages.Dto.Pos;
 using SmartTalk.Messages.Enums;
@@ -17,7 +18,7 @@ namespace SmartTalk.Core.Domain.Account
         public UserAccount()
         {
             Uuid = Guid.NewGuid();
-            CreatedOn = new DateTimeOffset(TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, TimeZoneInfo.FindSystemTimeZoneById("America/Los_Angeles")).DateTime, TimeSpan.Zero);
+            CreatedOn = new DateTimeOffset(TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, PstTimeZone.Get()).DateTime, TimeSpan.Zero);
             ModifiedOn = DateTimeOffset.Now;
         }
         

--- a/src/SmartTalk.Core/Jobs/RecurringJobs/SchedulingPhoneOrderDailyDataBroadcastRecurringJob.cs
+++ b/src/SmartTalk.Core/Jobs/RecurringJobs/SchedulingPhoneOrderDailyDataBroadcastRecurringJob.cs
@@ -1,5 +1,6 @@
 ﻿using Mediator.Net;
 using SmartTalk.Core.Settings.PhoneOrder;
+using SmartTalk.Core.Utils;
 using SmartTalk.Messages.Commands.PhoneOrder;
 
 namespace SmartTalk.Core.Jobs.RecurringJobs;
@@ -24,5 +25,5 @@ public class SchedulingPhoneOrderDailyDataBroadcastRecurringJob : IRecurringJob
     
     public string CronExpression => _cronExpressionSetting.Value;
     
-    public TimeZoneInfo TimeZone => TimeZoneInfo.FindSystemTimeZoneById("America/Los_Angeles");
+    public TimeZoneInfo TimeZone => PstTimeZone.Get();
 }

--- a/src/SmartTalk.Core/Mappings/PhoneOrderMapping.cs
+++ b/src/SmartTalk.Core/Mappings/PhoneOrderMapping.cs
@@ -1,5 +1,6 @@
 using AutoMapper;
 using SmartTalk.Core.Domain.PhoneOrder;
+using SmartTalk.Core.Utils;
 using SmartTalk.Messages.Dto.AiSpeechAssistant;
 using SmartTalk.Messages.Dto.EasyPos;
 using SmartTalk.Messages.Dto.PhoneOrder;
@@ -12,7 +13,7 @@ public class PhoneOrderMapping : Profile
     public PhoneOrderMapping()
     {
         CreateMap<PhoneOrderRecord, PhoneOrderRecordDto>()
-            .ForMember(dest => dest.CreatedDate, opt => opt.MapFrom(src => TimeZoneInfo.ConvertTimeFromUtc(src.CreatedDate.UtcDateTime, TimeZoneInfo.FindSystemTimeZoneById("America/Los_Angeles"))));
+            .ForMember(dest => dest.CreatedDate, opt => opt.MapFrom(src => TimeZoneInfo.ConvertTimeFromUtc(src.CreatedDate.UtcDateTime, PstTimeZone.Get())));
         
         CreateMap<PhoneOrderRecordDto, PhoneOrderRecord>();
         CreateMap<PhoneOrderConversation, PhoneOrderConversationDto>().ReverseMap();

--- a/src/SmartTalk.Core/Services/AiKids/AiKidRealtimeService.cs
+++ b/src/SmartTalk.Core/Services/AiKids/AiKidRealtimeService.cs
@@ -5,6 +5,7 @@ using SmartTalk.Core.Services.Jobs;
 using SmartTalk.Core.Services.Http.Clients;
 using SmartTalk.Core.Services.AiSpeechAssistant;
 using SmartTalk.Core.Services.RealtimeAi.Services;
+using SmartTalk.Core.Utils;
 using SmartTalk.Messages.Commands.AiKids;
 using SmartTalk.Messages.Dto.RealtimeAi;
 using SmartTalk.Messages.Dto.Smarties;
@@ -118,7 +119,7 @@ public class AiKidRealtimeService : IAiKidRealtimeService
     {
         if (assistant?.Knowledge == null || string.IsNullOrEmpty(assistant.Knowledge?.Prompt)) return string.Empty;
 
-        var pstTime = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time"));
+        var pstTime = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, PstTimeZone.Get());
         var currentTime = pstTime.ToString("yyyy-MM-dd HH:mm:ss");
 
         var finalPrompt = assistant.Knowledge.Prompt

--- a/src/SmartTalk.Core/Services/AiKids/AiKidRealtimeServiceV2.cs
+++ b/src/SmartTalk.Core/Services/AiKids/AiKidRealtimeServiceV2.cs
@@ -8,6 +8,7 @@ using SmartTalk.Core.Services.Http.Clients;
 using SmartTalk.Core.Services.Jobs;
 using SmartTalk.Core.Services.RealtimeAiV2;
 using SmartTalk.Core.Services.RealtimeAiV2.Services;
+using SmartTalk.Core.Utils;
 using SmartTalk.Messages.Commands.AiKids;
 using SmartTalk.Messages.Commands.Attachments;
 using SmartTalk.Messages.Dto.Attachments;
@@ -170,7 +171,7 @@ public class AiKidRealtimeServiceV2 : IAiKidRealtimeServiceV2
         if (assistant?.Knowledge == null || string.IsNullOrEmpty(assistant.Knowledge.Prompt))
             return string.Empty;
 
-        var pstTime = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time"));
+        var pstTime = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, PstTimeZone.Get());
         var currentTime = pstTime.ToString("yyyy-MM-dd HH:mm:ss");
 
         var finalPrompt = assistant.Knowledge.Prompt

--- a/src/SmartTalk.Core/Services/AiSpeechAssistant/AiSpeechAssistantService.cs
+++ b/src/SmartTalk.Core/Services/AiSpeechAssistant/AiSpeechAssistantService.cs
@@ -262,7 +262,7 @@ public partial class AiSpeechAssistantService : IAiSpeechAssistantService
         
         Log.Information("Matching Ai speech assistant: {@Assistant}、{@Knowledge}、{@UserProfile}", assistant, knowledge, userProfile);
         
-        var pstTime = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time"));
+        var pstTime = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, PstTimeZone.Get());
         var currentTime = pstTime.ToString("yyyy-MM-dd HH:mm:ss");
 
         var finalPrompt = knowledge.Prompt
@@ -1292,7 +1292,7 @@ public partial class AiSpeechAssistantService : IAiSpeechAssistantService
         
         var utcNow = DateTimeOffset.UtcNow;
 
-        var pstZone = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+        var pstZone = PstTimeZone.Get();
 
         var pstTime = TimeZoneInfo.ConvertTime(utcNow, pstZone);
         

--- a/src/SmartTalk.Core/Services/AutoTest/IAutoTestDataImportHandler.cs
+++ b/src/SmartTalk.Core/Services/AutoTest/IAutoTestDataImportHandler.cs
@@ -2,6 +2,7 @@ using Serilog;
 using SmartTalk.Core.Ioc;
 using SmartTalk.Core.Services.AutoTest.SalesAiOrder;
 using SmartTalk.Core.Services.Jobs;
+using SmartTalk.Core.Utils;
 using SmartTalk.Messages.Enums.AutoTest;
 
 namespace SmartTalk.Core.Services.AutoTest;
@@ -55,7 +56,7 @@ public class ApiDataImportHandler : IAutoTestDataImportHandler
                     var startUtc = startDateObj is DateTime dt1 ? dt1 : DateTime.Parse(startDateObj.ToString());
                     var endUtc = endDateObj is DateTime dt2 ? dt2 : DateTime.Parse(endDateObj.ToString());
 
-                    var pstZone = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+                    var pstZone = PstTimeZone.Get();
 
                     var startPstDate = TimeZoneInfo.ConvertTimeFromUtc(startUtc, pstZone).Date;
                     var endPstDate = TimeZoneInfo.ConvertTimeFromUtc(endUtc, pstZone).Date;

--- a/src/SmartTalk.Core/Services/AutoTest/SalesAiOrder/AutoTestSalesPhoneOrderProcessJobService.cs
+++ b/src/SmartTalk.Core/Services/AutoTest/SalesAiOrder/AutoTestSalesPhoneOrderProcessJobService.cs
@@ -27,6 +27,7 @@ using SmartTalk.Messages.Dto.SpeechMatics;
 using SmartTalk.Core.Services.Http.Clients;
 using SmartTalk.Core.Services.SpeechMatics;
 using SmartTalk.Core.Services.Caching.Redis;
+using SmartTalk.Core.Utils;
 using SmartTalk.Messages.Enums.SpeechMatics;
 using SmartTalk.Core.Services.AiSpeechAssistant;
 using SmartTalk.Core.Services.Attachments;
@@ -181,7 +182,7 @@ public class AutoTestSalesPhoneOrderProcessJobService : IAutoTestSalesPhoneOrder
                 return; 
             }
             
-            var pstZone = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time"); 
+            var pstZone = PstTimeZone.Get();
             var singleDayRecords = callRecords.SelectMany(r => new[] 
             { 
                 new { Phone = NormalizePhone(r.FromNumber), Record = r }, 
@@ -636,8 +637,7 @@ public class AutoTestSalesPhoneOrderProcessJobService : IAutoTestSalesPhoneOrder
     private async Task<List<ChatMessage>> ConfigureRecordAnalyzePromptAsync(
         Domain.AISpeechAssistant.AiSpeechAssistant aiSpeechAssistant, byte[] audioContent, CancellationToken cancellationToken)
     {
-        var pstTime = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow,
-            TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time"));
+        var pstTime = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, PstTimeZone.Get());
         var currentTime = pstTime.ToString("yyyy-MM-dd HH:mm:ss");
         
         var customerItemsCacheList = await _salesDataProvider.GetCustomerItemsCacheByAssistantNameAsync(aiSpeechAssistant.Name, cancellationToken);
@@ -815,7 +815,7 @@ public class AutoTestSalesPhoneOrderProcessJobService : IAutoTestSalesPhoneOrder
         var knowledge = await _aiSpeechAssistantDataProvider.GetAiSpeechAssistantKnowledgeAsync(assistantId: assistant.Id, isActive: true, cancellationToken: cancellationToken).ConfigureAwait(false);
         if (knowledge == null) return null;
         
-        var pstTime = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time"));
+        var pstTime = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, PstTimeZone.Get());
         var currentTime = pstTime.ToString("yyyy-MM-dd HH:mm:ss");
         var finalPrompt = knowledge.Prompt
             .Replace("#{current_time}", currentTime)
@@ -936,7 +936,7 @@ public class AutoTestSalesPhoneOrderProcessJobService : IAutoTestSalesPhoneOrder
                 return null;
             }
             
-            var pacificZone = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+            var pacificZone = PstTimeZone.Get();
             var sapStartDate = TimeZoneInfo.ConvertTimeFromUtc(record.StartTimeUtc, pacificZone).Date;
             
             var sapResp = await RetrySapAsync(() =>

--- a/src/SmartTalk.Core/Services/Linphone/LinphoneService.cs
+++ b/src/SmartTalk.Core/Services/Linphone/LinphoneService.cs
@@ -5,6 +5,7 @@ using SmartTalk.Core.Ioc;
 using SmartTalk.Core.Domain.Linphone;
 using SmartTalk.Core.Services.Caching;
 using SmartTalk.Core.Services.Http.Clients;
+using SmartTalk.Core.Utils;
 using SmartTalk.Messages.Dto.Linphone;
 using SmartTalk.Messages.Enums.Linphone;
 using SmartTalk.Messages.Requests.Linphone;
@@ -256,7 +257,7 @@ public class LinphoneService : ILinphoneService
     public async Task<GetLinphoneDataResponse> GetLinphoneDataAsync(GetLinphoneDataRequest request, CancellationToken cancellationToken)
     {
         var specifiedDate = request.Time.Date;
-        var pstOffset = TimeZoneInfo.FindSystemTimeZoneById("America/Los_Angeles").GetUtcOffset(specifiedDate);
+        var pstOffset = PstTimeZone.Get().GetUtcOffset(specifiedDate);
         var startPst = new DateTimeOffset(specifiedDate, pstOffset);
         var endPst = startPst.AddDays(1);
 
@@ -276,7 +277,7 @@ public class LinphoneService : ILinphoneService
 
             var linphoneDates = new List<LinphoneData>();
             
-            var pacificZone = TimeZoneInfo.FindSystemTimeZoneById("America/Los_Angeles");
+            var pacificZone = PstTimeZone.Get();
             
             var tasks = externalLinphoneGroupedCdrs.Select(async group =>
             {

--- a/src/SmartTalk.Core/Services/PhoneOrder/PhoneOrderProcessJobService.Record.cs
+++ b/src/SmartTalk.Core/Services/PhoneOrder/PhoneOrderProcessJobService.Record.cs
@@ -107,7 +107,7 @@ public partial class PhoneOrderProcessJobService
             Log.Warning("Fetched incoming phone number from Twilio failed: {Message}", e.Message);
         }
         
-        var pstTime = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time"));
+        var pstTime = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, PstTimeZone.Get());
         var currentTime = pstTime.ToString("yyyy-MM-dd HH:mm:ss");
         var callSubjectCn = "通话主题:";
         var callSubjectEn = "Conversation topic:";
@@ -263,7 +263,7 @@ public partial class PhoneOrderProcessJobService
     {
         var timezone = !string.IsNullOrWhiteSpace(agent.Timezone)
             ? TimeZoneInfo.FindSystemTimeZoneById(agent.Timezone)
-            : TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+            : PstTimeZone.Get();
         var nowDate = TimeZoneInfo.ConvertTime(DateTimeOffset.UtcNow, timezone);
 
         var utcDate = TimeZoneInfo.ConvertTimeToUtc(nowDate.Date, timezone);
@@ -437,7 +437,7 @@ public partial class PhoneOrderProcessJobService
                 .ConfigureAwait(false);
         if (!extractedOrders.Any()) return;
 
-        var pacificZone = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+        var pacificZone = PstTimeZone.Get();
         var pacificNow = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, pacificZone);
 
         foreach (var storeOrder in extractedOrders)

--- a/src/SmartTalk.Core/Services/PhoneOrder/PhoneOrderProcessJobService.cs
+++ b/src/SmartTalk.Core/Services/PhoneOrder/PhoneOrderProcessJobService.cs
@@ -12,6 +12,7 @@ using SmartTalk.Core.Services.Sale;
 using SmartTalk.Core.Services.SpeechMatics;
 using SmartTalk.Core.Settings.OpenAi;
 using SmartTalk.Core.Settings.Twilio;
+using SmartTalk.Core.Utils;
 using SmartTalk.Core.Services.Twilio;
 using SmartTalk.Messages.Commands.PhoneOrder;
 
@@ -94,7 +95,7 @@ public partial class PhoneOrderProcessJobService : IPhoneOrderProcessJobService
 
     private (DateTimeOffset Start, DateTimeOffset End) GetQueryTimeRange()
     {
-        var pacificZone = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+        var pacificZone = PstTimeZone.Get();
         
         var startLocal = new DateTime(2025, 8, 1, 0, 0, 0);
         var endLocal = new DateTime(2025, 8, 31, 23, 59, 59);

--- a/src/SmartTalk.Core/Services/PhoneOrder/PhoneOrderService.Record.cs
+++ b/src/SmartTalk.Core/Services/PhoneOrder/PhoneOrderService.Record.cs
@@ -17,6 +17,7 @@ using SmartTalk.Core.Domain.PhoneOrder;
 using SmartTalk.Core.Domain.SpeechMatics;
 using SmartTalk.Core.Services.Linphone;
 using SmartTalk.Core.Domain.Pos;
+using SmartTalk.Core.Utils;
 using SmartTalk.Messages.Dto.PhoneOrder;
 using SmartTalk.Messages.Dto.Attachments;
 using SmartTalk.Messages.Enums.PhoneOrder;
@@ -576,7 +577,7 @@ public partial class PhoneOrderService
 
         if (match.Success) time = match.Groups[1].Value;
 
-        return TimeZoneInfo.ConvertTime(DateTimeOffset.FromUnixTimeSeconds(long.Parse(time)), TimeZoneInfo.FindSystemTimeZoneById("America/Los_Angeles"));
+        return TimeZoneInfo.ConvertTime(DateTimeOffset.FromUnixTimeSeconds(long.Parse(time)), PstTimeZone.Get());
     }
 
     private async Task UpdatePhoneOrderRecordSpecificFieldsAsync(int recordId, int modifiedBy, string tips, string lastModifiedByName, CancellationToken cancellationToken)
@@ -626,7 +627,7 @@ public partial class PhoneOrderService
     {
         if (!inputDate.HasValue) return (null, null);
 
-        var pstTimeZone = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+        var pstTimeZone = PstTimeZone.Get();
 
         var pstDate = new DateTime(inputDate.Value.Year, inputDate.Value.Month, inputDate.Value.Day, 0, 0, 0);
         var pstStart = new DateTimeOffset(pstDate, pstTimeZone.GetUtcOffset(pstDate));
@@ -810,7 +811,7 @@ public partial class PhoneOrderService
     {
         if (month < 1 || month > 12) throw new ArgumentOutOfRangeException(nameof(month));
 
-        var tz = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time"); // PT, 含 DST
+        var tz = PstTimeZone.Get(); // PT, 含 DST
 
         var startLocal = new DateTime(year, month, 1, 0, 0, 0, DateTimeKind.Unspecified);
 
@@ -889,7 +890,7 @@ public partial class PhoneOrderService
     
     private string ConvertUtcToPst(DateTimeOffset utcTime)
     {
-        var pstTimeZone = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+        var pstTimeZone = PstTimeZone.Get();
         
         var pstTime = TimeZoneInfo.ConvertTimeFromUtc(utcTime.UtcDateTime, pstTimeZone);
         

--- a/src/SmartTalk.Core/Services/PhoneOrder/PhoneOrderService.Send.cs
+++ b/src/SmartTalk.Core/Services/PhoneOrder/PhoneOrderService.Send.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text;
+using SmartTalk.Core.Utils;
 using SmartTalk.Messages.Dto.WeChat;
 using SmartTalk.Messages.Commands.PhoneOrder;
 using SmartTalk.Messages.Enums.WeChat;
@@ -94,7 +95,7 @@ public partial class PhoneOrderService : IPhoneOrderService
     private static (DateTimeOffset today, DateTimeOffset yesterday) PstTime()
     {
         var utcNow = DateTimeOffset.UtcNow;
-        var pstZone = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+        var pstZone = PstTimeZone.Get();
 
         var today = TimeZoneInfo.ConvertTime(utcNow, pstZone);
         var yesterday = today.AddDays(-1);

--- a/src/SmartTalk.Core/Services/Printer/PrinterService.cs
+++ b/src/SmartTalk.Core/Services/Printer/PrinterService.cs
@@ -26,6 +26,7 @@ using SmartTalk.Core.Services.Jobs;
 using SmartTalk.Core.Services.PhoneOrder;
 using SmartTalk.Core.Services.Pos;
 using SmartTalk.Core.Settings.Printer;
+using SmartTalk.Core.Utils;
 using SmartTalk.Message.Commands.Printer;
 using SmartTalk.Message.Events.Printer;
 using SmartTalk.Messages.Commands.Pos;
@@ -457,7 +458,7 @@ public class PrinterService : IPrinterService
 
             var storeName = JsonConvert.DeserializeObject<Dictionary<string, Dictionary<string, string>>>(store.Names).GetValueOrDefault("en")?.GetValueOrDefault("name");
 
-            var text = new SendWorkWechatGroupRobotTextDto { Content = $"✅SMT Cloud Printer Online\nTime: {TimeZoneInfo.ConvertTimeFromUtc(DateTimeOffset.Now.UtcDateTime, TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time")):yyyy-MM-dd HH:mm:ss}\nStore: {storeName}"};
+            var text = new SendWorkWechatGroupRobotTextDto { Content = $"✅SMT Cloud Printer Online\nTime: {TimeZoneInfo.ConvertTimeFromUtc(DateTimeOffset.Now.UtcDateTime, PstTimeZone.Get()):yyyy-MM-dd HH:mm:ss}\nStore: {storeName}"};
             text.MentionedMobileList = "@all";
         
             await _weChatClient.SendWorkWechatRobotMessagesAsync(_printerSendErrorLogSetting.CloudPrinterSendErrorLogRobotUrl, new SendWorkWechatGroupRobotMessageDto
@@ -543,9 +544,9 @@ public class PrinterService : IPrinterService
             var storeName = JsonConvert.DeserializeObject<Dictionary<string, Dictionary<string, string>>>(store.Names).GetValueOrDefault("en")?.GetValueOrDefault("name");
             
             if (@event.MerchPrinterOrderDto.PrintFormat == PrintFormat.Order)
-                text = new SendWorkWechatGroupRobotTextDto { Content = $"🆘SMT Cloud Print Error Infor🆘\n\nPrint Error: {merchPrinterLog.Message}\nPrint Time: {TimeZoneInfo.ConvertTimeFromUtc(@event.MerchPrinterOrderDto.PrintDate.UtcDateTime, TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time")):yyyy-MM-dd HH:mm:ss}\nStore: {storeName}\nOrder Date:{order.CreatedDate.ToString("yyyy-MM-dd")}\nOrder NO: #{order.OrderNo}"};
+                text = new SendWorkWechatGroupRobotTextDto { Content = $"🆘SMT Cloud Print Error Infor🆘\n\nPrint Error: {merchPrinterLog.Message}\nPrint Time: {TimeZoneInfo.ConvertTimeFromUtc(@event.MerchPrinterOrderDto.PrintDate.UtcDateTime, PstTimeZone.Get()):yyyy-MM-dd HH:mm:ss}\nStore: {storeName}\nOrder Date:{order.CreatedDate.ToString("yyyy-MM-dd")}\nOrder NO: #{order.OrderNo}"};
             else
-                text = new SendWorkWechatGroupRobotTextDto { Content = $"🆘SMT Cloud Print Error Infor🆘\n\nPrint Error: {merchPrinterLog.Message}\nPrint Time: {TimeZoneInfo.ConvertTimeFromUtc(@event.MerchPrinterOrderDto.PrintDate.UtcDateTime, TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time")):yyyy-MM-dd HH:mm:ss}\nStore: {storeName}\nOrder Date:{@event.MerchPrinterOrderDto.PrintDate.ToString("yyyy-MM-dd")}\nOrder Id: #{@event.MerchPrinterOrderDto.OrderId}"};
+                text = new SendWorkWechatGroupRobotTextDto { Content = $"🆘SMT Cloud Print Error Infor🆘\n\nPrint Error: {merchPrinterLog.Message}\nPrint Time: {TimeZoneInfo.ConvertTimeFromUtc(@event.MerchPrinterOrderDto.PrintDate.UtcDateTime, PstTimeZone.Get()):yyyy-MM-dd HH:mm:ss}\nStore: {storeName}\nOrder Date:{@event.MerchPrinterOrderDto.PrintDate.ToString("yyyy-MM-dd")}\nOrder Id: #{@event.MerchPrinterOrderDto.OrderId}"};
            
             text.MentionedMobileList = "@all";
         
@@ -860,7 +861,7 @@ public class PrinterService : IPrinterService
              
              var storeName = JsonConvert.DeserializeObject<Dictionary<string, Dictionary<string, string>>>(store.Names).GetValueOrDefault("en")?.GetValueOrDefault("name");
              
-             var text = new SendWorkWechatGroupRobotTextDto { Content = $"❌SMT Cloud Printer Offline\nTime: {TimeZoneInfo.ConvertTimeFromUtc(DateTimeOffset.Now.UtcDateTime, TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time")):yyyy-MM-dd HH:mm:ss}\nStore: {storeName}"};
+             var text = new SendWorkWechatGroupRobotTextDto { Content = $"❌SMT Cloud Printer Offline\nTime: {TimeZoneInfo.ConvertTimeFromUtc(DateTimeOffset.Now.UtcDateTime, PstTimeZone.Get()):yyyy-MM-dd HH:mm:ss}\nStore: {storeName}"};
              text.MentionedMobileList = "@all";
         
              await _weChatClient.SendWorkWechatRobotMessagesAsync(_printerSendErrorLogSetting.CloudPrinterSendErrorLogRobotUrl, new SendWorkWechatGroupRobotMessageDto

--- a/src/SmartTalk.Core/Services/Webhook/TwilioWebhookService.cs
+++ b/src/SmartTalk.Core/Services/Webhook/TwilioWebhookService.cs
@@ -1,6 +1,7 @@
 using Serilog;
 using AutoMapper;
 using SmartTalk.Core.Ioc;
+using SmartTalk.Core.Utils;
 using SmartTalk.Core.Extensions;
 using SmartTalk.Messages.Dto.WeChat;
 using System.Text.RegularExpressions;
@@ -138,7 +139,7 @@ public class TwilioWebhookService : ITwilioWebhookService
 
     private async Task SendWorkWechatRobotMessagesAsync(string content, bool atAll, CancellationToken cancellationToken)
     {
-        var pacificTime = DateTimeOffset.UtcNow.ConvertFromUtc(TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time"));
+        var pacificTime = DateTimeOffset.UtcNow.ConvertFromUtc(PstTimeZone.Get());
         var currentDate = pacificTime.ToString("yyyy-MM-dd");
         var currentTime = pacificTime.ToString("HH:mm");
 


### PR DESCRIPTION
## Summary

- Move 15 inline `TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time" / "America/Los_Angeles")` call sites onto the existing `SmartTalk.Core.Utils.PstTimeZone.Get()` helper (introduced by #919)
- Picks up the deferred follow-up from #919's retrospective ("codebase 中還有 7+ 處用 `FindSystemTimeZoneById` 直接調用，留待後續統一收編到 helper")
- Pure refactor — every swap maps the same string literal to the same `TimeZoneInfo`. The helper caches via `Lazy<T>` and falls back from the Windows ID to the IANA ID on hosts without ICU

## Files touched

- V1 service: `Services/AiSpeechAssistant/AiSpeechAssistantService.cs` (2 sites)
- Realtime / AI services: `Services/AiKids/AiKidRealtimeService.cs`, `Services/AiKids/AiKidRealtimeServiceV2.cs`, `Services/Webhook/TwilioWebhookService.cs`
- PhoneOrder pipeline: `Services/PhoneOrder/PhoneOrderProcessJobService.cs`, `Services/PhoneOrder/PhoneOrderProcessJobService.Record.cs` (3 sites), `Services/PhoneOrder/PhoneOrderService.Send.cs`, `Services/PhoneOrder/PhoneOrderService.Record.cs` (4 sites)
- Recurring job: `Jobs/RecurringJobs/SchedulingPhoneOrderDailyDataBroadcastRecurringJob.cs`
- AutoMapper profile: `Mappings/PhoneOrderMapping.cs`
- Domain entity: `Domain/Account/UserAccount.cs`
- Other: `Services/Printer/PrinterService.cs` (4 sites), `Services/Linphone/LinphoneService.cs` (2 sites), `Services/AutoTest/IAutoTestDataImportHandler.cs`, `Services/AutoTest/SalesAiOrder/AutoTestSalesPhoneOrderProcessJobService.cs` (4 sites)

## Out of scope (intentionally untouched direct calls)

- `agent.Timezone` / `store.Timezone` / `windowsId` dynamic IDs (in `PhoneOrderUtilService`, `PhoneOrderProcessJobService.Record`, `PrinterService`, `AiSpeechAssistantService`, `PosService.Order`, `PosUtilService`, `AiSpeechAssistantConnectService.Build.Routing`) — these resolve user-configured time zones, not PST
- `"Asia/Shanghai"` / `"China Standard Time"` in `PhoneOrderService.Record.cs` — not PST

## Test plan

- [x] Build: 0 errors (4159 pre-existing warnings unchanged)
- [x] Full unit suite: 508/508 pass
- [ ] Staging observation alongside the rest of Round 3 sub-PRs

## Rollback

`git revert` on this commit. Behaviour is identical before and after the swap, so no operational change to monitor.