### PR TITLE
Wire V2 user-barge-in to OpenAI conversation.item.truncate

### DIFF
--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/IRealtimeAiProviderAdapter.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/IRealtimeAiProviderAdapter.cs
@@ -16,7 +16,14 @@ public interface IRealtimeAiProviderAdapter : IScopedDependency
     
     string BuildTextUserMessage(string text, string sessionId);
 
-    object BuildInterruptMessage(string lastAssistantItemIdToInterrupt);
+    /// <summary>
+    /// Builds the provider-specific message that truncates the in-flight assistant
+    /// turn at <paramref name="audioEndMs"/> milliseconds, called when the user barges
+    /// in. Returns <c>null</c> when the provider has no equivalent (Google's Live API
+    /// relies on its server-side VAD instead of an explicit client truncate). The
+    /// caller skips <c>SendToProviderAsync</c> on null without warning.
+    /// </summary>
+    string BuildTruncateMessage(string itemId, long audioEndMs);
 
     string BuildFunctionCallReplyMessage(RealtimeAiWssFunctionCallData functionCall, string output);
 

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Providers/Google/GoogleRealtimeAiProviderAdapter.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Providers/Google/GoogleRealtimeAiProviderAdapter.cs
@@ -99,21 +99,14 @@ public class GoogleRealtimeAiProviderAdapter : IRealtimeAiProviderAdapter
         return JsonSerializer.Serialize(message);
     }
     
-    public object BuildInterruptMessage(string lastAssistantItemIdToInterrupt)
-    {
-        if (!string.IsNullOrEmpty(lastAssistantItemIdToInterrupt))
-        {
-            var message = new
-            {
-                type = "conversation.interrupt",
-                item_id_to_interrupt = lastAssistantItemIdToInterrupt
-            };
-            return message;
-        }
-
-        Log.Warning("[RealtimeAi] Cannot build interrupt message, missing item ID");
-        return null;
-    }
+    /// <summary>
+    /// Google's Live API relies on its own server-side VAD to handle user barge-in;
+    /// there is no client-sent equivalent of OpenAI's <c>conversation.item.truncate</c>.
+    /// Returns null so the V2 service skips <c>SendToProviderAsync</c> without warning,
+    /// while still letting Twilio receive the <c>clear</c> frame that actually stops
+    /// playback. The signature is preserved for cross-provider symmetry with OpenAI.
+    /// </summary>
+    public string BuildTruncateMessage(string itemId, long audioEndMs) => null;
 
     public string BuildFunctionCallReplyMessage(RealtimeAiWssFunctionCallData functionCall, string output)
     {

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Providers/OpenAi/OpenAiRealtimeAiProviderAdapter.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Providers/OpenAi/OpenAiRealtimeAiProviderAdapter.cs
@@ -230,20 +230,31 @@ public class OpenAiRealtimeAiProviderAdapter : IRealtimeAiProviderAdapter
         return JsonSerializer.Serialize(message);
     }
     
-    public object BuildInterruptMessage(string lastAssistantItemIdToInterrupt)
+    /// <summary>
+    /// Builds the OpenAI GA <c>conversation.item.truncate</c> event. Per the GA contract
+    /// this truncates the assistant message's audio in OpenAI's conversation history at
+    /// the given offset so subsequent turns reference only what the user actually heard.
+    /// Returns null when <paramref name="itemId"/> is missing — sending the event without
+    /// an item id would be rejected by the GA server.
+    /// </summary>
+    public string BuildTruncateMessage(string itemId, long audioEndMs)
     {
-        if (!string.IsNullOrEmpty(lastAssistantItemIdToInterrupt))
+        if (string.IsNullOrEmpty(itemId))
         {
-            var message = new
-            {
-                type = "conversation.interrupt",
-                item_id_to_interrupt = lastAssistantItemIdToInterrupt
-            };
-            return message;
+            Log.Warning("[RealtimeAi] Cannot build truncate message, missing item ID");
+            return null;
         }
 
-        Log.Warning("[RealtimeAi] Cannot build interrupt message, missing item ID");
-        return null;
+        return JsonSerializer.Serialize(new
+        {
+            type = "conversation.item.truncate",
+            item_id = itemId,
+            content_index = 0,
+            // OpenAI rejects negative offsets; the service-side caller already clamps via
+            // Math.Max(0, ...) but we guard here too so a faulty consumer cannot ship a
+            // bad payload.
+            audio_end_ms = Math.Max(0L, audioEndMs)
+        });
     }
 
     public string BuildFunctionCallReplyMessage(RealtimeAiWssFunctionCallData functionCall, string output)

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Services/RealtimeAiService.Event.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Services/RealtimeAiService.Event.cs
@@ -128,7 +128,55 @@ public partial class RealtimeAiService
         if (_ctx.Options.IdleFollowUp != null)
             _inactivityTimerManager.StopTimer(_ctx.SessionId);
 
+        // Client `clear` frame goes FIRST — it's the time-critical signal that the
+        // user is waiting on (stops Twilio playback the user can still hear). The
+        // provider truncate is a history-correction follow-up that doesn't affect
+        // what the user perceives in the moment.
         await SendToClientAsync(_ctx.ClientAdapter.BuildSpeechDetectedMessage(_ctx.SessionId)).ConfigureAwait(false);
+
+        // Phase 10.3 barge-in: tell the provider exactly where the user heard the AI
+        // cut off so the conversation history reflects only what the user actually
+        // experienced. Skipped silently when any of the tracking values is missing
+        // (cold session, web client without timestamps, etc.).
+        await SendBargeInTruncateIfApplicableAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Builds and sends a provider truncate event when all three tracking values are
+    /// populated:
+    /// <list type="bullet">
+    ///   <item><see cref="RealtimeAiSessionContext.LastAssistantItemId"/> (Phase 10.1)</item>
+    ///   <item><see cref="RealtimeAiSessionContext.LatestMediaTimestamp"/> (Phase 10.2 running clock)</item>
+    ///   <item><see cref="RealtimeAiSessionContext.ResponseStartTimestampTwilio"/> (Phase 10.2 per-turn anchor)</item>
+    /// </list>
+    /// If any is missing, skip silently — the existing Twilio <c>clear</c> frame still
+    /// stops playback immediately; we just lose the OpenAI history precision (an
+    /// acceptable degraded mode). After sending, the interrupt window for this turn
+    /// is consumed; clear the per-turn fields so a subsequent speech-detected event
+    /// can't re-truncate the same already-truncated item (which OpenAI would reject).
+    /// <see cref="RealtimeAiSessionContext.LatestMediaTimestamp"/> deliberately keeps
+    /// its value because it's the running stream clock.
+    /// </summary>
+    private async Task SendBargeInTruncateIfApplicableAsync()
+    {
+        var itemId = _ctx.LastAssistantItemId;
+        var clock = _ctx.LatestMediaTimestamp;
+        var anchor = _ctx.ResponseStartTimestampTwilio;
+
+        if (string.IsNullOrEmpty(itemId) || !clock.HasValue || !anchor.HasValue) return;
+
+        var elapsedMs = Math.Max(0L, clock.Value - anchor.Value);
+
+        var truncateMessage = _ctx.ProviderAdapter.BuildTruncateMessage(itemId, elapsedMs);
+
+        if (truncateMessage != null)
+        {
+            await SendToProviderAsync(truncateMessage).ConfigureAwait(false);
+            Log.Information("[RealtimeAi] Barge-in truncate sent, SessionId: {SessionId}, ItemId: {ItemId}, AudioEndMs: {AudioEndMs}", _ctx.SessionId, itemId, elapsedMs);
+        }
+
+        _ctx.LastAssistantItemId = null;
+        _ctx.ResponseStartTimestampTwilio = null;
     }
 
     private async Task OnAiTurnCompletedAsync()

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/GoogleRealtimeAiProviderAdapterTruncateMessageTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/GoogleRealtimeAiProviderAdapterTruncateMessageTests.cs
@@ -1,0 +1,34 @@
+using Microsoft.Extensions.Configuration;
+using NSubstitute;
+using Shouldly;
+using SmartTalk.Core.Services.RealtimeAiV2.Adapters.Providers.Google;
+using SmartTalk.Core.Settings.Google;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Services.RealtimeAiV2;
+
+/// <summary>
+/// Pins that the Google adapter's <c>BuildTruncateMessage</c> returns null. Google's
+/// Live API relies on its server-side VAD to handle barge-in; sending a client-side
+/// truncate would either be ignored or generate a protocol-error log on Google's side.
+/// The caller (<c>RealtimeAiService.SendBargeInTruncateIfApplicableAsync</c>) checks
+/// for null and skips <c>SendToProviderAsync</c>, while the Twilio <c>clear</c> frame
+/// still flushes the audio buffer at the client side.
+/// </summary>
+public class GoogleRealtimeAiProviderAdapterTruncateMessageTests
+{
+    private static GoogleRealtimeAiProviderAdapter NewAdapter() =>
+        new(new GoogleSettings(Substitute.For<IConfiguration>()));
+
+    [Fact]
+    public void BuildTruncateMessage_ValidInput_ReturnsNull()
+    {
+        NewAdapter().BuildTruncateMessage("item_abc", 1500).ShouldBeNull();
+    }
+
+    [Fact]
+    public void BuildTruncateMessage_NullInput_ReturnsNull()
+    {
+        NewAdapter().BuildTruncateMessage(null, 0).ShouldBeNull();
+    }
+}

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterTruncateMessageTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterTruncateMessageTests.cs
@@ -1,0 +1,89 @@
+using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json.Linq;
+using NSubstitute;
+using Shouldly;
+using SmartTalk.Core.Services.RealtimeAiV2.Adapters.Providers.OpenAi;
+using SmartTalk.Core.Settings.OpenAi;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Services.RealtimeAiV2;
+
+/// <summary>
+/// Pins the GA <c>conversation.item.truncate</c> shape built by the OpenAI V2 adapter
+/// for Phase 10.3 barge-in. If OpenAI ever rejects this payload, the Twilio <c>clear</c>
+/// frame still stops playback, but the assistant message in OpenAI's history reverts
+/// to the un-truncated form and the next turn responds as if the user heard the AI
+/// finish (subtly wrong restaurant-call context).
+/// </summary>
+public class OpenAiRealtimeAiProviderAdapterTruncateMessageTests
+{
+    private static OpenAiRealtimeAiProviderAdapter NewAdapter() =>
+        new(new OpenAiSettings(Substitute.For<IConfiguration>()));
+
+    [Fact]
+    public void BuildTruncateMessage_ValidInput_EmitsCanonicalGaShape()
+    {
+        var json = NewAdapter().BuildTruncateMessage("item_abc123", 1500);
+
+        json.ShouldNotBeNull();
+        var parsed = JObject.Parse(json);
+        parsed["type"]!.Value<string>().ShouldBe("conversation.item.truncate");
+        parsed["item_id"]!.Value<string>().ShouldBe("item_abc123");
+        parsed["content_index"]!.Value<int>().ShouldBe(0);
+        parsed["audio_end_ms"]!.Value<long>().ShouldBe(1500);
+    }
+
+    [Fact]
+    public void BuildTruncateMessage_ZeroAudioEndMs_StillEmitsZeroNotOmits()
+    {
+        // OpenAI accepts audio_end_ms = 0 (means "user interrupted before any audio
+        // played"); the field must still be present in the payload. A common refactor
+        // mistake is to treat 0 as "default" and omit the key, which OpenAI would
+        // reject as a missing required field.
+        var json = NewAdapter().BuildTruncateMessage("item_abc", 0);
+
+        var parsed = JObject.Parse(json!);
+        parsed["audio_end_ms"]!.Value<long>().ShouldBe(0);
+    }
+
+    [Fact]
+    public void BuildTruncateMessage_NegativeAudioEndMs_ClampsToZero()
+    {
+        // Service-side caller already clamps, but the adapter guards too — a faulty
+        // future consumer that bypassed the clamp must not ship a payload OpenAI
+        // would reject.
+        var json = NewAdapter().BuildTruncateMessage("item_abc", -42);
+
+        var parsed = JObject.Parse(json!);
+        parsed["audio_end_ms"]!.Value<long>().ShouldBe(0);
+    }
+
+    [Fact]
+    public void BuildTruncateMessage_NullItemId_ReturnsNull()
+    {
+        // Sending the event without item_id would be rejected by the GA server.
+        // Returning null lets the caller skip SendToProviderAsync without a warning
+        // (the per-turn anchor may also be null in this case, e.g. cold session).
+        NewAdapter().BuildTruncateMessage(null, 100).ShouldBeNull();
+    }
+
+    [Fact]
+    public void BuildTruncateMessage_EmptyItemId_ReturnsNull()
+    {
+        // Empty string is treated identically to null — both indicate "no in-flight
+        // assistant turn to truncate". The skip is silent to avoid noise on every
+        // user-speech-detected event during cold-session warm-up.
+        NewAdapter().BuildTruncateMessage("", 100).ShouldBeNull();
+    }
+
+    [Fact]
+    public void BuildTruncateMessage_LargeAudioEndMs_RoundTripsExact()
+    {
+        // Long-running calls (hour-plus restaurant queues) can push audio_end_ms beyond
+        // int range. Pin that the long path holds without precision loss.
+        var json = NewAdapter().BuildTruncateMessage("item_long", 9_000_000_000L);
+
+        var parsed = JObject.Parse(json!);
+        parsed["audio_end_ms"]!.Value<long>().ShouldBe(9_000_000_000L);
+    }
+}

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/RealtimeAiServiceBargeInTruncateTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/RealtimeAiServiceBargeInTruncateTests.cs
@@ -1,0 +1,261 @@
+using NSubstitute;
+using Shouldly;
+using SmartTalk.Core.Services.RealtimeAiV2.Adapters;
+using SmartTalk.Messages.Dto.RealtimeAi;
+using SmartTalk.Messages.Enums.RealtimeAi;
+using Xunit;
+
+namespace SmartTalk.UnitTests.Services.RealtimeAiV2;
+
+/// <summary>
+/// End-to-end pins for Phase 10.3 V2 barge-in. Exercises the full
+/// <c>OnAiDetectedUserSpeechAsync</c> path with item_id (Phase 10.1),
+/// LatestMediaTimestamp + ResponseStartTimestampTwilio (Phase 10.2)
+/// already populated by upstream events, and asserts the provider
+/// <c>BuildTruncateMessage</c> is called with the elapsed-time math
+/// — the regression boundary for restaurant calls where users barge
+/// in mid-greeting and OpenAI's conversation history must stay aligned
+/// with what the user actually heard.
+/// </summary>
+public class RealtimeAiServiceBargeInTruncateTests : RealtimeAiServiceTestBase
+{
+    [Fact]
+    public async Task SpeechDetected_AfterAiSpokeWithItemIdAndTimestamps_SendsTruncate()
+    {
+        const string itemId = "item_barge_in";
+        const long clientStartTimestamp = 1000;
+        const long clientEndTimestamp = 1750;
+        const long expectedElapsedMs = 750;
+
+        var providerCall = 0;
+        ProviderAdapter.ParseMessage(Arg.Any<string>())
+            .Returns(_ =>
+            {
+                providerCall++;
+                return providerCall == 1
+                    ? new ParsedRealtimeAiProviderEvent
+                    {
+                        Type = RealtimeAiWssEventType.ResponseAudioDelta,
+                        Data = new RealtimeAiWssAudioData { Base64Payload = "AQID", ItemId = itemId }
+                    }
+                    : new ParsedRealtimeAiProviderEvent { Type = RealtimeAiWssEventType.SpeechDetected };
+            });
+
+        var clientCall = 0;
+        ClientAdapter.ParseMessage(Arg.Any<string>())
+            .Returns(_ =>
+            {
+                clientCall++;
+                return new ParsedClientMessage
+                {
+                    Type = RealtimeAiClientMessageType.Audio,
+                    Payload = "AQID",
+                    Timestamp = clientCall == 1 ? clientStartTimestamp : clientEndTimestamp
+                };
+            });
+
+        ProviderAdapter.BuildTruncateMessage(Arg.Any<string>(), Arg.Any<long>()).Returns("{}");
+
+        var sessionTask = await StartSessionInBackgroundAsync();
+
+        // 1. User audio @ ts=1000 → LatestMediaTimestamp = 1000
+        FakeWs.EnqueueClientMessage("{\"media\":{\"payload\":\"x\",\"timestamp\":\"1000\"}}");
+        await Task.Delay(50);
+
+        // 2. AI audio delta with item_id → LastAssistantItemId set, anchor = 1000
+        await FakeWssClient.SimulateMessageReceivedAsync("{\"type\":\"response.output_audio.delta\"}");
+        await Task.Delay(50);
+
+        // 3. User audio @ ts=1750 → LatestMediaTimestamp = 1750
+        FakeWs.EnqueueClientMessage("{\"media\":{\"payload\":\"y\",\"timestamp\":\"1750\"}}");
+        await Task.Delay(50);
+
+        // 4. SpeechDetected → barge-in: BuildTruncateMessage(itemId, 1750-1000=750)
+        await FakeWssClient.SimulateMessageReceivedAsync("{\"type\":\"input_audio_buffer.speech_started\"}");
+        await Task.Delay(100);
+
+        FakeWs.EnqueueClose();
+        await sessionTask;
+
+        ProviderAdapter.Received(1).BuildTruncateMessage(itemId, expectedElapsedMs);
+    }
+
+    [Fact]
+    public async Task SpeechDetected_WithoutPriorAiAudio_DoesNotSendTruncate()
+    {
+        // Cold-session edge case: user starts speaking before AI has produced any
+        // audio. LastAssistantItemId stays null; truncate must be skipped silently.
+        ProviderAdapter.ParseMessage(Arg.Any<string>())
+            .Returns(new ParsedRealtimeAiProviderEvent { Type = RealtimeAiWssEventType.SpeechDetected });
+
+        ClientAdapter.ParseMessage(Arg.Any<string>())
+            .Returns(new ParsedClientMessage { Type = RealtimeAiClientMessageType.Audio, Payload = "AQID", Timestamp = 1000 });
+
+        var sessionTask = await StartSessionInBackgroundAsync();
+
+        FakeWs.EnqueueClientMessage("{\"media\":{\"payload\":\"x\",\"timestamp\":\"1000\"}}");
+        await Task.Delay(50);
+
+        await FakeWssClient.SimulateMessageReceivedAsync("{\"type\":\"input_audio_buffer.speech_started\"}");
+        await Task.Delay(50);
+
+        FakeWs.EnqueueClose();
+        await sessionTask;
+
+        ProviderAdapter.DidNotReceive().BuildTruncateMessage(Arg.Any<string>(), Arg.Any<long>());
+    }
+
+    [Fact]
+    public async Task SpeechDetected_AiSpokeButNoClientTimestamp_DoesNotSendTruncate()
+    {
+        // Web (DefaultRealtimeAiClientAdapter) does not surface a stream clock. Without
+        // LatestMediaTimestamp the per-turn anchor never gets set, so the elapsed-time
+        // math has no input — skip the truncate rather than ship a bogus offset.
+        var providerCall = 0;
+        ProviderAdapter.ParseMessage(Arg.Any<string>())
+            .Returns(_ =>
+            {
+                providerCall++;
+                return providerCall == 1
+                    ? new ParsedRealtimeAiProviderEvent
+                    {
+                        Type = RealtimeAiWssEventType.ResponseAudioDelta,
+                        Data = new RealtimeAiWssAudioData { Base64Payload = "AQID", ItemId = "item_test" }
+                    }
+                    : new ParsedRealtimeAiProviderEvent { Type = RealtimeAiWssEventType.SpeechDetected };
+            });
+
+        ClientAdapter.ParseMessage(Arg.Any<string>())
+            .Returns(new ParsedClientMessage { Type = RealtimeAiClientMessageType.Audio, Payload = "AQID" /* no Timestamp */ });
+
+        var sessionTask = await StartSessionInBackgroundAsync();
+
+        FakeWs.EnqueueClientMessage("{\"media\":{\"payload\":\"x\"}}");
+        await Task.Delay(50);
+
+        await FakeWssClient.SimulateMessageReceivedAsync("{\"type\":\"response.output_audio.delta\"}");
+        await Task.Delay(50);
+
+        await FakeWssClient.SimulateMessageReceivedAsync("{\"type\":\"input_audio_buffer.speech_started\"}");
+        await Task.Delay(50);
+
+        FakeWs.EnqueueClose();
+        await sessionTask;
+
+        ProviderAdapter.DidNotReceive().BuildTruncateMessage(Arg.Any<string>(), Arg.Any<long>());
+    }
+
+    [Fact]
+    public async Task SpeechDetectedTwiceInARow_OnlyTruncatesOnce()
+    {
+        // After a successful truncate the per-turn fields are cleared so a second
+        // speech-detected within the same turn can't re-truncate the now-already-truncated
+        // item (OpenAI would error). Pin this so a future refactor of the cleanup
+        // doesn't reintroduce double-truncate.
+        const string itemId = "item_once";
+
+        var providerCall = 0;
+        ProviderAdapter.ParseMessage(Arg.Any<string>())
+            .Returns(_ =>
+            {
+                providerCall++;
+                return providerCall == 1
+                    ? new ParsedRealtimeAiProviderEvent
+                    {
+                        Type = RealtimeAiWssEventType.ResponseAudioDelta,
+                        Data = new RealtimeAiWssAudioData { Base64Payload = "AQID", ItemId = itemId }
+                    }
+                    : new ParsedRealtimeAiProviderEvent { Type = RealtimeAiWssEventType.SpeechDetected };
+            });
+
+        ClientAdapter.ParseMessage(Arg.Any<string>())
+            .Returns(new ParsedClientMessage { Type = RealtimeAiClientMessageType.Audio, Payload = "AQID", Timestamp = 500 });
+
+        ProviderAdapter.BuildTruncateMessage(Arg.Any<string>(), Arg.Any<long>()).Returns("{}");
+
+        var sessionTask = await StartSessionInBackgroundAsync();
+
+        FakeWs.EnqueueClientMessage("{\"media\":{\"payload\":\"x\",\"timestamp\":\"500\"}}");
+        await Task.Delay(50);
+
+        await FakeWssClient.SimulateMessageReceivedAsync("{\"type\":\"response.output_audio.delta\"}");
+        await Task.Delay(50);
+
+        // First barge-in
+        await FakeWssClient.SimulateMessageReceivedAsync("{\"type\":\"input_audio_buffer.speech_started\"}");
+        await Task.Delay(50);
+
+        // Second barge-in (no new AI delta in between)
+        await FakeWssClient.SimulateMessageReceivedAsync("{\"type\":\"input_audio_buffer.speech_started\"}");
+        await Task.Delay(50);
+
+        FakeWs.EnqueueClose();
+        await sessionTask;
+
+        ProviderAdapter.Received(1).BuildTruncateMessage(itemId, Arg.Any<long>());
+    }
+
+    [Fact]
+    public async Task SpeechDetected_AcrossTurns_TruncatesEachTurnIndependently()
+    {
+        // Two complete turns of AI speech, each interrupted. Both must emit a truncate
+        // with their own item_id and elapsed time — confirms the per-turn anchor
+        // re-arms after OnAiTurnCompletedAsync clears it.
+        var providerCall = 0;
+        ProviderAdapter.ParseMessage(Arg.Any<string>())
+            .Returns(_ =>
+            {
+                providerCall++;
+                return providerCall switch
+                {
+                    1 => new ParsedRealtimeAiProviderEvent
+                    {
+                        Type = RealtimeAiWssEventType.ResponseAudioDelta,
+                        Data = new RealtimeAiWssAudioData { Base64Payload = "AQID", ItemId = "item_turn_1" }
+                    },
+                    2 => new ParsedRealtimeAiProviderEvent
+                    {
+                        Type = RealtimeAiWssEventType.ResponseTurnCompleted,
+                        Data = new List<RealtimeAiWssFunctionCallData>()
+                    },
+                    3 => new ParsedRealtimeAiProviderEvent
+                    {
+                        Type = RealtimeAiWssEventType.ResponseAudioDelta,
+                        Data = new RealtimeAiWssAudioData { Base64Payload = "AQID", ItemId = "item_turn_2" }
+                    },
+                    _ => new ParsedRealtimeAiProviderEvent { Type = RealtimeAiWssEventType.SpeechDetected }
+                };
+            });
+
+        ClientAdapter.ParseMessage(Arg.Any<string>())
+            .Returns(new ParsedClientMessage { Type = RealtimeAiClientMessageType.Audio, Payload = "AQID", Timestamp = 100 });
+
+        ProviderAdapter.BuildTruncateMessage(Arg.Any<string>(), Arg.Any<long>()).Returns("{}");
+
+        var sessionTask = await StartSessionInBackgroundAsync();
+
+        // Clock established
+        FakeWs.EnqueueClientMessage("{\"media\":{\"payload\":\"x\",\"timestamp\":\"100\"}}");
+        await Task.Delay(50);
+
+        // Turn 1: AI delta + completed
+        await FakeWssClient.SimulateMessageReceivedAsync("{\"type\":\"response.output_audio.delta\"}");
+        await Task.Delay(50);
+        await FakeWssClient.SimulateMessageReceivedAsync("{\"type\":\"response.done\"}");
+        await Task.Delay(50);
+
+        // Turn 2: AI delta then barge-in
+        await FakeWssClient.SimulateMessageReceivedAsync("{\"type\":\"response.output_audio.delta\"}");
+        await Task.Delay(50);
+        await FakeWssClient.SimulateMessageReceivedAsync("{\"type\":\"input_audio_buffer.speech_started\"}");
+        await Task.Delay(50);
+
+        FakeWs.EnqueueClose();
+        await sessionTask;
+
+        // Only turn 2's item_id should be truncated — turn 1 was completed normally
+        // and its anchor was cleared by OnAiTurnCompletedAsync.
+        ProviderAdapter.Received(1).BuildTruncateMessage("item_turn_2", Arg.Any<long>());
+        ProviderAdapter.DidNotReceive().BuildTruncateMessage("item_turn_1", Arg.Any<long>());
+    }
+}


### PR DESCRIPTION
## Summary

- Phase 10.3 — the consumer for the state plumbed in #972 (`LastAssistantItemId`) and #973 (`LatestMediaTimestamp` + `ResponseStartTimestampTwilio`)
- When OpenAI's server-side VAD fires `input_audio_buffer.speech_started` mid-AI-turn, V2 now sends OpenAI a `conversation.item.truncate` event so the assistant message in OpenAI's conversation history reflects only the audio the user actually heard, not the un-played portion that was still buffered when the user spoke up
- Subsequent turns therefore respond to a faithful transcript rather than the AI's full unplayed monologue

## Adapter contract change

- **Replaces** the placeholder `object BuildInterruptMessage(string)` — which built a non-standard `conversation.interrupt` payload and had **zero callers** in V2 — with `string BuildTruncateMessage(string itemId, long audioEndMs)` that emits the canonical GA `conversation.item.truncate` event
- **OpenAI adapter**: produces `{ type, item_id, content_index: 0, audio_end_ms }`. Clamps negative `audio_end_ms` to zero defensively even though the caller already does so (faulty future consumer must not ship a bad payload). Returns null when `item_id` is empty so the caller skips `SendToProviderAsync` silently
- **Google adapter**: returns null. Google's Live API relies on its own server-side VAD; no client-sent truncate equivalent

## Service wiring (`OnAiDetectedUserSpeechAsync`)

Order intentionally chosen:
1. Twilio `clear` frame FIRST — time-critical signal that stops audio the user can still hear
2. Provider truncate SECOND — history-correction follow-up that doesn't affect what the user perceives in the moment

Then conditionally:
- Send truncate only when **all three** tracking values are populated. Skip silently otherwise — the Twilio clear still stopped playback; the only cost of skipping is reduced history precision (cold session, web client without timestamps, etc.)
- After sending, clear `LastAssistantItemId` + `ResponseStartTimestampTwilio` so a second speech-detected event in the same turn cannot re-truncate an already-truncated item (OpenAI would reject)
- `LatestMediaTimestamp` deliberately keeps its value — it's the running stream clock, not a per-turn quantity

## Tests

| File | Tests | What it pins |
|---|---|---|
| `OpenAiRealtimeAiProviderAdapterTruncateMessageTests` | 6 | Canonical GA shape, zero/negative/large `audio_end_ms`, null/empty `item_id` paths |
| `GoogleRealtimeAiProviderAdapterTruncateMessageTests` | 2 | Null-returns pinned for valid and null input |
| `RealtimeAiServiceBargeInTruncateTests` | 5 | End-to-end happy path (item_id + elapsed math = 750ms), cold-session skip, no-timestamp skip, double-speech-detected emits one truncate, multi-turn isolation (each turn's anchor re-arms independently after `OnAiTurnCompletedAsync`) |

## Test plan

- [x] Build: 0 errors
- [x] Targeted: 13/13 pass on the three new test files
- [x] Full unit suite: 532/532 pass (519 prior + 13 new)
- [ ] Staging observation alongside other Round 3 sub-PRs — focus on whether mid-greeting barge-ins now produce coherent next-turn context (vs the AI continuing as if it had finished its sentence)

## Rollback

`git revert` on this commit. Reverting restores the no-truncate behaviour where Twilio `clear` alone stops playback. The only loss is the conversation-history precision; production has been running without truncate for the entire V2 lifetime, so this is a known-safe fallback.