### PR TITLE
Tidy Round 3 comments — drop phase markers and verbose narration

### DIFF
--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Clients/Twilio/TwilioRealtimeAiClientAdapter.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Clients/Twilio/TwilioRealtimeAiClientAdapter.cs
@@ -77,25 +77,16 @@ public class TwilioRealtimeAiClientAdapter : IRealtimeAiClientAdapter
         };
     }
 
-    /// <summary>
-    /// Twilio's media-streams protocol ships <c>media.timestamp</c> as a string of
-    /// milliseconds since stream start. Returns null when the field is absent or
-    /// cannot be parsed — a single malformed timestamp must not drop the whole
-    /// media frame, the audio payload is more critical than the timing metadata.
-    /// </summary>
+    // Twilio doc'd shape is string ms; real payloads occasionally use the numeric form.
+    // Bad / missing timestamp must not drop the audio frame.
     private static long? ExtractMediaTimestamp(JsonElement media)
     {
         if (!media.TryGetProperty("timestamp", out var tsProp)) return null;
 
-        // Twilio docs specify string form, but real-world payloads occasionally surface
-        // the numeric form (older preview snapshots, future protocol revisions). Accept
-        // both rather than silently dropping one variant.
-        if (tsProp.ValueKind == JsonValueKind.String &&
-            long.TryParse(tsProp.GetString(), out var parsed))
+        if (tsProp.ValueKind == JsonValueKind.String && long.TryParse(tsProp.GetString(), out var parsed))
             return parsed;
 
-        if (tsProp.ValueKind == JsonValueKind.Number &&
-            tsProp.TryGetInt64(out var direct))
+        if (tsProp.ValueKind == JsonValueKind.Number && tsProp.TryGetInt64(out var direct))
             return direct;
 
         return null;

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/IRealtimeAiClientAdapter.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/IRealtimeAiClientAdapter.cs
@@ -18,11 +18,8 @@ public class ParsedClientMessage
     public Dictionary<string, string> Metadata { get; set; }
 
     /// <summary>
-    /// Optional millisecond timestamp the client emitted alongside this message.
-    /// Currently populated only by <see cref="Clients.Twilio.TwilioRealtimeAiClientAdapter"/>
-    /// from the <c>media.timestamp</c> field; web / default clients leave it null.
-    /// Phase 10.3 reads this on user-speech-detected to compute the OpenAI
-    /// <c>conversation.item.truncate audio_end_ms</c> for the in-flight assistant turn.
+    /// Optional millisecond timestamp from the client. Populated by Twilio from
+    /// <c>media.timestamp</c>; web / default clients leave it null.
     /// </summary>
     public long? Timestamp { get; set; }
 }

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/IRealtimeAiProviderAdapter.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/IRealtimeAiProviderAdapter.cs
@@ -17,11 +17,8 @@ public interface IRealtimeAiProviderAdapter : IScopedDependency
     string BuildTextUserMessage(string text, string sessionId);
 
     /// <summary>
-    /// Builds the provider-specific message that truncates the in-flight assistant
-    /// turn at <paramref name="audioEndMs"/> milliseconds, called when the user barges
-    /// in. Returns <c>null</c> when the provider has no equivalent (Google's Live API
-    /// relies on its server-side VAD instead of an explicit client truncate). The
-    /// caller skips <c>SendToProviderAsync</c> on null without warning.
+    /// Builds the provider truncate message at user barge-in. Returns null when the
+    /// provider has no equivalent; the caller skips sending on null.
     /// </summary>
     string BuildTruncateMessage(string itemId, long audioEndMs);
 

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Providers/Google/GoogleRealtimeAiProviderAdapter.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Providers/Google/GoogleRealtimeAiProviderAdapter.cs
@@ -99,13 +99,7 @@ public class GoogleRealtimeAiProviderAdapter : IRealtimeAiProviderAdapter
         return JsonSerializer.Serialize(message);
     }
     
-    /// <summary>
-    /// Google's Live API relies on its own server-side VAD to handle user barge-in;
-    /// there is no client-sent equivalent of OpenAI's <c>conversation.item.truncate</c>.
-    /// Returns null so the V2 service skips <c>SendToProviderAsync</c> without warning,
-    /// while still letting Twilio receive the <c>clear</c> frame that actually stops
-    /// playback. The signature is preserved for cross-provider symmetry with OpenAI.
-    /// </summary>
+    // Google's Live API handles barge-in via its own server-side VAD; no client-sent truncate.
     public string BuildTruncateMessage(string itemId, long audioEndMs) => null;
 
     public string BuildFunctionCallReplyMessage(RealtimeAiWssFunctionCallData functionCall, string output)

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Providers/OpenAi/OpenAiRealtimeAiProviderAdapter.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Adapters/Providers/OpenAi/OpenAiRealtimeAiProviderAdapter.cs
@@ -230,13 +230,6 @@ public class OpenAiRealtimeAiProviderAdapter : IRealtimeAiProviderAdapter
         return JsonSerializer.Serialize(message);
     }
     
-    /// <summary>
-    /// Builds the OpenAI GA <c>conversation.item.truncate</c> event. Per the GA contract
-    /// this truncates the assistant message's audio in OpenAI's conversation history at
-    /// the given offset so subsequent turns reference only what the user actually heard.
-    /// Returns null when <paramref name="itemId"/> is missing — sending the event without
-    /// an item id would be rejected by the GA server.
-    /// </summary>
     public string BuildTruncateMessage(string itemId, long audioEndMs)
     {
         if (string.IsNullOrEmpty(itemId))
@@ -250,9 +243,6 @@ public class OpenAiRealtimeAiProviderAdapter : IRealtimeAiProviderAdapter
             type = "conversation.item.truncate",
             item_id = itemId,
             content_index = 0,
-            // OpenAI rejects negative offsets; the service-side caller already clamps via
-            // Math.Max(0, ...) but we guard here too so a faulty consumer cannot ship a
-            // bad payload.
             audio_end_ms = Math.Max(0L, audioEndMs)
         });
     }

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Services/RealtimeAiService.Event.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Services/RealtimeAiService.Event.cs
@@ -101,18 +101,11 @@ public partial class RealtimeAiService
 
         _ctx.IsAiSpeaking = true;
 
-        // Track the latest assistant item_id for Phase 10.3 barge-in. Adapter populates
-        // this on every OpenAI response.output_audio.delta; Google adapter leaves it null
-        // (Google's protocol does not surface a per-delta id). Either way, an empty value
-        // must not clobber a previously-tracked id from earlier in the same turn.
+        // Empty item_id must not clobber a previously-tracked id from earlier in the same turn.
         if (!string.IsNullOrEmpty(aiAudioData.ItemId))
             _ctx.LastAssistantItemId = aiAudioData.ItemId;
 
-        // Capture the stream-time at which the AI started speaking THIS turn (set-once
-        // per turn). Phase 10.3 will compute audio_end_ms = LatestMediaTimestamp - this
-        // value to tell OpenAI exactly where to truncate the assistant message in its
-        // conversation history. Set only on the FIRST delta of the turn so subsequent
-        // deltas don't shift the anchor forwards.
+        // Anchor is set once per turn — first delta wins so subsequent deltas don't shift it.
         if (!_ctx.ResponseStartTimestampTwilio.HasValue && _ctx.LatestMediaTimestamp.HasValue)
             _ctx.ResponseStartTimestampTwilio = _ctx.LatestMediaTimestamp;
 
@@ -128,34 +121,15 @@ public partial class RealtimeAiService
         if (_ctx.Options.IdleFollowUp != null)
             _inactivityTimerManager.StopTimer(_ctx.SessionId);
 
-        // Client `clear` frame goes FIRST — it's the time-critical signal that the
-        // user is waiting on (stops Twilio playback the user can still hear). The
-        // provider truncate is a history-correction follow-up that doesn't affect
-        // what the user perceives in the moment.
+        // `clear` first (time-critical playback stop), truncate after (history correction).
         await SendToClientAsync(_ctx.ClientAdapter.BuildSpeechDetectedMessage(_ctx.SessionId)).ConfigureAwait(false);
-
-        // Phase 10.3 barge-in: tell the provider exactly where the user heard the AI
-        // cut off so the conversation history reflects only what the user actually
-        // experienced. Skipped silently when any of the tracking values is missing
-        // (cold session, web client without timestamps, etc.).
         await SendBargeInTruncateIfApplicableAsync().ConfigureAwait(false);
     }
 
     /// <summary>
-    /// Builds and sends a provider truncate event when all three tracking values are
-    /// populated:
-    /// <list type="bullet">
-    ///   <item><see cref="RealtimeAiSessionContext.LastAssistantItemId"/> (Phase 10.1)</item>
-    ///   <item><see cref="RealtimeAiSessionContext.LatestMediaTimestamp"/> (Phase 10.2 running clock)</item>
-    ///   <item><see cref="RealtimeAiSessionContext.ResponseStartTimestampTwilio"/> (Phase 10.2 per-turn anchor)</item>
-    /// </list>
-    /// If any is missing, skip silently — the existing Twilio <c>clear</c> frame still
-    /// stops playback immediately; we just lose the OpenAI history precision (an
-    /// acceptable degraded mode). After sending, the interrupt window for this turn
-    /// is consumed; clear the per-turn fields so a subsequent speech-detected event
-    /// can't re-truncate the same already-truncated item (which OpenAI would reject).
-    /// <see cref="RealtimeAiSessionContext.LatestMediaTimestamp"/> deliberately keeps
-    /// its value because it's the running stream clock.
+    /// Sends a provider truncate when item_id, stream clock, and per-turn anchor are
+    /// all set. Skipped silently otherwise. Clears per-turn state after sending so a
+    /// second speech-detected in the same turn cannot re-truncate the same item.
     /// </summary>
     private async Task SendBargeInTruncateIfApplicableAsync()
     {
@@ -186,13 +160,8 @@ public partial class RealtimeAiService
         _ctx.Round += 1;
         _ctx.IsAiSpeaking = false;
 
-        // The interrupt window for this turn has closed; clear so the next user-barge-in
-        // opportunity (Phase 10.3) can't send a stale id that the provider would reject.
+        // Clear per-turn barge-in state. LatestMediaTimestamp keeps its value (running clock).
         _ctx.LastAssistantItemId = null;
-
-        // Reset the per-turn stream-time anchor. The next turn's first ResponseAudioDelta
-        // will set it again. LatestMediaTimestamp deliberately keeps its value — it's the
-        // running clock, not a per-turn quantity.
         _ctx.ResponseStartTimestampTwilio = null;
 
         var idleFollowUp = _ctx.Options.IdleFollowUp;

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Services/RealtimeAiService.Orchestration.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Services/RealtimeAiService.Orchestration.cs
@@ -67,11 +67,8 @@ public partial class RealtimeAiService
         {
             var parsed = _ctx.ClientAdapter.ParseMessage(rawMessage);
 
-            // Twilio populates this on every media frame; web / default clients leave it
-            // null and we keep whatever value the previous Twilio frame deposited. The
-            // value drives Phase 10.3's audio_end_ms truncate calculation, so updating
-            // before the dispatch switch is intentional — even messages we don't act on
-            // (e.g. video frames) advance the stream clock.
+            // Advance the stream clock for every frame that carries a timestamp, including
+            // those we don't dispatch (e.g. video).
             if (parsed.Timestamp.HasValue)
                 _ctx.LatestMediaTimestamp = parsed.Timestamp.Value;
 

--- a/src/SmartTalk.Core/Services/RealtimeAiV2/Services/RealtimeAiSessionContext.cs
+++ b/src/SmartTalk.Core/Services/RealtimeAiV2/Services/RealtimeAiSessionContext.cs
@@ -30,36 +30,10 @@ public class RealtimeAiSessionContext
     public bool IsProviderResponseInProgress;
     public bool HasPendingProviderResponseTrigger;
 
-    /// <summary>
-    /// The provider <c>item_id</c> of the AI's current in-flight assistant turn,
-    /// captured from every <see cref="Messages.Enums.RealtimeAi.RealtimeAiWssEventType.ResponseAudioDelta"/>
-    /// that carries one. Phase 10.3 will read this to build the OpenAI
-    /// <c>conversation.interrupt</c> message at user-barge-in time. <c>null</c>
-    /// between turns (cleared by <c>OnAiTurnCompletedAsync</c>) so a stale id
-    /// from a previous turn cannot be sent on the next interrupt opportunity.
-    /// Phase 10.1 wires the tracking; today no consumer reads it.
-    /// </summary>
+    // Barge-in state: item_id of the in-flight assistant turn + stream-time anchor.
+    // Both cleared after the truncate is sent or the turn completes.
     public string LastAssistantItemId { get; set; }
-
-    /// <summary>
-    /// Most recent <c>media.timestamp</c> (ms since stream start) parsed from a
-    /// client-direction media frame. Twilio populates this on every incoming
-    /// audio chunk; web / default clients leave it null because they have no
-    /// equivalent timing signal. Phase 10.3 subtracts <see cref="ResponseStartTimestampTwilio"/>
-    /// from this value to compute <c>audio_end_ms</c> for the OpenAI
-    /// <c>conversation.item.truncate</c> sent at user barge-in time.
-    /// Phase 10.2 wires the tracking; today no consumer reads it.
-    /// </summary>
     public long? LatestMediaTimestamp { get; set; }
-
-    /// <summary>
-    /// The <see cref="LatestMediaTimestamp"/> snapshot taken on the FIRST
-    /// <c>ResponseAudioDelta</c> of the current AI turn — i.e. the stream-time
-    /// at which the AI started speaking this turn. Set lazily (only when null)
-    /// to capture the first delta; cleared by <c>OnAiTurnCompletedAsync</c>
-    /// alongside <see cref="LastAssistantItemId"/>. <c>null</c> between turns
-    /// and for non-Twilio clients.
-    /// </summary>
     public long? ResponseStartTimestampTwilio { get; set; }
 
     // Recording — buffer encapsulates the previous (MemoryStream + SemaphoreSlim)

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/GoogleRealtimeAiProviderAdapterTruncateMessageTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/GoogleRealtimeAiProviderAdapterTruncateMessageTests.cs
@@ -8,12 +8,9 @@ using Xunit;
 namespace SmartTalk.UnitTests.Services.RealtimeAiV2;
 
 /// <summary>
-/// Pins that the Google adapter's <c>BuildTruncateMessage</c> returns null. Google's
-/// Live API relies on its server-side VAD to handle barge-in; sending a client-side
-/// truncate would either be ignored or generate a protocol-error log on Google's side.
-/// The caller (<c>RealtimeAiService.SendBargeInTruncateIfApplicableAsync</c>) checks
-/// for null and skips <c>SendToProviderAsync</c>, while the Twilio <c>clear</c> frame
-/// still flushes the audio buffer at the client side.
+/// Pins that the Google adapter's <c>BuildTruncateMessage</c> returns null —
+/// Google's Live API handles barge-in via server-side VAD with no client-sent
+/// truncate equivalent.
 /// </summary>
 public class GoogleRealtimeAiProviderAdapterTruncateMessageTests
 {

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterItemIdTrackingTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterItemIdTrackingTests.cs
@@ -10,18 +10,10 @@ using Xunit;
 namespace SmartTalk.UnitTests.Services.RealtimeAiV2;
 
 /// <summary>
-/// Pins that the V2 OpenAI adapter surfaces the per-message <c>item_id</c> on both
+/// Pins that the OpenAI adapter surfaces <c>item_id</c> on both
 /// <see cref="ParsedRealtimeAiProviderEvent.ItemId"/> and (for audio deltas)
-/// <see cref="RealtimeAiWssAudioData.ItemId"/>.
-///
-/// <para>
-/// Captured separately from the existing <c>BetaEventSunset</c> / <c>ParseMessageUsage</c>
-/// suites because those assert on event type and usage; they do not pin the
-/// <c>item_id</c> propagation, which is the regression boundary for the Phase 10
-/// barge-in work (Phase 10.3 will read <see cref="RealtimeAiSessionContext.LastAssistantItemId"/>
-/// to build the OpenAI <c>conversation.interrupt</c> message; if the adapter ever
-/// drops <c>item_id</c>, barge-in stops working silently).
-/// </para>
+/// <see cref="RealtimeAiWssAudioData.ItemId"/> — the regression boundary for
+/// barge-in: if the adapter drops <c>item_id</c>, barge-in stops working silently.
 /// </summary>
 public class OpenAiRealtimeAiProviderAdapterItemIdTrackingTests
 {
@@ -50,8 +42,7 @@ public class OpenAiRealtimeAiProviderAdapterItemIdTrackingTests
     [Fact]
     public void ParseMessage_ResponseAudioDeltaWithItemId_AlsoSetsItemIdOnParsedEvent()
     {
-        // The top-level ItemId on ParsedRealtimeAiProviderEvent must be in sync with the
-        // audio-data ItemId so that consumers reading from either path see the same value.
+        // Both surfaces must carry the same id so consumers reading either path agree.
         var raw = """
             {
               "type": "response.output_audio.delta",
@@ -69,9 +60,8 @@ public class OpenAiRealtimeAiProviderAdapterItemIdTrackingTests
     [Fact]
     public void ParseMessage_ResponseAudioDeltaWithoutItemId_LeavesItemIdNull()
     {
-        // Defensive: providers may emit deltas without item_id (older snapshots, edge
-        // events). The adapter must not synthesize a value or crash; it must leave
-        // both fields as null so downstream consumers can detect "no id available".
+        // Adapter must not synthesise a value when id is absent — consumers rely on null
+        // to detect "no id available".
         var raw = """
             {
               "type": "response.output_audio.delta",
@@ -89,9 +79,7 @@ public class OpenAiRealtimeAiProviderAdapterItemIdTrackingTests
     [Fact]
     public void ParseMessage_NonAudioEventWithItemId_PopulatesParsedEventItemId()
     {
-        // item_id appears on non-audio events too (e.g. response.output_audio_transcript.delta).
-        // It must propagate to ParsedRealtimeAiProviderEvent.ItemId regardless of event type
-        // so Phase 10 can correlate transcripts to specific assistant items if needed.
+        // item_id appears on transcript deltas too — must propagate regardless of event type.
         var raw = """
             {
               "type": "response.output_audio_transcript.delta",
@@ -109,10 +97,7 @@ public class OpenAiRealtimeAiProviderAdapterItemIdTrackingTests
     [Fact]
     public void ParseMessage_TurnCompletedEvent_ItemIdNotRequired()
     {
-        // response.done events don't carry item_id at the top level; consumers must not
-        // rely on it being present for turn completion. This pins the contract so a
-        // future barge-in / cleanup refactor that incorrectly required ItemId on turn-end
-        // would surface here.
+        // response.done carries no top-level item_id; consumers must not require it on turn-end.
         var raw = """
             {
               "type": "response.done",

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterTruncateMessageTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/OpenAiRealtimeAiProviderAdapterTruncateMessageTests.cs
@@ -9,11 +9,9 @@ using Xunit;
 namespace SmartTalk.UnitTests.Services.RealtimeAiV2;
 
 /// <summary>
-/// Pins the GA <c>conversation.item.truncate</c> shape built by the OpenAI V2 adapter
-/// for Phase 10.3 barge-in. If OpenAI ever rejects this payload, the Twilio <c>clear</c>
-/// frame still stops playback, but the assistant message in OpenAI's history reverts
-/// to the un-truncated form and the next turn responds as if the user heard the AI
-/// finish (subtly wrong restaurant-call context).
+/// Pins the GA <c>conversation.item.truncate</c> shape built by the OpenAI adapter
+/// at user barge-in. Wrong payload → OpenAI rejects → next turn responds as if the
+/// user heard the full AI utterance (subtly wrong restaurant-call context).
 /// </summary>
 public class OpenAiRealtimeAiProviderAdapterTruncateMessageTests
 {
@@ -36,10 +34,7 @@ public class OpenAiRealtimeAiProviderAdapterTruncateMessageTests
     [Fact]
     public void BuildTruncateMessage_ZeroAudioEndMs_StillEmitsZeroNotOmits()
     {
-        // OpenAI accepts audio_end_ms = 0 (means "user interrupted before any audio
-        // played"); the field must still be present in the payload. A common refactor
-        // mistake is to treat 0 as "default" and omit the key, which OpenAI would
-        // reject as a missing required field.
+        // OpenAI accepts 0; the field must still be present (don't treat 0 as "default and omit").
         var json = NewAdapter().BuildTruncateMessage("item_abc", 0);
 
         var parsed = JObject.Parse(json!);
@@ -49,9 +44,7 @@ public class OpenAiRealtimeAiProviderAdapterTruncateMessageTests
     [Fact]
     public void BuildTruncateMessage_NegativeAudioEndMs_ClampsToZero()
     {
-        // Service-side caller already clamps, but the adapter guards too — a faulty
-        // future consumer that bypassed the clamp must not ship a payload OpenAI
-        // would reject.
+        // Adapter clamps even though the caller already does — defensive against future consumers.
         var json = NewAdapter().BuildTruncateMessage("item_abc", -42);
 
         var parsed = JObject.Parse(json!);
@@ -61,26 +54,19 @@ public class OpenAiRealtimeAiProviderAdapterTruncateMessageTests
     [Fact]
     public void BuildTruncateMessage_NullItemId_ReturnsNull()
     {
-        // Sending the event without item_id would be rejected by the GA server.
-        // Returning null lets the caller skip SendToProviderAsync without a warning
-        // (the per-turn anchor may also be null in this case, e.g. cold session).
         NewAdapter().BuildTruncateMessage(null, 100).ShouldBeNull();
     }
 
     [Fact]
     public void BuildTruncateMessage_EmptyItemId_ReturnsNull()
     {
-        // Empty string is treated identically to null — both indicate "no in-flight
-        // assistant turn to truncate". The skip is silent to avoid noise on every
-        // user-speech-detected event during cold-session warm-up.
         NewAdapter().BuildTruncateMessage("", 100).ShouldBeNull();
     }
 
     [Fact]
     public void BuildTruncateMessage_LargeAudioEndMs_RoundTripsExact()
     {
-        // Long-running calls (hour-plus restaurant queues) can push audio_end_ms beyond
-        // int range. Pin that the long path holds without precision loss.
+        // Long calls can exceed int range — pin the long path to keep precision.
         var json = NewAdapter().BuildTruncateMessage("item_long", 9_000_000_000L);
 
         var parsed = JObject.Parse(json!);

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/RealtimeAiServiceBargeInTruncateTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/RealtimeAiServiceBargeInTruncateTests.cs
@@ -8,14 +8,11 @@ using Xunit;
 namespace SmartTalk.UnitTests.Services.RealtimeAiV2;
 
 /// <summary>
-/// End-to-end pins for Phase 10.3 V2 barge-in. Exercises the full
-/// <c>OnAiDetectedUserSpeechAsync</c> path with item_id (Phase 10.1),
-/// LatestMediaTimestamp + ResponseStartTimestampTwilio (Phase 10.2)
-/// already populated by upstream events, and asserts the provider
-/// <c>BuildTruncateMessage</c> is called with the elapsed-time math
-/// — the regression boundary for restaurant calls where users barge
-/// in mid-greeting and OpenAI's conversation history must stay aligned
-/// with what the user actually heard.
+/// End-to-end pins for V2 user-barge-in. Drives the full
+/// <c>OnAiDetectedUserSpeechAsync</c> path with item_id + clock + anchor populated
+/// by upstream events and asserts the provider truncate is built with the right
+/// elapsed-time math — the regression boundary for mid-greeting barge-ins where
+/// OpenAI's history must stay aligned with what the user actually heard.
 /// </summary>
 public class RealtimeAiServiceBargeInTruncateTests : RealtimeAiServiceTestBase
 {
@@ -83,8 +80,7 @@ public class RealtimeAiServiceBargeInTruncateTests : RealtimeAiServiceTestBase
     [Fact]
     public async Task SpeechDetected_WithoutPriorAiAudio_DoesNotSendTruncate()
     {
-        // Cold-session edge case: user starts speaking before AI has produced any
-        // audio. LastAssistantItemId stays null; truncate must be skipped silently.
+        // Cold session: user speaks before AI produced any audio → LastAssistantItemId null → skip.
         ProviderAdapter.ParseMessage(Arg.Any<string>())
             .Returns(new ParsedRealtimeAiProviderEvent { Type = RealtimeAiWssEventType.SpeechDetected });
 
@@ -108,9 +104,7 @@ public class RealtimeAiServiceBargeInTruncateTests : RealtimeAiServiceTestBase
     [Fact]
     public async Task SpeechDetected_AiSpokeButNoClientTimestamp_DoesNotSendTruncate()
     {
-        // Web (DefaultRealtimeAiClientAdapter) does not surface a stream clock. Without
-        // LatestMediaTimestamp the per-turn anchor never gets set, so the elapsed-time
-        // math has no input — skip the truncate rather than ship a bogus offset.
+        // Web client has no stream clock → anchor never sets → skip rather than ship a bogus offset.
         var providerCall = 0;
         ProviderAdapter.ParseMessage(Arg.Any<string>())
             .Returns(_ =>
@@ -148,10 +142,8 @@ public class RealtimeAiServiceBargeInTruncateTests : RealtimeAiServiceTestBase
     [Fact]
     public async Task SpeechDetectedTwiceInARow_OnlyTruncatesOnce()
     {
-        // After a successful truncate the per-turn fields are cleared so a second
-        // speech-detected within the same turn can't re-truncate the now-already-truncated
-        // item (OpenAI would error). Pin this so a future refactor of the cleanup
-        // doesn't reintroduce double-truncate.
+        // After truncate the per-turn fields are cleared so a second speech-detected
+        // in the same turn cannot re-truncate the already-truncated item.
         const string itemId = "item_once";
 
         var providerCall = 0;
@@ -198,9 +190,7 @@ public class RealtimeAiServiceBargeInTruncateTests : RealtimeAiServiceTestBase
     [Fact]
     public async Task SpeechDetected_AcrossTurns_TruncatesEachTurnIndependently()
     {
-        // Two complete turns of AI speech, each interrupted. Both must emit a truncate
-        // with their own item_id and elapsed time — confirms the per-turn anchor
-        // re-arms after OnAiTurnCompletedAsync clears it.
+        // Each turn's anchor re-arms after OnAiTurnCompletedAsync clears it.
         var providerCall = 0;
         ProviderAdapter.ParseMessage(Arg.Any<string>())
             .Returns(_ =>
@@ -253,8 +243,7 @@ public class RealtimeAiServiceBargeInTruncateTests : RealtimeAiServiceTestBase
         FakeWs.EnqueueClose();
         await sessionTask;
 
-        // Only turn 2's item_id should be truncated — turn 1 was completed normally
-        // and its anchor was cleared by OnAiTurnCompletedAsync.
+        // Only turn 2's item_id is truncated — turn 1 completed normally so its anchor was cleared.
         ProviderAdapter.Received(1).BuildTruncateMessage("item_turn_2", Arg.Any<long>());
         ProviderAdapter.DidNotReceive().BuildTruncateMessage("item_turn_1", Arg.Any<long>());
     }

--- a/src/SmartTalk.UnitTests/Services/RealtimeAiV2/TwilioRealtimeAiClientAdapterMediaTimestampTests.cs
+++ b/src/SmartTalk.UnitTests/Services/RealtimeAiV2/TwilioRealtimeAiClientAdapterMediaTimestampTests.cs
@@ -6,18 +6,10 @@ using Xunit;
 namespace SmartTalk.UnitTests.Services.RealtimeAiV2;
 
 /// <summary>
-/// Pins that the Twilio client adapter surfaces <c>media.timestamp</c> on
-/// <see cref="SmartTalk.Core.Services.RealtimeAiV2.Adapters.ParsedClientMessage.Timestamp"/>.
-///
-/// <para>
-/// Phase 10.3 will use the running <c>_ctx.LatestMediaTimestamp</c> minus the per-turn
-/// <c>_ctx.ResponseStartTimestampTwilio</c> snapshot to compute <c>audio_end_ms</c> for
-/// the OpenAI <c>conversation.item.truncate</c> sent at user barge-in time. If the
-/// adapter ever stopped extracting <c>media.timestamp</c>, barge-in would still fire
-/// (the Twilio <c>clear</c> event already stops playback), but the conversation
-/// history sent to OpenAI for the next turn would carry the un-truncated assistant
-/// utterance and confuse subsequent prompt context.
-/// </para>
+/// Pins that the Twilio adapter surfaces <c>media.timestamp</c> on
+/// <see cref="ParsedClientMessage.Timestamp"/> — the input to the barge-in elapsed-time
+/// calculation. Losing this field would silently un-truncate OpenAI's conversation
+/// history.
 /// </summary>
 public class TwilioRealtimeAiClientAdapterMediaTimestampTests
 {
@@ -26,8 +18,7 @@ public class TwilioRealtimeAiClientAdapterMediaTimestampTests
     [Fact]
     public void ParseMessage_MediaWithStringTimestamp_PopulatesTimestamp()
     {
-        // Canonical Twilio shape per Media Streams docs: timestamp is a string of
-        // milliseconds since the stream started.
+        // Canonical Twilio shape: timestamp is a string of ms since stream start.
         const string raw = """
             {
               "event": "media",
@@ -45,9 +36,7 @@ public class TwilioRealtimeAiClientAdapterMediaTimestampTests
     [Fact]
     public void ParseMessage_MediaWithNumericTimestamp_PopulatesTimestamp()
     {
-        // Real-world payloads occasionally surface the numeric form (older preview
-        // snapshots, future protocol revisions). Accept both rather than silently
-        // dropping one variant — the audio payload is too critical to lose.
+        // Numeric form occasionally appears in real payloads — accept it as well as the doc'd string form.
         const string raw = """
             {
               "event": "media",
@@ -65,8 +54,7 @@ public class TwilioRealtimeAiClientAdapterMediaTimestampTests
     [Fact]
     public void ParseMessage_MediaWithoutTimestamp_LeavesTimestampNull()
     {
-        // Some Twilio snapshots / connect-flow setups don't include timestamp.
-        // The adapter must not synthesise one (would break Phase 10.3 elapsed math).
+        // Adapter must not synthesise a timestamp when absent — would break elapsed math.
         const string raw = """
             {
               "event": "media",
@@ -84,8 +72,7 @@ public class TwilioRealtimeAiClientAdapterMediaTimestampTests
     [Fact]
     public void ParseMessage_MediaWithNonNumericStringTimestamp_LeavesTimestampNull()
     {
-        // Malformed timestamp string must not drop the audio frame. The payload is
-        // delivered (Type = Audio, Payload is populated); only Timestamp is null.
+        // Malformed timestamp must not drop the audio frame — payload is delivered, only Timestamp is null.
         const string raw = """
             {
               "event": "media",
@@ -104,9 +91,7 @@ public class TwilioRealtimeAiClientAdapterMediaTimestampTests
     [Fact]
     public void ParseMessage_StartEvent_LeavesTimestampNull()
     {
-        // Lifecycle events don't carry timestamp; the field must stay null so the
-        // service doesn't accidentally clobber LatestMediaTimestamp with zero between
-        // genuine media frames.
+        // Lifecycle events have no timestamp — must stay null so they don't clobber the running clock.
         const string raw = """
             {
               "event": "start",
@@ -123,8 +108,7 @@ public class TwilioRealtimeAiClientAdapterMediaTimestampTests
     [Fact]
     public void ParseMessage_VideoMediaWithTimestamp_PopulatesTimestamp()
     {
-        // Image frames also advance the stream clock. They go to a different handler
-        // but must still update LatestMediaTimestamp via the parser surface.
+        // Video frames advance the stream clock too — different handler, same parser surface.
         const string raw = """
             {
               "event": "media",


### PR DESCRIPTION
## Summary

Round 3's production and test files accumulated comment noise that violates Rule 13 (no progress markers) and Simplicity First:

- Phase markers (`Phase 10.1 wires the tracking; today no consumer reads it`)
- Future-tense placeholders (`Phase 10.3 will read this to build the OpenAI conversation.interrupt message`)
- Multi-paragraph doc-comments restating what a 5-line method already says
- Redundant "running-clock vs anchor" explanations repeated at every callsite

This PR deletes them and keeps only comments that explain *why* or guard a non-obvious edge case (e.g. "Empty value must not clobber a previously-tracked id from earlier in the same turn"). Doc-comments shrink to one sentence describing what the symbol is for.

## Diff shape

- 208 deletions, 58 insertions — pure comment / formatting change
- Production code: 8 files (context, service, adapters, interfaces)
- Test code: 5 files (the new Round 3 test suites)
- No behaviour modified, no method bodies touched

## Test plan

- [x] Build: 0 errors
- [x] Full unit suite: 532/532 pass (unchanged from Round 3 baseline)
- [x] `grep -rn "Phase [0-9]" src/SmartTalk.Core/Services/RealtimeAiV2` returns empty for production code
- [x] Round 3 test files also free of phase markers

## Rollback

`git revert` returns the verbose comments. Cosmetic-only — no behavioural concern.