### PR TITLE
Track assistant item_id in V2 session context

### DIFF
--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Services/RealtimeAiService.Event.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Services/RealtimeAiService.Event.cs
@@ -101,6 +101,13 @@ public partial class RealtimeAiService
 
         _ctx.IsAiSpeaking = true;
 
+        // Track the latest assistant item_id for Phase 10.3 barge-in. Adapter populates
+        // this on every OpenAI response.output_audio.delta; Google adapter leaves it null
+        // (Google's protocol does not surface a per-delta id). Either way, an empty value
+        // must not clobber a previously-tracked id from earlier in the same turn.
+        if (!string.IsNullOrEmpty(aiAudioData.ItemId))
+            _ctx.LastAssistantItemId = aiAudioData.ItemId;
+
         var clientBase64 = await TranscodeAudioAsync(aiAudioData.Base64Payload, AudioSource.Provider).ConfigureAwait(false);
 
         await SendAudioToClientAsync(clientBase64).ConfigureAwait(false);
@@ -122,6 +129,10 @@ public partial class RealtimeAiService
 
         _ctx.Round += 1;
         _ctx.IsAiSpeaking = false;
+
+        // The interrupt window for this turn has closed; clear so the next user-barge-in
+        // opportunity (Phase 10.3) can't send a stale id that the provider would reject.
+        _ctx.LastAssistantItemId = null;
 
         var idleFollowUp = _ctx.Options.IdleFollowUp;
 

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Services/RealtimeAiSessionContext.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Services/RealtimeAiSessionContext.cs
@@ -30,6 +30,17 @@ public class RealtimeAiSessionContext
     public bool IsProviderResponseInProgress;
     public bool HasPendingProviderResponseTrigger;
 
+    /// <summary>
+    /// The provider <c>item_id</c> of the AI's current in-flight assistant turn,
+    /// captured from every <see cref="Messages.Enums.RealtimeAi.RealtimeAiWssEventType.ResponseAudioDelta"/>
+    /// that carries one. Phase 10.3 will read this to build the OpenAI
+    /// <c>conversation.interrupt</c> message at user-barge-in time. <c>null</c>
+    /// between turns (cleared by <c>OnAiTurnCompletedAsync</c>) so a stale id
+    /// from a previous turn cannot be sent on the next interrupt opportunity.
+    /// Phase 10.1 wires the tracking; today no consumer reads it.
+    /// </summary>
+    public string LastAssistantItemId { get; set; }
+
     // Recording — buffer encapsulates the previous (MemoryStream + SemaphoreSlim)
     // pair behind a single interface; PR 3.2 will swap implementations via env var.
     public IRecordingBuffer AudioBuffer { get; set; }

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterItemIdTrackingTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterItemIdTrackingTests.cs
@@ -1,0 +1,128 @@
+using Microsoft.Extensions.Configuration;
+using NSubstitute;
+using Shouldly;
+using SmartTalk.Core.Services.RealtimeAiV2.Adapters.Providers.OpenAi;
+using SmartTalk.Core.Settings.OpenAi;
+using SmartTalk.Messages.Dto.RealtimeAi;
+using SmartTalk.Messages.Enums.RealtimeAi;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Services.RealtimeAiV2;
+
+/// <summary>
+/// Pins that the V2 OpenAI adapter surfaces the per-message <c>item_id</c> on both
+/// <see cref="ParsedRealtimeAiProviderEvent.ItemId"/> and (for audio deltas)
+/// <see cref="RealtimeAiWssAudioData.ItemId"/>.
+///
+/// <para>
+/// Captured separately from the existing <c>BetaEventSunset</c> / <c>ParseMessageUsage</c>
+/// suites because those assert on event type and usage; they do not pin the
+/// <c>item_id</c> propagation, which is the regression boundary for the Phase 10
+/// barge-in work (Phase 10.3 will read <see cref="RealtimeAiSessionContext.LastAssistantItemId"/>
+/// to build the OpenAI <c>conversation.interrupt</c> message; if the adapter ever
+/// drops <c>item_id</c>, barge-in stops working silently).
+/// </para>
+/// </summary>
+public class OpenAiRealtimeAiProviderAdapterItemIdTrackingTests
+{
+    private static OpenAiRealtimeAiProviderAdapter NewAdapter() =>
+        new(new OpenAiSettings(Substitute.For<IConfiguration>()));
+
+    [Fact]
+    public void ParseMessage_ResponseAudioDeltaWithItemId_PopulatesItemIdOnAudioData()
+    {
+        var raw = """
+            {
+              "type": "response.output_audio.delta",
+              "item_id": "item_abc123",
+              "delta": "AQID"
+            }
+            """;
+
+        var parsed = NewAdapter().ParseMessage(raw);
+
+        parsed.Type.ShouldBe(RealtimeAiWssEventType.ResponseAudioDelta);
+        var audio = parsed.Data.ShouldBeOfType<RealtimeAiWssAudioData>();
+        audio.ItemId.ShouldBe("item_abc123");
+        audio.Base64Payload.ShouldBe("AQID");
+    }
+
+    [Fact]
+    public void ParseMessage_ResponseAudioDeltaWithItemId_AlsoSetsItemIdOnParsedEvent()
+    {
+        // The top-level ItemId on ParsedRealtimeAiProviderEvent must be in sync with the
+        // audio-data ItemId so that consumers reading from either path see the same value.
+        var raw = """
+            {
+              "type": "response.output_audio.delta",
+              "item_id": "item_xyz789",
+              "delta": "BAUG"
+            }
+            """;
+
+        var parsed = NewAdapter().ParseMessage(raw);
+
+        parsed.ItemId.ShouldBe("item_xyz789");
+        ((RealtimeAiWssAudioData)parsed.Data).ItemId.ShouldBe(parsed.ItemId);
+    }
+
+    [Fact]
+    public void ParseMessage_ResponseAudioDeltaWithoutItemId_LeavesItemIdNull()
+    {
+        // Defensive: providers may emit deltas without item_id (older snapshots, edge
+        // events). The adapter must not synthesize a value or crash; it must leave
+        // both fields as null so downstream consumers can detect "no id available".
+        var raw = """
+            {
+              "type": "response.output_audio.delta",
+              "delta": "AQID"
+            }
+            """;
+
+        var parsed = NewAdapter().ParseMessage(raw);
+
+        parsed.Type.ShouldBe(RealtimeAiWssEventType.ResponseAudioDelta);
+        parsed.ItemId.ShouldBeNull();
+        ((RealtimeAiWssAudioData)parsed.Data).ItemId.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ParseMessage_NonAudioEventWithItemId_PopulatesParsedEventItemId()
+    {
+        // item_id appears on non-audio events too (e.g. response.output_audio_transcript.delta).
+        // It must propagate to ParsedRealtimeAiProviderEvent.ItemId regardless of event type
+        // so Phase 10 can correlate transcripts to specific assistant items if needed.
+        var raw = """
+            {
+              "type": "response.output_audio_transcript.delta",
+              "item_id": "item_transcript_1",
+              "delta": "hello"
+            }
+            """;
+
+        var parsed = NewAdapter().ParseMessage(raw);
+
+        parsed.Type.ShouldBe(RealtimeAiWssEventType.OutputAudioTranscriptionPartial);
+        parsed.ItemId.ShouldBe("item_transcript_1");
+    }
+
+    [Fact]
+    public void ParseMessage_TurnCompletedEvent_ItemIdNotRequired()
+    {
+        // response.done events don't carry item_id at the top level; consumers must not
+        // rely on it being present for turn completion. This pins the contract so a
+        // future barge-in / cleanup refactor that incorrectly required ItemId on turn-end
+        // would surface here.
+        var raw = """
+            {
+              "type": "response.done",
+              "response": { "id": "resp_test" }
+            }
+            """;
+
+        var parsed = NewAdapter().ParseMessage(raw);
+
+        parsed.Type.ShouldBe(RealtimeAiWssEventType.ResponseTurnCompleted);
+        parsed.ItemId.ShouldBeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- Capture OpenAI's per-turn `item_id` (already surfaced by `OpenAiRealtimeAiProviderAdapter.ParseMessage`) into `RealtimeAiSessionContext.LastAssistantItemId`, following the V1 pattern (`AiSpeechAssistantStreamContext.LastAssistantItem`)
- Plumbing only — **no production behaviour changes in this PR**. Phase 10.3 (V2 barge-in) will plug this state into the user-speech-detected handler to fire OpenAI `conversation.interrupt` (the `IRealtimeAiProviderAdapter.BuildInterruptMessage(string)` contract already takes this id, but no caller tracked it until now)
- Close adapter-parse coverage gap: existing Beta-sunset / usage tests asserted on event type and usage but not on `item_id` propagation. A future refactor that silently dropped the field would have broken barge-in without any test failing

## Lifecycle

- **Set** in `OnAiAudioOutputReadyAsync` on every `ResponseAudioDelta` carrying a non-empty `ItemId`. Google adapter leaves it null (Google's protocol does not surface a per-delta id) — empty values must not clobber a previously-tracked id from earlier in the same turn
- **Cleared** in `OnAiTurnCompletedAsync`. After turn completion the interrupt window is closed; a stale id from the previous turn would be rejected by the provider as referring to a non-existent item

## Scope discipline

- Adapter side already populates `RealtimeAiWssAudioData.ItemId` and `ParsedRealtimeAiProviderEvent.ItemId`; this PR does NOT change adapter parse code
- `IRealtimeAiProviderAdapter.BuildInterruptMessage(string)` already exists on both OpenAI and Google adapters; this PR does NOT call it (deferred to 10.3)
- V1 (`AiSpeechAssistantService`) untouched — V2 is the prod path
- No service-level test for the ctx field directly: Phase 10.3 will pin behaviour end-to-end (interrupt sent with correct id at user-speech-detected). The plumbing here is 4 lines of obviously-correct code on top of well-tested adapter parse output

## Test plan

- [x] Build: 0 errors
- [x] Targeted: 5/5 pass on the new `OpenAiRealtimeAiProviderAdapterItemIdTrackingTests`
- [x] Full unit suite: 513/513 pass (508 prior + 5 new)
- [ ] Staging observation alongside other Round 3 sub-PRs

## Rollback

`git revert` on this commit. No production behaviour changed, so nothing to monitor operationally; reverting only removes the tracked field.