### PR TITLE
Use a per-call instruction as the call prompt when provided

### DIFF
--- a/src/SmartTalk.Api/Controllers/AiSpeechAssistantController.cs
+++ b/src/SmartTalk.Api/Controllers/AiSpeechAssistantController.cs
@@ -56,7 +56,7 @@ public class AiSpeechAssistantController : ControllerBase
     [AllowAnonymous]
     [HttpGet("outbound/connect")]
     [HttpGet("outbound/connect/{from}/{to}/{id}/{numberId}")]
-    public async Task OutboundConnectAiSpeechAssistantAsync(string from, string to, int id, int numberId)
+    public async Task OutboundConnectAiSpeechAssistantAsync(string from, string to, int id, int numberId, [FromQuery] string instruction = null)
     {
         if (HttpContext.WebSockets.IsWebSocketRequest)
         {
@@ -68,6 +68,7 @@ public class AiSpeechAssistantController : ControllerBase
                 AssistantId = id,
                 Host = HttpContext.Request.Host.Host,
                 NumberId = numberId,
+                Instruction = instruction,
                 TwilioWebSocket = await HttpContext.WebSockets.AcceptWebSocketAsync(),
                 OrderRecordType = PhoneOrderRecordType.OutBount,
             };

--- a/src/SmartTalk.Core/Services/AiSpeechAssistant/AiSpeechAssistantService.cs
+++ b/src/SmartTalk.Core/Services/AiSpeechAssistant/AiSpeechAssistantService.cs
@@ -203,7 +203,7 @@ public partial class AiSpeechAssistantService : IAiSpeechAssistantService
 
         InitAiSpeechAssistantStreamContext(command.Host, command.From);
 
-        await BuildingAiSpeechAssistantKnowledgeBaseAsync(command.From, command.To, command.AssistantId, command.NumberId, agent.Id, cancellationToken).ConfigureAwait(false);
+        await BuildingAiSpeechAssistantKnowledgeBaseAsync(command.From, command.To, command.AssistantId, command.NumberId, agent.Id, command.Instruction, cancellationToken).ConfigureAwait(false);
         
         CheckIfInServiceHours(agent);
         _aiSpeechAssistantStreamContext.TransferCallNumber = agent.TransferCallNumber;
@@ -240,7 +240,7 @@ public partial class AiSpeechAssistantService : IAiSpeechAssistantService
         _aiSpeechAssistantStreamContext.LastUserInfo = new AiSpeechAssistantUserInfoDto { PhoneNumber = from };
     }
 
-    private async Task BuildingAiSpeechAssistantKnowledgeBaseAsync(string from, string to, int? assistantId, int? numberId, int? agentId, CancellationToken cancellationToken)
+    private async Task BuildingAiSpeechAssistantKnowledgeBaseAsync(string from, string to, int? assistantId, int? numberId, int? agentId, string instruction, CancellationToken cancellationToken)
     {
         var inboundRoute = await _aiSpeechAssistantDataProvider.GetAiSpeechAssistantInboundRouteAsync(from, to, cancellationToken).ConfigureAwait(false);
         
@@ -314,9 +314,10 @@ public partial class AiSpeechAssistantService : IAiSpeechAssistantService
             finalPrompt = finalPrompt.Replace("#{delivery_info}", string.IsNullOrEmpty(deliveryInfo) ? " " : deliveryInfo);
         }
         
-        Log.Information($"The final prompt: {finalPrompt}");
-        
-        _aiSpeechAssistantStreamContext.LastPrompt = finalPrompt;
+        // 代客致电等场景: connect URL 带了 ?instruction= 则用它作本通对话指令 (覆盖 DB prompt); 无则照旧 (non-breaking)。
+        _aiSpeechAssistantStreamContext.LastPrompt = !string.IsNullOrWhiteSpace(instruction) ? instruction : finalPrompt;
+
+        Log.Information($"The final prompt: {_aiSpeechAssistantStreamContext.LastPrompt}");
         _aiSpeechAssistantStreamContext.Assistant = _mapper.Map<AiSpeechAssistantDto>(assistant);
         _aiSpeechAssistantStreamContext.Knowledge = _mapper.Map<AiSpeechAssistantKnowledgeDto>(knowledge);
     }

--- a/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectContext.cs
+++ b/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectContext.cs
@@ -21,6 +21,9 @@ public class AiSpeechAssistantConnectContext
     public WebSocket TwilioWebSocket { get; set; }
     public PhoneOrderRecordType OrderRecordType { get; set; }
 
+    // 代客致电等场景: 调用方经 connect URL ?instruction= 传入的本通指令; 有值则覆盖 DB prompt (non-breaking)。
+    public string Instruction { get; set; }
+
     // Assistant & knowledge
     public string Prompt { get; set; }
     public string UserProfileJson { get; set; }

--- a/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectService.Build.Session.cs
+++ b/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectService.Build.Session.cs
@@ -29,7 +29,7 @@ public partial class AiSpeechAssistantConnectService
                 Voice = assistant.ModelVoice ?? "alloy",
                 ModelName = assistant.ModelName,
                 ModelLanguage = assistant.ModelLanguage,
-                Prompt = _ctx.Prompt,
+                Prompt = !string.IsNullOrWhiteSpace(_ctx.Instruction) ? _ctx.Instruction : _ctx.Prompt,   // 代客致电: 有 instruction 则用作本通指令 (non-breaking)
                 Tools = _ctx.FunctionCalls
                     .Where(x => x.Type == AiSpeechAssistantSessionConfigType.Tool && !string.IsNullOrWhiteSpace(x.Content))
                     .Select(x => JsonConvert.DeserializeObject<object>(x.Content))

--- a/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectService.Build.cs
+++ b/src/SmartTalk.Core/Services/AiSpeechAssistantConnect/AiSpeechAssistantConnectService.Build.cs
@@ -13,6 +13,7 @@ public partial class AiSpeechAssistantConnectService
         To = command.To,
         AssistantId = command.AssistantId,
         NumberId = command.NumberId,
+        Instruction = command.Instruction,
         TwilioWebSocket = command.TwilioWebSocket,
         OrderRecordType = command.OrderRecordType,
         LastUserInfo = new AiSpeechAssistantUserInfoDto { PhoneNumber = command.From }

--- a/src/SmartTalk.IntegrationTests/Services/AiSpeechAssistant/AiSpeechAssistantConnectFixture.KnowledgeBase.cs
+++ b/src/SmartTalk.IntegrationTests/Services/AiSpeechAssistant/AiSpeechAssistantConnectFixture.KnowledgeBase.cs
@@ -95,6 +95,73 @@ public partial class AiSpeechAssistantConnectFixture
     }
 
     [Fact]
+    public async Task ShouldUseInstructionAsPrompt_WhenConnectCommandHasInstruction()
+    {
+        // 代客致电 (KitchChat AI Call): connect URL 带 ?instruction= 时, 发给 OpenAI 的 session 指令应是该 instruction,
+        // 而不是 DB assistant prompt (non-breaking 覆盖)。无 instruction 时 ShouldReplacePromptVariables 已覆盖 = 照旧用 DB prompt。
+        await RunWithUnitOfWork<IRepository, IUnitOfWork>(async (repository, unitOfWork) =>
+        {
+            var agent = new Agent
+            {
+                Name = "TestAgent", IsReceiveCall = true, Type = AgentType.Assistant, ServiceHours = null
+            };
+            await repository.InsertAsync(agent);
+
+            var assistant = new Core.Domain.AISpeechAssistant.AiSpeechAssistant
+            {
+                Name = "TestAssistant", AnsweringNumber = TestDidNumber, ModelProvider = RealtimeAiProvider.OpenAi,
+                ModelVoice = "alloy", IsDefault = true, IsDisplay = true
+            };
+            await repository.InsertAsync(assistant);
+            await unitOfWork.SaveChangesAsync();
+
+            await repository.InsertAsync(new AgentAssistant { AgentId = agent.Id, AssistantId = assistant.Id });
+            await repository.InsertAsync(new AiSpeechAssistantKnowledge
+            {
+                AssistantId = assistant.Id,
+                Prompt = "DB_PROMPT_MARKER_should_be_overridden",
+                IsActive = true, Version = "1.0"
+            });
+        });
+
+        var twilioWs = new MockWebSocket();
+        twilioWs.EnqueueMessage(JsonConvert.SerializeObject(new
+        {
+            @event = "start",
+            start = new { callSid = "CA_INSTR", streamSid = "MZ_INSTR" }
+        }));
+
+        var openaiWs = CreateProviderMock();
+        openaiWs.EnqueueMessage(JsonConvert.SerializeObject(new { type = "session.updated" }));
+
+        const string instruction = "INSTRUCTION_MARKER_use_this_as_prompt — you are calling a merchant on behalf of a customer.";
+
+        var command = new ConnectAiSpeechAssistantCommand
+        {
+            From = TestCallerNumber,
+            To = TestDidNumber,
+            Host = TestHost,
+            Instruction = instruction,
+            TwilioWebSocket = twilioWs
+        };
+
+        await Run<IMediator>(async mediator =>
+        {
+            await mediator.SendAsync(command);
+        }, builder =>
+        {
+            builder.RegisterInstance(Substitute.For<ISmartTalkBackgroundJobClient>()).As<ISmartTalkBackgroundJobClient>();
+            builder.RegisterInstance(Substitute.For<ISmartiesClient>()).AsImplementedInterfaces();
+            openaiWs.Register(builder);
+        });
+
+        openaiWs.SentMessages.ShouldNotBeEmpty();
+        var sessionUpdate = Encoding.UTF8.GetString(openaiWs.SentMessages.First());
+        sessionUpdate.ShouldContain("INSTRUCTION_MARKER_use_this_as_prompt");          // 用了 instruction
+        sessionUpdate.ShouldNotContain("DB_PROMPT_MARKER_should_be_overridden");       // 没用 DB prompt
+    }
+
+    [Fact]
     public async Task ShouldBuildKnowledge_WithForwardedAssistantId()
     {
         await RunWithUnitOfWork<IRepository, IUnitOfWork>(async (repository, unitOfWork) =>

--- a/src/SmartTalk.Messages/Commands/AiSpeechAssistant/ConnectAiSpeechAssistantCommand.cs
+++ b/src/SmartTalk.Messages/Commands/AiSpeechAssistant/ConnectAiSpeechAssistantCommand.cs
@@ -15,7 +15,11 @@ public class ConnectAiSpeechAssistantCommand : ICommand
     public int? NumberId { get; set; }
     
     public int? AssistantId { get; set; }
-    
+
+    // 代客致电等场景: 调用方 (如 Smarties KitchChat) 经 connect URL 的 ?instruction= 传入本通电话的系统指令/prompt。
+    // 有值则用作本通对话指令 (覆盖 DB assistant prompt); 无值 = 照旧用 DB prompt (non-breaking)。
+    public string Instruction { get; set; }
+
     public WebSocket TwilioWebSocket { get; set; }
     
     public PhoneOrderRecordType OrderRecordType { get; set; }


### PR DESCRIPTION
## Summary

- Add an optional `instruction` to the outbound AI-speech-assistant connect (read from the connect-URL query string). When present it overrides the DB assistant prompt for that call's realtime session; when absent, behaviour is unchanged.
- Lets a caller (Smarties KitchChat "AI Call") drive a per-call "calling on behalf of a customer" persona + question list with a fixed assistant id and no per-call knowledge-base setup.
- Wired into both engine paths: V1 `AiSpeechAssistantService` (the live EngineVersion) overrides `LastPrompt`; V2 `AiSpeechAssistantConnect` overrides the session prompt.

## Test plan

- [x] Build: Core, Api, IntegrationTests compile clean.
- [x] Added integration test `ShouldUseInstructionAsPrompt_WhenConnectCommandHasInstruction` (mirrors the existing prompt-variable test; asserts the OpenAI session.update uses the instruction, not the DB prompt).
- [ ] CI integration run — local run blocked by a pre-existing DbUp migration FK (`fk_dynamic_config_parent_id`) on a fresh MySQL 8.0, which fails the whole fixture (unrelated to this change).
- Non-breaking: the sales/phone-order path passes no instruction and is unaffected.