### PR TITLE
Track Twilio media timestamps for V2 barge-in timing

### DIFF
--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Clients/Twilio/TwilioRealtimeAiClientAdapter.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Clients/Twilio/TwilioRealtimeAiClientAdapter.cs
@@ -68,12 +68,37 @@ public class TwilioRealtimeAiClientAdapter : IRealtimeAiClientAdapter
             return new ParsedClientMessage { Type = RealtimeAiClientMessageType.Unknown };
 
         var mediaType = media.TryGetProperty("type", out var t) ? t.GetString() : null;
+        var timestamp = ExtractMediaTimestamp(media);
 
         return mediaType switch
         {
-            "video" => new ParsedClientMessage { Type = RealtimeAiClientMessageType.Image, Payload = payload },
-            _ => new ParsedClientMessage { Type = RealtimeAiClientMessageType.Audio, Payload = payload }
+            "video" => new ParsedClientMessage { Type = RealtimeAiClientMessageType.Image, Payload = payload, Timestamp = timestamp },
+            _ => new ParsedClientMessage { Type = RealtimeAiClientMessageType.Audio, Payload = payload, Timestamp = timestamp }
         };
+    }
+
+    /// <summary>
+    /// Twilio's media-streams protocol ships <c>media.timestamp</c> as a string of
+    /// milliseconds since stream start. Returns null when the field is absent or
+    /// cannot be parsed — a single malformed timestamp must not drop the whole
+    /// media frame, the audio payload is more critical than the timing metadata.
+    /// </summary>
+    private static long? ExtractMediaTimestamp(JsonElement media)
+    {
+        if (!media.TryGetProperty("timestamp", out var tsProp)) return null;
+
+        // Twilio docs specify string form, but real-world payloads occasionally surface
+        // the numeric form (older preview snapshots, future protocol revisions). Accept
+        // both rather than silently dropping one variant.
+        if (tsProp.ValueKind == JsonValueKind.String &&
+            long.TryParse(tsProp.GetString(), out var parsed))
+            return parsed;
+
+        if (tsProp.ValueKind == JsonValueKind.Number &&
+            tsProp.TryGetInt64(out var direct))
+            return direct;
+
+        return null;
     }
 
     public object BuildAudioDeltaMessage(string base64Payload, string sessionId)

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/IRealtimeAiClientAdapter.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/IRealtimeAiClientAdapter.cs
@@ -9,13 +9,22 @@ public enum RealtimeAiClientMessageType { Audio, Image, Text, Start, Stop, Unkno
 public class ParsedClientMessage
 {
     public string Payload { get; set; }
-    
+
     public RealtimeAiClientMessageType Type { get; set; }
 
     /// <summary>
     /// Metadata from lifecycle events (e.g. CallSid, StreamSid from Twilio "start").
     /// </summary>
     public Dictionary<string, string> Metadata { get; set; }
+
+    /// <summary>
+    /// Optional millisecond timestamp the client emitted alongside this message.
+    /// Currently populated only by <see cref="Clients.Twilio.TwilioRealtimeAiClientAdapter"/>
+    /// from the <c>media.timestamp</c> field; web / default clients leave it null.
+    /// Phase 10.3 reads this on user-speech-detected to compute the OpenAI
+    /// <c>conversation.item.truncate audio_end_ms</c> for the in-flight assistant turn.
+    /// </summary>
+    public long? Timestamp { get; set; }
 }
 
 public interface IRealtimeAiClientAdapter : IScopedDependency

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Services/RealtimeAiService.Event.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Services/RealtimeAiService.Event.cs
@@ -108,6 +108,14 @@ public partial class RealtimeAiService
         if (!string.IsNullOrEmpty(aiAudioData.ItemId))
             _ctx.LastAssistantItemId = aiAudioData.ItemId;
 
+        // Capture the stream-time at which the AI started speaking THIS turn (set-once
+        // per turn). Phase 10.3 will compute audio_end_ms = LatestMediaTimestamp - this
+        // value to tell OpenAI exactly where to truncate the assistant message in its
+        // conversation history. Set only on the FIRST delta of the turn so subsequent
+        // deltas don't shift the anchor forwards.
+        if (!_ctx.ResponseStartTimestampTwilio.HasValue && _ctx.LatestMediaTimestamp.HasValue)
+            _ctx.ResponseStartTimestampTwilio = _ctx.LatestMediaTimestamp;
+
         var clientBase64 = await TranscodeAudioAsync(aiAudioData.Base64Payload, AudioSource.Provider).ConfigureAwait(false);
 
         await SendAudioToClientAsync(clientBase64).ConfigureAwait(false);
@@ -133,6 +141,11 @@ public partial class RealtimeAiService
         // The interrupt window for this turn has closed; clear so the next user-barge-in
         // opportunity (Phase 10.3) can't send a stale id that the provider would reject.
         _ctx.LastAssistantItemId = null;
+
+        // Reset the per-turn stream-time anchor. The next turn's first ResponseAudioDelta
+        // will set it again. LatestMediaTimestamp deliberately keeps its value — it's the
+        // running clock, not a per-turn quantity.
+        _ctx.ResponseStartTimestampTwilio = null;
 
         var idleFollowUp = _ctx.Options.IdleFollowUp;
 

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Services/RealtimeAiService.Orchestration.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Services/RealtimeAiService.Orchestration.cs
@@ -67,6 +67,14 @@ public partial class RealtimeAiService
         {
             var parsed = _ctx.ClientAdapter.ParseMessage(rawMessage);
 
+            // Twilio populates this on every media frame; web / default clients leave it
+            // null and we keep whatever value the previous Twilio frame deposited. The
+            // value drives Phase 10.3's audio_end_ms truncate calculation, so updating
+            // before the dispatch switch is intentional — even messages we don't act on
+            // (e.g. video frames) advance the stream clock.
+            if (parsed.Timestamp.HasValue)
+                _ctx.LatestMediaTimestamp = parsed.Timestamp.Value;
+
             switch (parsed.Type)
             {
                 case RealtimeAiClientMessageType.Start:

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Services/RealtimeAiSessionContext.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Services/RealtimeAiSessionContext.cs
@@ -41,6 +41,27 @@ public class RealtimeAiSessionContext
     /// </summary>
     public string LastAssistantItemId { get; set; }
 
+    /// <summary>
+    /// Most recent <c>media.timestamp</c> (ms since stream start) parsed from a
+    /// client-direction media frame. Twilio populates this on every incoming
+    /// audio chunk; web / default clients leave it null because they have no
+    /// equivalent timing signal. Phase 10.3 subtracts <see cref="ResponseStartTimestampTwilio"/>
+    /// from this value to compute <c>audio_end_ms</c> for the OpenAI
+    /// <c>conversation.item.truncate</c> sent at user barge-in time.
+    /// Phase 10.2 wires the tracking; today no consumer reads it.
+    /// </summary>
+    public long? LatestMediaTimestamp { get; set; }
+
+    /// <summary>
+    /// The <see cref="LatestMediaTimestamp"/> snapshot taken on the FIRST
+    /// <c>ResponseAudioDelta</c> of the current AI turn — i.e. the stream-time
+    /// at which the AI started speaking this turn. Set lazily (only when null)
+    /// to capture the first delta; cleared by <c>OnAiTurnCompletedAsync</c>
+    /// alongside <see cref="LastAssistantItemId"/>. <c>null</c> between turns
+    /// and for non-Twilio clients.
+    /// </summary>
+    public long? ResponseStartTimestampTwilio { get; set; }
+
     // Recording — buffer encapsulates the previous (MemoryStream + SemaphoreSlim)
     // pair behind a single interface; PR 3.2 will swap implementations via env var.
     public IRecordingBuffer AudioBuffer { get; set; }

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/TwilioRealtimeAiClientAdapterMediaTimestampTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/TwilioRealtimeAiClientAdapterMediaTimestampTests.cs
@@ -1,0 +1,141 @@
+using Shouldly;
+using SmartTalk.Core.Services.RealtimeAiV2.Adapters;
+using SmartTalk.Core.Services.RealtimeAiV2.Adapters.Clients.Twilio;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Services.RealtimeAiV2;
+
+/// <summary>
+/// Pins that the Twilio client adapter surfaces <c>media.timestamp</c> on
+/// <see cref="SmartTalk.Core.Services.RealtimeAiV2.Adapters.ParsedClientMessage.Timestamp"/>.
+///
+/// <para>
+/// Phase 10.3 will use the running <c>_ctx.LatestMediaTimestamp</c> minus the per-turn
+/// <c>_ctx.ResponseStartTimestampTwilio</c> snapshot to compute <c>audio_end_ms</c> for
+/// the OpenAI <c>conversation.item.truncate</c> sent at user barge-in time. If the
+/// adapter ever stopped extracting <c>media.timestamp</c>, barge-in would still fire
+/// (the Twilio <c>clear</c> event already stops playback), but the conversation
+/// history sent to OpenAI for the next turn would carry the un-truncated assistant
+/// utterance and confuse subsequent prompt context.
+/// </para>
+/// </summary>
+public class TwilioRealtimeAiClientAdapterMediaTimestampTests
+{
+    private static TwilioRealtimeAiClientAdapter NewAdapter() => new();
+
+    [Fact]
+    public void ParseMessage_MediaWithStringTimestamp_PopulatesTimestamp()
+    {
+        // Canonical Twilio shape per Media Streams docs: timestamp is a string of
+        // milliseconds since the stream started.
+        const string raw = """
+            {
+              "event": "media",
+              "streamSid": "MZ-test",
+              "media": { "payload": "AQID", "timestamp": "1234" }
+            }
+            """;
+
+        var parsed = NewAdapter().ParseMessage(raw);
+
+        parsed.Type.ShouldBe(RealtimeAiClientMessageType.Audio);
+        parsed.Timestamp.ShouldBe(1234L);
+    }
+
+    [Fact]
+    public void ParseMessage_MediaWithNumericTimestamp_PopulatesTimestamp()
+    {
+        // Real-world payloads occasionally surface the numeric form (older preview
+        // snapshots, future protocol revisions). Accept both rather than silently
+        // dropping one variant — the audio payload is too critical to lose.
+        const string raw = """
+            {
+              "event": "media",
+              "streamSid": "MZ-test",
+              "media": { "payload": "AQID", "timestamp": 4567 }
+            }
+            """;
+
+        var parsed = NewAdapter().ParseMessage(raw);
+
+        parsed.Type.ShouldBe(RealtimeAiClientMessageType.Audio);
+        parsed.Timestamp.ShouldBe(4567L);
+    }
+
+    [Fact]
+    public void ParseMessage_MediaWithoutTimestamp_LeavesTimestampNull()
+    {
+        // Some Twilio snapshots / connect-flow setups don't include timestamp.
+        // The adapter must not synthesise one (would break Phase 10.3 elapsed math).
+        const string raw = """
+            {
+              "event": "media",
+              "streamSid": "MZ-test",
+              "media": { "payload": "AQID" }
+            }
+            """;
+
+        var parsed = NewAdapter().ParseMessage(raw);
+
+        parsed.Type.ShouldBe(RealtimeAiClientMessageType.Audio);
+        parsed.Timestamp.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ParseMessage_MediaWithNonNumericStringTimestamp_LeavesTimestampNull()
+    {
+        // Malformed timestamp string must not drop the audio frame. The payload is
+        // delivered (Type = Audio, Payload is populated); only Timestamp is null.
+        const string raw = """
+            {
+              "event": "media",
+              "streamSid": "MZ-test",
+              "media": { "payload": "AQID", "timestamp": "not-a-number" }
+            }
+            """;
+
+        var parsed = NewAdapter().ParseMessage(raw);
+
+        parsed.Type.ShouldBe(RealtimeAiClientMessageType.Audio);
+        parsed.Payload.ShouldBe("AQID");
+        parsed.Timestamp.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ParseMessage_StartEvent_LeavesTimestampNull()
+    {
+        // Lifecycle events don't carry timestamp; the field must stay null so the
+        // service doesn't accidentally clobber LatestMediaTimestamp with zero between
+        // genuine media frames.
+        const string raw = """
+            {
+              "event": "start",
+              "start": { "streamSid": "MZ-test", "callSid": "CA-test" }
+            }
+            """;
+
+        var parsed = NewAdapter().ParseMessage(raw);
+
+        parsed.Type.ShouldBe(RealtimeAiClientMessageType.Start);
+        parsed.Timestamp.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ParseMessage_VideoMediaWithTimestamp_PopulatesTimestamp()
+    {
+        // Image frames also advance the stream clock. They go to a different handler
+        // but must still update LatestMediaTimestamp via the parser surface.
+        const string raw = """
+            {
+              "event": "media",
+              "streamSid": "MZ-test",
+              "media": { "payload": "AQID", "type": "video", "timestamp": "9999" }
+            }
+            """;
+
+        var parsed = NewAdapter().ParseMessage(raw);
+
+        parsed.Type.ShouldBe(RealtimeAiClientMessageType.Image);
+        parsed.Timestamp.ShouldBe(9999L);
+    }
+}


### PR DESCRIPTION
## Summary

- Parse Twilio's `media.timestamp` (ms since stream start) on every inbound media frame and surface it via a new nullable `ParsedClientMessage.Timestamp`
- Maintain a running `RealtimeAiSessionContext.LatestMediaTimestamp` updated by `ProcessClientMessageAsync` before dispatch, plus a per-turn `ResponseStartTimestampTwilio` anchor set lazily on the first `ResponseAudioDelta` of each turn and cleared by `OnAiTurnCompletedAsync` (alongside `LastAssistantItemId` from Phase 10.1)
- **No production behaviour changes** — nothing reads `LatestMediaTimestamp` / `ResponseStartTimestampTwilio` yet. Phase 10.3 will subtract the anchor from the running clock to compute `audio_end_ms` for OpenAI `conversation.item.truncate`
- Closes the V1 timing bug-by-omission (V1's `LatestMediaTimestamp` was initialised to 0 and never updated; the corresponding truncate call was commented out — see `AiSpeechAssistantService.cs:596` and `:1139`). V2 lands the wiring correctly

## Lifecycle

- **Set**: `ProcessClientMessageAsync` writes `_ctx.LatestMediaTimestamp = parsed.Timestamp.Value` before the type switch — even for video frames, because the stream clock advances independently of how we route the payload
- **Anchor**: `OnAiAudioOutputReadyAsync` writes `_ctx.ResponseStartTimestampTwilio = _ctx.LatestMediaTimestamp` only when the anchor is null AND a clock value exists. Subsequent deltas in the same turn must not shift the anchor forwards
- **Clear**: `OnAiTurnCompletedAsync` resets `_ctx.ResponseStartTimestampTwilio = null`. `LatestMediaTimestamp` deliberately keeps its value across turns — it's the running clock, not a per-turn quantity

## Tolerance for payload-shape drift

`media.timestamp` is documented as a string of milliseconds but real-world snapshots occasionally surface the numeric form. The new `ExtractMediaTimestamp` helper accepts both, falling back to null on anything else (e.g. malformed string, missing field). A bad timestamp must never drop the audio frame — the payload is more critical than the timing metadata, and Phase 10.3 will gracefully treat a null anchor as "skip the truncate" rather than crashing.

## Scope

- Twilio-only — `DefaultRealtimeAiClientAdapter` (web) untouched; its `Timestamp` stays null
- No mark queue / mark-event handling added (V1's MarkQueue ended up being dead code: only used as `Count > 0` flag duplicating `IsAiSpeaking`, and the calculated elapsed time was never sent to OpenAI because the truncate was commented out). The pure timestamp pair is what Phase 10.3 actually needs
- V1 untouched

## Test plan

- [x] Build: 0 errors
- [x] Targeted: 6/6 pass on the new `TwilioRealtimeAiClientAdapterMediaTimestampTests` (string ts, numeric ts, missing ts, malformed string ts, lifecycle event ts-null, video frame ts)
- [x] Full unit suite: 519/519 pass (513 prior + 6 new)
- [ ] Staging observation alongside other Round 3 sub-PRs

## Rollback

`git revert` on this commit. No production behaviour changed — reverting only removes the tracking fields and the timestamp extraction, leaving the existing Twilio `clear`-based barge-in path intact.